### PR TITLE
add info about error and enabling apple intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Every Mac with Apple Silicon has a **built-in LLM** - Apple's on-device foundati
 
 - Apple Silicon Mac, macOS 26 Tahoe or newer, [Apple Intelligence enabled](https://support.apple.com/en-us/121115)
 - Building from source requires Command Line Tools with macOS 26.4 SDK (ships Swift 6.3). No Xcode required.
+- Apple Intelligence is enabled (System Settings GUI (Apple menu > System Settings > Apple Intelligence & Siri))
 
 **Homebrew** (recommended):
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -79,3 +79,8 @@ apfel "Hello, world!"
 apfel --version
 apfel --release       # full build info
 ```
+
+## Errors
+If you get this error, "error: Apple Intelligence is not enabled or model is not ready. Run: apfel --model-info", check to see that you have Apple Intelligence enabled. (System Settings GUI (Apple menu > System Settings > Apple Intelligence & Siri))
+
+


### PR DESCRIPTION
## Summary
I did not see the requirements in the docs/install.md file. I made it a bit more explicit in the readme and added the error to hopefully help others.

Fix for #28 

## Test plan
- [x] `swift build -c release`
- [x] `swift run apfel-tests`
- [NA] `make install` and manual smoke test
