### PR TITLE
fix(cli): remove trailing newline from --json output

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -59,7 +59,7 @@ func singlePrompt(_ prompt: String, systemPrompt: String?, stream: Bool, options
             content: content,
             metadata: .init(onDevice: true, version: version)
         )
-        print(jsonString(obj))
+        print(jsonString(obj), terminator: "")
     }
 }
 

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -174,6 +174,21 @@ def test_piped_stdin_json_output_is_machine_readable():
     assert result.stderr == ""
 
 
+def test_json_output_no_trailing_newline():
+    """Regression: --json piped output must not end with a newline (GH-9)."""
+    require_model()
+    result = run_cli(
+        ["-q", "-o", "json", "What is 2+2? Reply with just the number."],
+        timeout=90,
+    )
+    assert result.returncode == 0
+    assert not result.stdout.endswith("\n"), (
+        f"JSON stdout ends with trailing newline: {result.stdout!r}"
+    )
+    # Ensure the output is still valid JSON
+    json.loads(result.stdout)
+
+
 def test_stream_returns_content():
     require_model()
     result = run_cli(["--stream", "Reply with the single word OK."], timeout=90)


### PR DESCRIPTION
## Summary

- Fix `print(jsonString(obj))` on CLI.swift:62 to use `terminator: ""`, preventing a trailing `\n` when piped (e.g. `apfel -o json "prompt" | jq -c .`)
- Chat JSONL output (lines 117-120, 137-140) left unchanged — newlines are needed as JSONL delimiters
- Add regression test `test_json_output_no_trailing_newline` in `Tests/integration/cli_e2e_test.py`

Closes #9

## Test plan

- [ ] `make install` and verify `apfel -q -o json "hi" | xxd | tail -1` shows no trailing `0a`
- [ ] `python3 -m pytest Tests/integration/cli_e2e_test.py::test_json_output_no_trailing_newline -v`
- [ ] Verify chat JSONL still works: `apfel --chat` with `-o json` still delimits lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)