### PR TITLE
Improve error message when server port is already in use

### DIFF
--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Hummingbird
+import NIOCore
 import ApfelCore
 
 /// Server configuration passed from CLI argument parsing.
@@ -235,7 +236,15 @@ func startServer(config: ServerConfig) async throws {
     printStderr("  GET  http://\(config.host):\(config.port)/health")
     printStderr("")
 
-    try await app.run()
+    do {
+        try await app.run()
+    } catch let error as IOError where error.errnoCode == EADDRINUSE {
+        printStderr("")
+        printStderr(styled("error: Port \(config.port) is already in use.", .red, .bold))
+        printStderr("Another process (e.g. Ollama) may be listening on this port.")
+        printStderr("Fix: \(styled("apfel --serve --port <other-port>", .cyan)) or stop the other process.")
+        exit(exitRuntimeError)
+    }
 }
 
 func isLoopbackHost(_ host: String) -> Bool {


### PR DESCRIPTION
## Summary

I ran `apfel --serve` and got a cryptic error that didn't tell me what was wrong:

```
error: [error] The operation couldn't be completed. (NIOCore.IOError error 1.)
```

Turns out I had Ollama running on the same port, since both default to 11434. It took me a while to figure that out since the error gave no hint about a port conflict.

This PR catches `EADDRINUSE` from NIO and shows an actionable message instead:

```
error: Port 11434 is already in use.
Another process (e.g. Ollama) may be listening on this port.
Fix: apfel --serve --port <other-port> or stop the other process.
```


## Test plan
- [x] `swift build -c release`
- [x] `swift run apfel-tests`
- [x] `make install` and manual smoke test
