### PR TITLE
feat: configurable context management (5 strategies)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -144,13 +144,13 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults) async thro
             // Context window protection: check transcript size after each turn
             let transcript = session.transcript
             let tokenCount = await TokenCounter.shared.count(entries: Array(Array(transcript)))
-            let budget = await TokenCounter.shared.inputBudget(reservedForOutput: 512)
+            let budget = await TokenCounter.shared.inputBudget(reservedForOutput: options.contextConfig.outputReserve)
             if tokenCount > budget {
                 do {
-                    let truncated = try await truncateTranscript(transcript, budget: budget)
+                    let truncated = try await truncateTranscript(transcript, budget: budget, config: options.contextConfig)
                     session = LanguageModelSession(model: model, transcript: truncated)
                     if !quietMode && outputFormat == .plain {
-                        print(styled("  [context rotated — oldest messages trimmed]", .dim))
+                        print(styled("  [context rotated — \(options.contextConfig.strategy.rawValue)]", .dim))
                     }
                 } catch {
                     let classified = ApfelError.classify(error)
@@ -176,9 +176,8 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults) async thro
 
 // MARK: - Context Truncation
 
-/// Truncate a transcript to fit within the token budget.
-/// Keeps instructions + newest turns that fit.
-func truncateTranscript(_ transcript: Transcript, budget: Int) async throws -> Transcript {
+/// Truncate a transcript to fit within the token budget using the configured strategy.
+func truncateTranscript(_ transcript: Transcript, budget: Int, config: ContextConfig = .defaults) async throws -> Transcript {
     let entries = Array(Array(transcript))
     guard !entries.isEmpty else { return transcript }
 
@@ -195,7 +194,8 @@ func truncateTranscript(_ transcript: Transcript, budget: Int) async throws -> T
     guard let trimmed = await trimHistoryEntriesToBudget(
         baseEntries: baseEntries,
         historyEntries: historyEntries,
-        budget: budget
+        budget: budget,
+        config: config
     ) else {
         throw ApfelError.contextOverflow
     }
@@ -250,6 +250,14 @@ func printUsage() {
       -h, --help                Show this help
       -v, --version             Print version
 
+    \(styled("CONTEXT OPTIONS:", .yellow, .bold))
+          --context-strategy <s>  Context management strategy [default: newest-first]
+                                  newest-first, oldest-first, sliding-window,
+                                  summarize, strict (error on overflow)
+          --context-max-turns <n> Max history turns (sliding-window only)
+          --context-output-reserve <n>
+                                  Tokens reserved for output [default: 512]
+
     \(styled("SERVER OPTIONS:", .yellow, .bold))
           --serve                Start OpenAI-compatible HTTP server
           --port <number>        Server port [default: 11434]
@@ -264,6 +272,10 @@ func printUsage() {
       APFEL_PORT                Server port [default: 11434]
       APFEL_TEMPERATURE         Default temperature
       APFEL_MAX_TOKENS          Default max tokens
+      APFEL_CONTEXT_STRATEGY    Default context strategy
+      APFEL_CONTEXT_MAX_TURNS   Max turns for sliding-window
+      APFEL_CONTEXT_OUTPUT_RESERVE
+                                Tokens reserved for output
       NO_COLOR                  Disable colored output (https://no-color.org)
 
     \(styled("EXIT CODES:", .yellow, .bold))

--- a/Sources/ContextManager.swift
+++ b/Sources/ContextManager.swift
@@ -89,12 +89,13 @@ enum ContextManager {
 
         let historyEntries = history.compactMap { historyEntry(for: $0, options: options) }
         let finalPromptEntry = makePromptEntry(finalPrompt, options: options)
-        let budget = await TokenCounter.shared.inputBudget(reservedForOutput: 512)
+        let budget = await TokenCounter.shared.inputBudget(reservedForOutput: options.contextConfig.outputReserve)
         guard let entries = await trimHistoryEntriesToBudget(
             baseEntries: baseEntries,
             historyEntries: historyEntries,
             finalEntry: finalPromptEntry,
-            budget: budget
+            budget: budget,
+            config: options.contextConfig
         ) else {
             throw ApfelError.contextOverflow
         }

--- a/Sources/Core/ContextStrategy.swift
+++ b/Sources/Core/ContextStrategy.swift
@@ -1,0 +1,32 @@
+// ============================================================================
+// ContextStrategy.swift — Configurable context window management
+// Part of ApfelCore — pure data types, no FoundationModels dependency
+// ============================================================================
+
+/// Strategy for trimming conversation history when approaching the context limit.
+public enum ContextStrategy: String, Codable, Sendable, CaseIterable {
+    case newestFirst = "newest-first"
+    case oldestFirst = "oldest-first"
+    case slidingWindow = "sliding-window"
+    case summarize = "summarize"
+    case strict = "strict"
+}
+
+/// Configuration for context window management.
+public struct ContextConfig: Sendable, Equatable {
+    public let strategy: ContextStrategy
+    public let maxTurns: Int?
+    public let outputReserve: Int
+
+    public init(
+        strategy: ContextStrategy = .newestFirst,
+        maxTurns: Int? = nil,
+        outputReserve: Int = 512
+    ) {
+        self.strategy = strategy
+        self.maxTurns = maxTurns
+        self.outputReserve = outputReserve
+    }
+
+    public static let defaults = ContextConfig()
+}

--- a/Sources/GUI/APIClient.swift
+++ b/Sources/GUI/APIClient.swift
@@ -39,6 +39,9 @@ final class APIClient: Sendable {
         let model: String
         let messages: [Message]
         let stream: Bool
+        let x_context_strategy: String?
+        let x_context_max_turns: Int?
+        let x_context_output_reserve: Int?
 
         struct Message: Encodable {
             let role: String
@@ -68,14 +71,20 @@ final class APIClient: Sendable {
 
     func chatCompletion(
         messages: [(role: String, content: String)],
-        systemPrompt: String?
+        systemPrompt: String?,
+        contextStrategy: String? = nil,
+        contextMaxTurns: Int? = nil,
+        contextOutputReserve: Int? = nil
     ) async throws -> (response: ChatResponse, requestJSON: String, responseJSON: String, durationMs: Int) {
         let start = Date()
         let apiMessages = buildMessages(messages: messages, systemPrompt: systemPrompt)
         let request = ChatRequest(
             model: "apple-foundationmodel",
             messages: apiMessages,
-            stream: false
+            stream: false,
+            x_context_strategy: contextStrategy,
+            x_context_max_turns: contextMaxTurns,
+            x_context_output_reserve: contextOutputReserve
         )
         let requestJSON = prettyJSON(request)
 
@@ -109,13 +118,19 @@ final class APIClient: Sendable {
 
     func streamChatCompletion(
         messages: [(role: String, content: String)],
-        systemPrompt: String?
+        systemPrompt: String?,
+        contextStrategy: String? = nil,
+        contextMaxTurns: Int? = nil,
+        contextOutputReserve: Int? = nil
     ) -> (stream: AsyncThrowingStream<String, Error>, requestJSON: String) {
         let apiMessages = buildMessages(messages: messages, systemPrompt: systemPrompt)
         let request = ChatRequest(
             model: "apple-foundationmodel",
             messages: apiMessages,
-            stream: true
+            stream: true,
+            x_context_strategy: contextStrategy,
+            x_context_max_turns: contextMaxTurns,
+            x_context_output_reserve: contextOutputReserve
         )
         let requestJSON = prettyJSON(request)
         let url = URL(string: "/v1/chat/completions", relativeTo: baseURL)!

--- a/Sources/GUI/ChatViewModel.swift
+++ b/Sources/GUI/ChatViewModel.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import SwiftUI
+import ApfelCore
 
 /// A single chat message with debug metadata.
 struct ChatMsg: Identifiable {
@@ -37,6 +38,15 @@ class ChatViewModel {
     var speakEnabled: Bool = false
     var isSelfDiscussing: Bool = false
     var showSelfDiscussion: Bool = false
+    var showContextSettings: Bool = false
+    var contextStrategyRaw: String = ContextStrategy.newestFirst.rawValue
+    var contextMaxTurns: Int? = nil
+    var contextOutputReserve: Int = 512
+
+    var contextStrategy: ContextStrategy {
+        get { ContextStrategy(rawValue: contextStrategyRaw) ?? .newestFirst }
+        set { contextStrategyRaw = newValue.rawValue }
+    }
 
     let apiClient: APIClient
     let tts = TTSManager()
@@ -63,9 +73,16 @@ class ChatViewModel {
         history.append((role: "user", content: input))
 
         // Get request JSON early so user message can show it too
+        let currentStrategy = ContextStrategy(rawValue: contextStrategyRaw) ?? .newestFirst
+        let strategy = currentStrategy == .newestFirst ? nil : currentStrategy.rawValue
+        let maxTurns = contextMaxTurns
+        let reserve = contextOutputReserve == 512 ? nil : contextOutputReserve
         let (stream, requestJSON) = apiClient.streamChatCompletion(
             messages: history,
-            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt
+            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+            contextStrategy: strategy,
+            contextMaxTurns: maxTurns,
+            contextOutputReserve: reserve
         )
 
         // Build curl command for debug

--- a/Sources/GUI/ContextSettingsView.swift
+++ b/Sources/GUI/ContextSettingsView.swift
@@ -1,0 +1,78 @@
+// ============================================================================
+// ContextSettingsView.swift — Context management settings sheet
+// Part of apfel GUI
+// ============================================================================
+
+import SwiftUI
+import ApfelCore
+
+struct ContextSettingsView: View {
+    @Bindable var viewModel: ChatViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    private var currentStrategy: ContextStrategy {
+        ContextStrategy(rawValue: viewModel.contextStrategyRaw) ?? .newestFirst
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Context Management")
+                .font(.headline)
+
+            Picker("Strategy", selection: $viewModel.contextStrategyRaw) {
+                ForEach(ContextStrategy.allCases, id: \.rawValue) { strategy in
+                    Text(strategy.rawValue).tag(strategy.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+
+            strategyDescription
+
+            if currentStrategy == .slidingWindow {
+                HStack {
+                    Text("Max turns:")
+                    TextField("e.g. 6", value: $viewModel.contextMaxTurns, format: .number)
+                        .frame(width: 60)
+                }
+            }
+
+            HStack {
+                Text("Output reserve:")
+                Stepper(
+                    "\(viewModel.contextOutputReserve) tokens",
+                    value: $viewModel.contextOutputReserve,
+                    in: 128...2048, step: 128
+                )
+            }
+
+            Divider()
+
+            HStack {
+                Button("Reset to Defaults") {
+                    viewModel.contextStrategyRaw = ContextStrategy.newestFirst.rawValue
+                    viewModel.contextMaxTurns = nil
+                    viewModel.contextOutputReserve = 512
+                }
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+    }
+
+    @ViewBuilder
+    private var strategyDescription: some View {
+        let desc: String = switch currentStrategy {
+        case .newestFirst: "Keeps the most recent turns that fit within the context window."
+        case .oldestFirst: "Keeps the oldest turns. Good for reference-heavy conversations."
+        case .slidingWindow: "Keeps the last N turns, then enforces the token budget."
+        case .summarize: "Compresses old turns into a summary using the on-device model."
+        case .strict: "No trimming. Returns an error if context is exceeded."
+        }
+        Text(desc)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/GUI/DebugPanel.swift
+++ b/Sources/GUI/DebugPanel.swift
@@ -8,6 +8,8 @@ import AppKit
 struct DebugPanel: View {
     @Bindable var viewModel: ChatViewModel
 
+    private var strategyLabel: String { viewModel.contextStrategyRaw }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
@@ -82,6 +84,12 @@ struct DebugPanel: View {
                                     }
                                     ProgressView(value: ratio)
                                         .tint(color)
+                                    HStack {
+                                        Image(systemName: "arrow.triangle.branch")
+                                        Text("Strategy: \(strategyLabel)")
+                                            .font(.system(.caption, design: .monospaced))
+                                    }
+                                    .foregroundStyle(.secondary)
                                 }
                             }
                         }

--- a/Sources/GUI/MainWindow.swift
+++ b/Sources/GUI/MainWindow.swift
@@ -46,6 +46,11 @@ struct MainWindow: View {
 
                 Divider()
 
+                Button(action: { viewModel.showContextSettings = true }) {
+                    Label("Context", systemImage: "gearshape")
+                }
+                .help("Context management settings")
+
                 Toggle(isOn: $viewModel.showDebugPanel) {
                     Label("Debug", systemImage: "ant.circle")
                 }
@@ -62,6 +67,9 @@ struct MainWindow: View {
         .frame(minWidth: 700, minHeight: 500)
         .sheet(isPresented: $viewModel.showSelfDiscussion) {
             SelfDiscussionView(viewModel: viewModel)
+        }
+        .sheet(isPresented: $viewModel.showContextSettings) {
+            ContextSettingsView(viewModel: viewModel)
         }
     }
 }

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -83,12 +83,20 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
 
     events.append("decoded messages=\(chatRequest.messages.count) stream=\(chatRequest.stream == true) model=\(chatRequest.model)")
 
+    // Build context config from request extensions (optional, defaults to newest-first)
+    let contextConfig = ContextConfig(
+        strategy: chatRequest.x_context_strategy.flatMap { ContextStrategy(rawValue: $0) } ?? .newestFirst,
+        maxTurns: chatRequest.x_context_max_turns,
+        outputReserve: chatRequest.x_context_output_reserve ?? 512
+    )
+
     // Build session options from request
     let sessionOpts = SessionOptions(
         temperature: chatRequest.temperature,
         maxTokens: chatRequest.max_tokens,
         seed: chatRequest.seed.map { UInt64($0) },
-        permissive: false
+        permissive: false,
+        contextConfig: contextConfig
     )
 
     // Build session + extract final prompt via ContextManager (Transcript API)

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -42,6 +42,10 @@ struct ChatCompletionRequest: Decodable, Sendable {
     let presence_penalty: Double?
     let frequency_penalty: Double?
     let user: String?
+    // Context management extensions
+    let x_context_strategy: String?
+    let x_context_max_turns: Int?
+    let x_context_output_reserve: Int?
 }
 
 // MARK: - OpenAI Message (supports string content, content array, and tool calls)

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -69,7 +69,7 @@ func startServer(config: ServerConfig) async throws {
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
                 context_window: contextSize,
-                supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format"],
+                supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
                 notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(langs.joined(separator: ", "))"
             )]

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -16,9 +16,11 @@ struct SessionOptions: Sendable {
     let maxTokens: Int?
     let seed: UInt64?
     let permissive: Bool
+    let contextConfig: ContextConfig
 
     static let defaults = SessionOptions(
-        temperature: nil, maxTokens: nil, seed: nil, permissive: false
+        temperature: nil, maxTokens: nil, seed: nil, permissive: false,
+        contextConfig: .defaults
     )
 }
 
@@ -79,7 +81,8 @@ func trimHistoryEntriesToBudget(
     baseEntries: [Transcript.Entry],
     historyEntries: [Transcript.Entry],
     finalEntry: Transcript.Entry? = nil,
-    budget: Int
+    budget: Int,
+    config: ContextConfig = .defaults
 ) async -> [Transcript.Entry]? {
     var requiredEntries = baseEntries
     if let finalEntry {
@@ -89,21 +92,71 @@ func trimHistoryEntriesToBudget(
         return nil
     }
 
-    var keptHistory: [Transcript.Entry] = []
-    for entry in historyEntries.reversed() {
-        var candidate = baseEntries
-        candidate.append(entry)
-        candidate.append(contentsOf: keptHistory)
-        if let finalEntry {
-            candidate.append(finalEntry)
-        }
-        if await TokenCounter.shared.count(entries: candidate) > budget {
-            break
-        }
-        keptHistory.insert(entry, at: 0)
+    switch config.strategy {
+    case .newestFirst:
+        return await trimNewestFirst(
+            base: baseEntries, history: historyEntries, final: finalEntry, budget: budget)
+    case .oldestFirst:
+        return await trimOldestFirst(
+            base: baseEntries, history: historyEntries, final: finalEntry, budget: budget)
+    case .slidingWindow:
+        return await trimSlidingWindow(
+            base: baseEntries, history: historyEntries, final: finalEntry,
+            budget: budget, maxTurns: config.maxTurns)
+    case .summarize:
+        return await trimWithSummary(
+            base: baseEntries, history: historyEntries, final: finalEntry, budget: budget)
+    case .strict:
+        // No trimming — return all history or nil if it exceeds budget
+        var all = baseEntries + historyEntries
+        if let finalEntry { all.append(finalEntry) }
+        return await TokenCounter.shared.count(entries: all) <= budget ? all : nil
     }
+}
 
-    return baseEntries + keptHistory
+// MARK: - Strategy: Newest First (default)
+
+func trimNewestFirst(
+    base: [Transcript.Entry], history: [Transcript.Entry],
+    final: Transcript.Entry?, budget: Int
+) async -> [Transcript.Entry] {
+    var kept: [Transcript.Entry] = []
+    for entry in history.reversed() {
+        var candidate = base + [entry] + kept
+        if let final { candidate.append(final) }
+        if await TokenCounter.shared.count(entries: candidate) > budget { break }
+        kept.insert(entry, at: 0)
+    }
+    return base + kept
+}
+
+// MARK: - Strategy: Oldest First
+
+func trimOldestFirst(
+    base: [Transcript.Entry], history: [Transcript.Entry],
+    final: Transcript.Entry?, budget: Int
+) async -> [Transcript.Entry] {
+    var kept: [Transcript.Entry] = []
+    for entry in history {
+        var candidate = base + kept + [entry]
+        if let final { candidate.append(final) }
+        if await TokenCounter.shared.count(entries: candidate) > budget { break }
+        kept.append(entry)
+    }
+    return base + kept
+}
+
+// MARK: - Strategy: Sliding Window
+
+func trimSlidingWindow(
+    base: [Transcript.Entry], history: [Transcript.Entry],
+    final: Transcript.Entry?, budget: Int, maxTurns: Int?
+) async -> [Transcript.Entry] {
+    let windowSize = min(maxTurns ?? Int.max, history.count)
+    let windowed = Array(history.suffix(windowSize))
+    // Apply token-budget safety net (drop from front if over budget)
+    return await trimNewestFirst(
+        base: base, history: windowed, final: final, budget: budget)
 }
 
 // MARK: - Streaming Helper

--- a/Sources/Summarizer.swift
+++ b/Sources/Summarizer.swift
@@ -1,0 +1,91 @@
+// ============================================================================
+// Summarizer.swift — Context strategy: compress old history into a summary
+// Part of apfel — Apple Intelligence from the command line
+//
+// Uses the on-device model itself to generate a summary of older turns,
+// keeping recent turns verbatim. Falls back to newest-first on failure.
+// ============================================================================
+
+import FoundationModels
+import Foundation
+import ApfelCore
+
+/// Summarize old history entries, keeping recent ones verbatim.
+/// Falls back to newest-first if summarization fails or budget is too tight.
+func trimWithSummary(
+    base: [Transcript.Entry], history: [Transcript.Entry],
+    final: Transcript.Entry?, budget: Int
+) async -> [Transcript.Entry] {
+    guard history.count > 2 else {
+        return await trimNewestFirst(
+            base: base, history: history, final: final, budget: budget)
+    }
+
+    // Split: keep recent 50% of budget, summarize the rest
+    let halfBudget = budget / 2
+    var recentEntries: [Transcript.Entry] = []
+    for entry in history.reversed() {
+        var candidate = base + [entry] + recentEntries
+        if let final { candidate.append(final) }
+        if await TokenCounter.shared.count(entries: candidate) > halfBudget { break }
+        recentEntries.insert(entry, at: 0)
+    }
+
+    let oldEntries = Array(history.dropLast(recentEntries.count))
+    guard !oldEntries.isEmpty else {
+        return base + recentEntries
+    }
+
+    // Render old entries to text for summarization
+    let oldText = renderEntries(oldEntries)
+    guard !oldText.isEmpty else {
+        return await trimNewestFirst(
+            base: base, history: history, final: final, budget: budget)
+    }
+
+    // Summarize using the on-device model
+    let summaryText = await generateSummary(oldText)
+    guard let summaryText else {
+        return await trimNewestFirst(
+            base: base, history: history, final: final, budget: budget)
+    }
+
+    let segment = Transcript.TextSegment(content: "[Summary of prior conversation]: \(summaryText)")
+    let summaryEntry = Transcript.Entry.response(
+        Transcript.Response(assetIDs: [], segments: [.text(segment)]))
+
+    return base + [summaryEntry] + recentEntries
+}
+
+// MARK: - Helpers
+
+private func renderEntries(_ entries: [Transcript.Entry]) -> String {
+    entries.compactMap { entry -> String? in
+        switch entry {
+        case .prompt(let p):
+            return p.segments.compactMap { seg in
+                if case .text(let t) = seg { return "User: \(t.content)" }; return nil
+            }.joined()
+        case .response(let r):
+            return r.segments.compactMap { seg in
+                if case .text(let t) = seg { return "Assistant: \(t.content)" }; return nil
+            }.joined()
+        default: return nil
+        }
+    }.joined(separator: "\n")
+}
+
+private func generateSummary(_ text: String) async -> String? {
+    let model = SystemLanguageModel.default
+    let session = LanguageModelSession(
+        model: model,
+        instructions: "Summarize the following conversation in 2-3 sentences. Be concise."
+    )
+    do {
+        let response = try await session.respond(to: text)
+        let summary = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return summary.isEmpty ? nil : summary
+    } catch {
+        return nil
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -85,6 +85,9 @@ var cliTemperature: Double? = Double(env["APFEL_TEMPERATURE"] ?? "")
 var cliSeed: UInt64? = nil
 var cliMaxTokens: Int? = Int(env["APFEL_MAX_TOKENS"] ?? "").flatMap { $0 > 0 ? $0 : nil }
 var cliPermissive: Bool = false
+var cliContextStrategy: ContextStrategy? = env["APFEL_CONTEXT_STRATEGY"].flatMap { ContextStrategy(rawValue: $0) }
+var cliContextMaxTurns: Int? = env["APFEL_CONTEXT_MAX_TURNS"].flatMap { Int($0) }
+var cliContextOutputReserve: Int? = env["APFEL_CONTEXT_OUTPUT_RESERVE"].flatMap { Int($0) }.flatMap { $0 > 0 ? $0 : nil }
 
 var i = 0
 while i < args.count {
@@ -192,6 +195,30 @@ while i < args.count {
     case "--permissive":
         cliPermissive = true
 
+    case "--context-strategy":
+        i += 1
+        guard i < args.count, let s = ContextStrategy(rawValue: args[i]) else {
+            printError("--context-strategy requires: newest-first|oldest-first|sliding-window|summarize|strict")
+            exit(exitUsageError)
+        }
+        cliContextStrategy = s
+
+    case "--context-max-turns":
+        i += 1
+        guard i < args.count, let n = Int(args[i]), n > 0 else {
+            printError("--context-max-turns requires a positive number")
+            exit(exitUsageError)
+        }
+        cliContextMaxTurns = n
+
+    case "--context-output-reserve":
+        i += 1
+        guard i < args.count, let n = Int(args[i]), n > 0 else {
+            printError("--context-output-reserve requires a positive number")
+            exit(exitUsageError)
+        }
+        cliContextOutputReserve = n
+
     case "--system-file":
         i += 1
         guard i < args.count else {
@@ -233,11 +260,18 @@ if prompt.isEmpty && mode == "single" && isatty(STDIN_FILENO) == 0 {
 
 // MARK: - Dispatch
 
+let contextConfig = ContextConfig(
+    strategy: cliContextStrategy ?? .newestFirst,
+    maxTurns: cliContextMaxTurns,
+    outputReserve: cliContextOutputReserve ?? 512
+)
+
 let sessionOpts = SessionOptions(
     temperature: cliTemperature,
     maxTokens: cliMaxTokens,
     seed: cliSeed,
-    permissive: cliPermissive
+    permissive: cliPermissive,
+    contextConfig: contextConfig
 )
 
 // Check model availability for modes that need it

--- a/Tests/apfelTests/ContextStrategyTests.swift
+++ b/Tests/apfelTests/ContextStrategyTests.swift
@@ -1,0 +1,55 @@
+// ============================================================================
+// ContextStrategyTests.swift — Unit tests for ContextStrategy and ContextConfig
+// ============================================================================
+
+import ApfelCore
+
+func runContextStrategyTests() {
+    test("ContextStrategy raw values") {
+        try assertEqual(ContextStrategy.newestFirst.rawValue, "newest-first")
+        try assertEqual(ContextStrategy.oldestFirst.rawValue, "oldest-first")
+        try assertEqual(ContextStrategy.slidingWindow.rawValue, "sliding-window")
+        try assertEqual(ContextStrategy.summarize.rawValue, "summarize")
+        try assertEqual(ContextStrategy.strict.rawValue, "strict")
+    }
+
+    test("ContextStrategy allCases has 5 entries") {
+        try assertEqual(ContextStrategy.allCases.count, 5)
+    }
+
+    test("ContextStrategy init from valid raw value") {
+        try assertNotNil(ContextStrategy(rawValue: "newest-first"))
+        try assertNotNil(ContextStrategy(rawValue: "strict"))
+    }
+
+    test("ContextStrategy init from invalid raw value returns nil") {
+        try assertNil(ContextStrategy(rawValue: "invalid"))
+        try assertNil(ContextStrategy(rawValue: ""))
+    }
+
+    test("ContextConfig defaults") {
+        let cfg = ContextConfig.defaults
+        try assertEqual(cfg.strategy, .newestFirst)
+        try assertNil(cfg.maxTurns)
+        try assertEqual(cfg.outputReserve, 512)
+    }
+
+    test("ContextConfig custom values") {
+        let cfg = ContextConfig(strategy: .slidingWindow, maxTurns: 6, outputReserve: 256)
+        try assertEqual(cfg.strategy, .slidingWindow)
+        try assertEqual(cfg.maxTurns, 6)
+        try assertEqual(cfg.outputReserve, 256)
+    }
+
+    test("ContextConfig equality") {
+        let a = ContextConfig(strategy: .strict, outputReserve: 300)
+        let b = ContextConfig(strategy: .strict, outputReserve: 300)
+        let c = ContextConfig(strategy: .newestFirst, outputReserve: 300)
+        try assertTrue(a == b)
+        try assertTrue(a != c)
+    }
+
+    test("ContextConfig zero-arg init matches defaults") {
+        try assertTrue(ContextConfig() == ContextConfig.defaults)
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -46,6 +46,7 @@ func suite(_ name: String, _ block: () -> Void) {
 
 suite("ApfelErrorTests") { runApfelErrorTests() }
 suite("ToolCallHandlerTests") { runToolCallHandlerTests() }
+suite("ContextStrategyTests") { runContextStrategyTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
## Summary
- Add 5 configurable context strategies: `newest-first` (default), `oldest-first`, `sliding-window`, `summarize`, `strict`
- Expose via CLI flags (`--context-strategy`, `--context-max-turns`, `--context-output-reserve`), env vars, and OpenAI API extension fields (`x_context_*`)
- Add GUI settings sheet (gear icon in toolbar) with strategy picker, max turns, output reserve stepper
- Show active strategy in debug panel; replaces hardcoded 512-token output reserve with configurable value
- Zero breaking changes — current behavior is the default

## Test plan
- [x] `swift run apfel-tests` — all 48 tests pass (8 new ContextStrategy tests)
- [ ] CLI: `apfel --chat --context-strategy sliding-window --context-max-turns 4`
- [ ] CLI: `apfel --context-strategy invalid` exits code 2
- [ ] Server: POST with `x_context_strategy: "oldest-first"` succeeds
- [ ] GUI: Gear icon opens settings, picker changes strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)