### PR TITLE
Fix --json trailing newline when piped

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -59,7 +59,7 @@ func singlePrompt(_ prompt: String, systemPrompt: String?, stream: Bool, options
             content: content,
             metadata: .init(onDevice: true, version: version)
         )
-        print(jsonString(obj))
+        print(jsonString(obj), terminator: "")
     }
 }
 

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -160,6 +160,21 @@ def test_quiet_json_prompt_output_is_machine_readable():
     assert result.stderr == ""
 
 
+def test_json_output_has_no_trailing_newline():
+    """Regression test for #9: JSON output should not end with a newline."""
+    require_model()
+    result = run_cli(
+        ["-q", "-o", "json", "What is 2+2? Reply with just the number."],
+        timeout=90,
+    )
+    assert result.returncode == 0
+    assert not result.stdout.endswith("\n"), (
+        f"JSON output has trailing newline: {result.stdout!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload["content"].strip()
+
+
 def test_piped_stdin_json_output_is_machine_readable():
     require_model()
     result = run_cli(


### PR DESCRIPTION
## Summary
- Fixes #9: `apfel -o json "prompt"` appended a trailing `\n` via Swift's `print()`, breaking downstream tools expecting clean JSON
- Changed `print(jsonString(obj))` to `print(jsonString(obj), terminator: "")` in single-prompt JSON output path
- Chat JSONL output unchanged — newlines are correct delimiters between messages there
- Added regression test `test_json_output_has_no_trailing_newline`

## Test plan
- [ ] Run `apfel -o json "test" | xxd | tail -1` — verify no trailing `0a` byte
- [ ] Run `apfel -o json "test" | jq .content` — still parses correctly
- [ ] Run integration tests: `python3 Tests/integration/cli_e2e_test.py`
- [ ] Verify chat mode JSONL still has newline delimiters between messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)