### PR TITLE
feat(tests): add testAsync() to test harness for async unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .triage-log/
 .wrangler/
 __pycache__/
+.notes/

--- a/Tests/apfelTests/AsyncHarnessTests.swift
+++ b/Tests/apfelTests/AsyncHarnessTests.swift
@@ -1,0 +1,43 @@
+// ============================================================================
+// AsyncHarnessTests.swift — Validate testAsync() harness works correctly
+// ============================================================================
+
+import Foundation
+
+func runAsyncHarnessTests() {
+
+    testAsync("async passing test runs") {
+        let value = await Task { 42 }.value
+        try assertEqual(value, 42)
+    }
+
+    testAsync("async assertTrue works") {
+        let result = await Task { true }.value
+        try assertTrue(result)
+    }
+
+    testAsync("async assertNil works") {
+        let result: Int? = await Task { nil }.value
+        try assertNil(result)
+    }
+
+    testAsync("async assertNotNil works") {
+        let result: Int? = await Task { 1 }.value
+        try assertNotNil(result)
+    }
+
+    testAsync("async assertEqual with strings") {
+        let greeting = await Task { "hello" }.value
+        try assertEqual(greeting, "hello")
+    }
+
+    testAsync("async work completes before assertion") {
+        // Verify that the semaphore actually waits for the Task to finish
+        let result = await withCheckedContinuation { continuation in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                continuation.resume(returning: "done")
+            }
+        }
+        try assertEqual(result, "done")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -19,6 +19,33 @@ func test(_ name: String, _ block: () throws -> Void) {
     }
 }
 
+/// Async variant — runs the block on a Task and waits synchronously via semaphore.
+/// Enables unit-testing async functions without XCTest or Swift Testing.
+func testAsync(_ name: String, _ block: @Sendable @escaping () async throws -> Void) {
+    let semaphore = DispatchSemaphore(value: 0)
+    nonisolated(unsafe) var failure: Error? = nil
+    nonisolated(unsafe) var passed = false
+
+    Task {
+        do {
+            try await block()
+            passed = true
+        } catch {
+            failure = error
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+
+    if passed {
+        print("  ✅ \(name)")
+        _passed += 1
+    } else {
+        print("  ❌ \(name): \(failure!)")
+        _failed += 1
+    }
+}
+
 func assertEqual<T: Equatable>(_ a: T, _ b: T, _ msg: String = "") throws {
     guard a == b else { throw TestFailure("\(a) != \(b)\(msg.isEmpty ? "" : " — \(msg)")") }
 }
@@ -51,6 +78,7 @@ suite("OpenAIModelsTests") { runOpenAIModelsTests() }
 suite("ChatRequestValidatorTests") { runChatRequestValidatorTests() }
 suite("OriginValidatorTests") { runOriginValidatorTests() }
 suite("MCPClientTests") { runMCPClientTests() }
+suite("AsyncHarnessTests") { runAsyncHarnessTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
## Summary

- Adds `testAsync()` harness function — runs async test blocks on a `Task`, waits via `DispatchSemaphore`, same pass/fail reporting as existing `test()`
- Adds `AsyncHarnessTests.swift` with 6 self-tests validating the async harness (basic execution, all assertion helpers, delayed-completion wait)
- Adds `.notes/` to `.gitignore` for local development notes

## Design Decisions

**Why `DispatchSemaphore`?** The existing harness is synchronous `main.swift` calling `suite()` blocks sequentially. Converting to `async main()` would change the build target config and how all existing sync tests run. The semaphore approach is purely additive.

**Why not XCTest or Swift Testing?** The project explicitly avoids them (line 1 of `main.swift`). `swift run apfel-tests` works with Command Line Tools only — no Xcode project needed.

**Why no trimming/SchemaConverter tests yet?** The test target depends only on `ApfelCore` (no `FoundationModels`). The trimming functions and `SchemaConverter` live in the `apfel` executable target, which can't be imported as a library. The next step would be extracting those into a testable library target, at which point the full async test suites can be wired up.

## Test plan

- [x] `swift run apfel-tests` passes — 139 tests (133 existing + 6 new), 0 failures
- [x] No changes to existing test behavior
- [x] New `AsyncHarnessTests` suite validates async execution, all assertion helpers, and semaphore wait behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)