### PR TITLE
perf: buffered reads for MCP stdio transport

### DIFF
--- a/Sources/Core/BufferedLineReader.swift
+++ b/Sources/Core/BufferedLineReader.swift
@@ -1,0 +1,103 @@
+// ============================================================================
+// BufferedLineReader.swift — Buffered newline-delimited reader for file descriptors
+// Part of ApfelCore — pure Swift, no FoundationModels dependency
+// ============================================================================
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Reads newline-delimited lines from a file descriptor using buffered I/O.
+/// Each `readLine()` call returns one complete line (without the trailing newline).
+/// Bytes arriving after the newline are stashed for the next call.
+public final class BufferedLineReader: @unchecked Sendable {
+    private let fd: Int32
+    private let bufferSize: Int
+    private var leftover = Data()
+
+    public init(fileDescriptor: Int32, bufferSize: Int = 4096) {
+        self.fd = fileDescriptor
+        self.bufferSize = bufferSize
+    }
+
+    /// Read one newline-delimited line from the file descriptor.
+    /// - Parameters:
+    ///   - timeoutMilliseconds: Maximum time to wait for a complete line.
+    ///   - operationDescription: Human-readable label for error messages.
+    /// - Returns: The line content (without trailing newline).
+    /// - Throws: `MCPError.timedOut` or `MCPError.processError` on failure.
+    public func readLine(timeoutMilliseconds: Int, operationDescription: String) throws -> String {
+        var lineBuffer = Data()
+        let deadline = Date().timeIntervalSinceReferenceDate + (Double(timeoutMilliseconds) / 1000.0)
+
+        // Drain any leftover bytes from a previous read that crossed a message boundary.
+        if let newlineIndex = leftover.firstIndex(of: UInt8(ascii: "\n")) {
+            lineBuffer.append(leftover[leftover.startIndex..<newlineIndex])
+            leftover = Data(leftover[(newlineIndex + 1)...])
+            if let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty {
+                return line
+            }
+        } else if !leftover.isEmpty {
+            lineBuffer.append(leftover)
+            leftover = Data()
+        }
+
+        var chunk = [UInt8](repeating: 0, count: bufferSize)
+
+        while true {
+            let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
+            if remainingMilliseconds <= 0 {
+                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
+            }
+
+            var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&pollDescriptor, 1, Int32(remainingMilliseconds))
+            if ready == 0 {
+                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
+            }
+            if ready < 0 {
+                if errno == EINTR { continue }
+                throw MCPError.processError("Failed waiting for MCP response: \(String(cString: strerror(errno)))")
+            }
+            if (pollDescriptor.revents & Int16(POLLNVAL)) != 0 {
+                throw MCPError.processError("MCP stdout became invalid")
+            }
+            if (pollDescriptor.revents & Int16(POLLERR)) != 0 {
+                throw MCPError.processError("MCP stdout reported an I/O error")
+            }
+            if (pollDescriptor.revents & Int16(POLLHUP)) != 0 && (pollDescriptor.revents & Int16(POLLIN)) == 0 {
+                throw MCPError.processError("MCP server closed unexpectedly")
+            }
+            if (pollDescriptor.revents & Int16(POLLIN)) == 0 {
+                continue
+            }
+
+            let readCount = Darwin.read(fd, &chunk, chunk.count)
+            if readCount == 0 {
+                throw MCPError.processError("MCP server closed unexpectedly")
+            }
+            if readCount < 0 {
+                if errno == EINTR { continue }
+                throw MCPError.processError("Failed reading MCP response: \(String(cString: strerror(errno)))")
+            }
+
+            let bytes = chunk[..<readCount]
+            if let newlineOffset = bytes.firstIndex(of: UInt8(ascii: "\n")) {
+                lineBuffer.append(contentsOf: bytes[bytes.startIndex..<newlineOffset])
+                let afterNewline = bytes.index(after: newlineOffset)
+                if afterNewline < bytes.endIndex {
+                    leftover = Data(bytes[afterNewline...])
+                }
+                break
+            }
+            lineBuffer.append(contentsOf: bytes)
+        }
+        guard let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty else {
+            throw MCPError.processError("Empty response from MCP server")
+        }
+        return line
+    }
+}

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -17,6 +17,7 @@ final class MCPConnection: @unchecked Sendable {
     private let process: Process
     private let stdinPipe: Pipe
     private let stdoutPipe: Pipe
+    private let lineReader: BufferedLineReader
     private let lock = NSLock()
     private var nextId = 1
 
@@ -45,6 +46,7 @@ final class MCPConnection: @unchecked Sendable {
         self.process = proc
         self.stdinPipe = stdinP
         self.stdoutPipe = stdoutP
+        self.lineReader = BufferedLineReader(fileDescriptor: stdoutP.fileHandleForReading.fileDescriptor)
         self.tools = [] // placeholder, filled below
 
         try proc.run()
@@ -118,86 +120,16 @@ final class MCPConnection: @unchecked Sendable {
         stdinPipe.fileHandleForWriting.write(data)
     }
 
-    /// Leftover bytes from a previous buffered read that arrived after a newline.
-    private var readBuffer = Data()
-
     private func sendAndReceive(
         _ message: String,
         timeoutMilliseconds: Int,
         operationDescription: String
     ) throws -> String {
         send(message)
-        var lineBuffer = Data()
-        let fd = stdoutPipe.fileHandleForReading.fileDescriptor
-        let deadline = Date().timeIntervalSinceReferenceDate + (Double(timeoutMilliseconds) / 1000.0)
-
-        // Drain any leftover bytes from the previous read that crossed a message boundary.
-        if let newlineIndex = readBuffer.firstIndex(of: UInt8(ascii: "\n")) {
-            lineBuffer.append(readBuffer[readBuffer.startIndex..<newlineIndex])
-            readBuffer = Data(readBuffer[(newlineIndex + 1)...])
-            if let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty {
-                return line
-            }
-        } else if !readBuffer.isEmpty {
-            lineBuffer.append(readBuffer)
-            readBuffer = Data()
-        }
-
-        var chunk = [UInt8](repeating: 0, count: 4096)
-
-        while true {
-            let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
-            if remainingMilliseconds <= 0 {
-                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
-            }
-
-            var pollDescriptor = pollfd(fd: Int32(fd), events: Int16(POLLIN), revents: 0)
-            let ready = poll(&pollDescriptor, 1, Int32(remainingMilliseconds))
-            if ready == 0 {
-                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
-            }
-            if ready < 0 {
-                if errno == EINTR { continue }
-                throw MCPError.processError("Failed waiting for MCP response: \(String(cString: strerror(errno)))")
-            }
-            if (pollDescriptor.revents & Int16(POLLNVAL)) != 0 {
-                throw MCPError.processError("MCP stdout became invalid")
-            }
-            if (pollDescriptor.revents & Int16(POLLERR)) != 0 {
-                throw MCPError.processError("MCP stdout reported an I/O error")
-            }
-            if (pollDescriptor.revents & Int16(POLLHUP)) != 0 && (pollDescriptor.revents & Int16(POLLIN)) == 0 {
-                throw MCPError.processError("MCP server closed unexpectedly")
-            }
-            if (pollDescriptor.revents & Int16(POLLIN)) == 0 {
-                continue
-            }
-
-            let readCount = Darwin.read(fd, &chunk, chunk.count)
-            if readCount == 0 {
-                throw MCPError.processError("MCP server closed unexpectedly")
-            }
-            if readCount < 0 {
-                if errno == EINTR { continue }
-                throw MCPError.processError("Failed reading MCP response: \(String(cString: strerror(errno)))")
-            }
-
-            let bytes = chunk[..<readCount]
-            if let newlineOffset = bytes.firstIndex(of: UInt8(ascii: "\n")) {
-                lineBuffer.append(contentsOf: bytes[bytes.startIndex..<newlineOffset])
-                // Stash anything after the newline for the next call.
-                let afterNewline = bytes.index(after: newlineOffset)
-                if afterNewline < bytes.endIndex {
-                    readBuffer = Data(bytes[afterNewline...])
-                }
-                break
-            }
-            lineBuffer.append(contentsOf: bytes)
-        }
-        guard let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty else {
-            throw MCPError.processError("Empty response from MCP server")
-        }
-        return line
+        return try lineReader.readLine(
+            timeoutMilliseconds: timeoutMilliseconds,
+            operationDescription: operationDescription
+        )
     }
 }
 

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -118,15 +118,32 @@ final class MCPConnection: @unchecked Sendable {
         stdinPipe.fileHandleForWriting.write(data)
     }
 
+    /// Leftover bytes from a previous buffered read that arrived after a newline.
+    private var readBuffer = Data()
+
     private func sendAndReceive(
         _ message: String,
         timeoutMilliseconds: Int,
         operationDescription: String
     ) throws -> String {
         send(message)
-        var buffer = Data()
+        var lineBuffer = Data()
         let fd = stdoutPipe.fileHandleForReading.fileDescriptor
         let deadline = Date().timeIntervalSinceReferenceDate + (Double(timeoutMilliseconds) / 1000.0)
+
+        // Drain any leftover bytes from the previous read that crossed a message boundary.
+        if let newlineIndex = readBuffer.firstIndex(of: UInt8(ascii: "\n")) {
+            lineBuffer.append(readBuffer[readBuffer.startIndex..<newlineIndex])
+            readBuffer = Data(readBuffer[(newlineIndex + 1)...])
+            if let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty {
+                return line
+            }
+        } else if !readBuffer.isEmpty {
+            lineBuffer.append(readBuffer)
+            readBuffer = Data()
+        }
+
+        var chunk = [UInt8](repeating: 0, count: 4096)
 
         while true {
             let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
@@ -156,8 +173,7 @@ final class MCPConnection: @unchecked Sendable {
                 continue
             }
 
-            var byte: UInt8 = 0
-            let readCount = Darwin.read(fd, &byte, 1)
+            let readCount = Darwin.read(fd, &chunk, chunk.count)
             if readCount == 0 {
                 throw MCPError.processError("MCP server closed unexpectedly")
             }
@@ -165,10 +181,20 @@ final class MCPConnection: @unchecked Sendable {
                 if errno == EINTR { continue }
                 throw MCPError.processError("Failed reading MCP response: \(String(cString: strerror(errno)))")
             }
-            if byte == UInt8(ascii: "\n") { break }
-            buffer.append(&byte, count: 1)
+
+            let bytes = chunk[..<readCount]
+            if let newlineOffset = bytes.firstIndex(of: UInt8(ascii: "\n")) {
+                lineBuffer.append(contentsOf: bytes[bytes.startIndex..<newlineOffset])
+                // Stash anything after the newline for the next call.
+                let afterNewline = bytes.index(after: newlineOffset)
+                if afterNewline < bytes.endIndex {
+                    readBuffer = Data(bytes[afterNewline...])
+                }
+                break
+            }
+            lineBuffer.append(contentsOf: bytes)
         }
-        guard let line = String(data: buffer, encoding: .utf8), !line.isEmpty else {
+        guard let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty else {
             throw MCPError.processError("Empty response from MCP server")
         }
         return line

--- a/Tests/apfelTests/BufferedLineReaderTests.swift
+++ b/Tests/apfelTests/BufferedLineReaderTests.swift
@@ -1,0 +1,197 @@
+// ============================================================================
+// BufferedLineReaderTests.swift — Unit tests for BufferedLineReader
+// Uses real UNIX pipes to test the buffered read logic end-to-end.
+// ============================================================================
+
+import Foundation
+import ApfelCore
+#if canImport(Darwin)
+import Darwin
+#endif
+
+func runBufferedLineReaderTests() {
+
+    /// Helper: create a pipe pair and return (readFD, writeFD).
+    func makePipe() -> (Int32, Int32) {
+        var fds: [Int32] = [0, 0]
+        pipe(&fds)
+        return (fds[0], fds[1])
+    }
+
+    /// Helper: write a string to a file descriptor.
+    func writeString(_ fd: Int32, _ string: String) {
+        let data = Array(string.utf8)
+        data.withUnsafeBufferPointer { buf in
+            _ = Darwin.write(fd, buf.baseAddress, buf.count)
+        }
+    }
+
+    // -- Basic single-line reads --
+
+    test("reads a single line terminated by newline") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        writeString(writeFD, "hello world\n")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        let line = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(line, "hello world")
+    }
+
+    test("reads multiple lines sequentially") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        writeString(writeFD, "line one\nline two\nline three\n")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        let first = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        let second = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        let third = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(first, "line one")
+        try assertEqual(second, "line two")
+        try assertEqual(third, "line three")
+    }
+
+    test("handles leftover bytes from previous read correctly") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        // Write two lines in one write — the reader must stash the second line's bytes
+        writeString(writeFD, "first\nsecond\n")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        let first = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(first, "first")
+
+        // Second line should come from the leftover buffer without needing another read()
+        let second = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(second, "second")
+    }
+
+    test("reads JSON-RPC style messages") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        let msg = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n"
+        writeString(writeFD, msg)
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        let line = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(line, "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}")
+    }
+
+    // -- Buffering behavior --
+
+    test("handles data arriving in small chunks") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+
+        // Write partial data, then the rest with newline
+        writeString(writeFD, "hel")
+        writeString(writeFD, "lo\n")
+
+        let line = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(line, "hello")
+    }
+
+    test("custom buffer size works") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        // Use a tiny buffer to force multiple read() calls for a longer message
+        let reader = BufferedLineReader(fileDescriptor: readFD, bufferSize: 4)
+        writeString(writeFD, "abcdefghijklmnop\n")
+
+        let line = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        try assertEqual(line, "abcdefghijklmnop")
+    }
+
+    test("handles large messages efficiently") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        let largePayload = String(repeating: "x", count: 8000)
+        writeString(writeFD, largePayload + "\n")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        let line = try reader.readLine(timeoutMilliseconds: 2000, operationDescription: "test")
+        try assertEqual(line.count, 8000)
+    }
+
+    // -- Error handling --
+
+    test("times out when no newline arrives") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        // Write data without a newline
+        writeString(writeFD, "no newline here")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        var didThrow = false
+        do {
+            let _ = try reader.readLine(timeoutMilliseconds: 100, operationDescription: "test")
+        } catch {
+            didThrow = true
+            try assertTrue("\(error)".contains("timed out"), "Expected timeout error, got: \(error)")
+        }
+        try assertTrue(didThrow, "Expected timeout error")
+    }
+
+    test("throws on closed pipe (EOF)") {
+        let (readFD, writeFD) = makePipe()
+        close(writeFD) // Close write end immediately — reader sees EOF
+        defer { close(readFD) }
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        var didThrow = false
+        do {
+            let _ = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        } catch {
+            didThrow = true
+            try assertTrue("\(error)".contains("closed unexpectedly"), "Expected closed error, got: \(error)")
+        }
+        try assertTrue(didThrow, "Expected closed pipe error")
+    }
+
+    test("throws on empty line (newline only)") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        writeString(writeFD, "\n")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        var didThrow = false
+        do {
+            let _ = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "test")
+        } catch {
+            didThrow = true
+            try assertTrue("\(error)".contains("Empty response"), "Expected empty response error, got: \(error)")
+        }
+        try assertTrue(didThrow, "Expected empty response error")
+    }
+
+    // -- Multi-message sequences (simulating MCP handshake) --
+
+    test("handles init + tools/list sequence like real MCP handshake") {
+        let (readFD, writeFD) = makePipe()
+        defer { close(readFD); close(writeFD) }
+
+        let initResponse = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"serverInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}"
+        let toolsResponse = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"add\",\"description\":\"Add numbers\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"number\"},\"b\":{\"type\":\"number\"}},\"required\":[\"a\",\"b\"]}}]}}"
+
+        // Write both responses at once — tests that leftover buffering works across messages
+        writeString(writeFD, initResponse + "\n" + toolsResponse + "\n")
+
+        let reader = BufferedLineReader(fileDescriptor: readFD)
+        let first = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "initialize")
+        let second = try reader.readLine(timeoutMilliseconds: 1000, operationDescription: "tools/list")
+
+        try assertTrue(first.contains("protocolVersion"))
+        try assertTrue(second.contains("\"name\":\"add\""))
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -81,6 +81,7 @@ suite("MCPClientTests") { runMCPClientTests() }
 suite("AsyncHarnessTests") { runAsyncHarnessTests() }
 suite("RetryTests") { runRetryTests() }
 suite("DebugLoggerTests") { runDebugLoggerTests() }
+suite("BufferedLineReaderTests") { runBufferedLineReaderTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
## Summary

- Extracts buffered read logic into a standalone `BufferedLineReader` class in `ApfelCore`
- Replaces byte-at-a-time `Darwin.read(fd, &byte, 1)` with 4KB buffered reads
- For a typical 1KB MCP response, reduces syscalls from ~1000 to 1-2
- `MCPConnection.sendAndReceive()` now delegates to `BufferedLineReader.readLine()`
- **11 new unit tests** using real UNIX pipes (203 + 11 = 214 total)

## Problem

The MCP stdio transport read responses one byte at a time. Each iteration called `poll()` + `Darwin.read(fd, &byte, 1)` and appended to a `Data` buffer until a newline. For a 1KB JSON-RPC response, that was ~1000 separate syscalls.

The logic was also private inside `MCPConnection`, making it impossible to unit test without spawning a real MCP server process.

## Solution

**New: `Sources/Core/BufferedLineReader.swift`** — a standalone class in `ApfelCore` that:
- Reads from a file descriptor using a configurable buffer (default 4KB)
- Scans for newlines and returns complete lines
- Stashes leftover bytes past the newline for the next `readLine()` call
- Handles all poll/timeout/error conditions (POLLNVAL, POLLERR, POLLHUP, EINTR, EOF)

**Refactored: `MCPConnection.sendAndReceive()`** — now a 4-line method that calls `send()` + `lineReader.readLine()`.

## Tests

`Tests/apfelTests/BufferedLineReaderTests.swift` — 11 tests using real UNIX pipe pairs:

| Test | What it covers |
|------|---------------|
| single line read | Basic newline-delimited read |
| multiple sequential lines | Three lines read in order |
| leftover byte handling | Two lines written at once, second comes from buffer |
| JSON-RPC messages | Realistic MCP response parsing |
| small chunks | Data arriving in multiple writes |
| custom buffer size | Tiny buffer (4 bytes) forces multiple `read()` calls |
| large messages | 8KB payload exceeding default buffer |
| timeout | No newline within deadline |
| closed pipe (EOF) | Writer closes before newline |
| empty line | Newline-only input rejected |
| MCP handshake sequence | init + tools/list written at once, split by buffer |

## What didn't change

- All poll/timeout/error handling logic is preserved identically
- The `send()` path is unchanged
- All existing error messages are preserved
- No changes to `MCPManager` or the public API

## Test plan

- [x] `swift run apfel-tests` — 214 tests pass, 0 failures
- [x] `swift build` succeeds
- [ ] Integration tests with MCP calculator server

🤖 Generated with [Claude Code](https://claude.com/claude-code)