### PR TITLE
refactor: extract CLIArguments struct from main.swift into ApfelCore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,16 +22,23 @@ let package = Package(
             dependencies: [],
             path: "Sources/Core"
         ),
-        // Main executable — depends on ApfelCore + Hummingbird + FoundationModels
+        // CLI argument parsing — depends on ApfelCore for ContextStrategy
+        .target(
+            name: "ApfelCLI",
+            dependencies: ["ApfelCore"],
+            path: "Sources/CLI"
+        ),
+        // Main executable — depends on ApfelCore + ApfelCLI + Hummingbird + FoundationModels
         .executableTarget(
             name: "apfel",
             dependencies: [
                 .product(name: "Hummingbird", package: "hummingbird"),
                 "ApfelCore",
+                "ApfelCLI",
                 "CReadline",
             ],
             path: "Sources",
-            exclude: ["Core"],
+            exclude: ["Core", "CLI"],
             linkerSettings: [
                 .unsafeFlags([
                     "-Xlinker", "-sectcreate",
@@ -44,7 +51,7 @@ let package = Package(
         // Test runner — pure Swift, no XCTest/Testing (Command Line Tools only)
         .executableTarget(
             name: "apfel-tests",
-            dependencies: ["ApfelCore"],
+            dependencies: ["ApfelCore", "ApfelCLI"],
             path: "Tests/apfelTests"
         ),
     ]

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -1,12 +1,14 @@
 // ============================================================================
 // CLIArguments.swift — Parsed CLI arguments as a testable value type
-// Part of ApfelCore — pure data types, no FoundationModels dependency
+// Part of ApfelCLI — CLI-specific parsing, separate from ApfelCore domain logic
 // ============================================================================
 
 import Foundation
+import ApfelCore
 
 /// Represents the result of parsing CLI arguments into a typed struct.
-/// No side effects, no exit() calls — just pure parsing logic.
+/// Pure parsing logic — no side effects, no exit() calls.
+/// File I/O is injectable via the `readFile` parameter for testability.
 public struct CLIArguments: Sendable, Equatable {
 
     // MARK: - Mode
@@ -89,10 +91,17 @@ public struct CLIParseError: Error, Equatable, CustomStringConvertible {
 extension CLIArguments {
 
     /// Parse command-line arguments into a CLIArguments struct.
-    /// Does not call exit() or perform I/O — just returns the parsed result or throws.
-    /// File reads (--system-file, --file) are the one exception, since the content
-    /// must be captured at parse time.
-    public static func parse(_ args: [String], env: [String: String] = [:]) throws -> CLIArguments {
+    /// Does not call exit() — returns the parsed result or throws `CLIParseError`.
+    ///
+    /// - Parameters:
+    ///   - args: Command-line arguments (without the executable name).
+    ///   - env: Environment variables. Defaults applied first, CLI flags override.
+    ///   - readFile: Closure to read file contents by path. Injectable for testing.
+    public static func parse(
+        _ args: [String],
+        env: [String: String] = [:],
+        readFile: (_ path: String) throws -> String = { try String(contentsOfFile: $0, encoding: .utf8) }
+    ) throws -> CLIArguments {
         var result = CLIArguments()
 
         // Environment variable defaults
@@ -292,8 +301,10 @@ extension CLIArguments {
                 guard i < args.count else { throw CLIParseError("--system-file requires a file path") }
                 let path = args[i]
                 do {
-                    result.systemPrompt = try String(contentsOfFile: path, encoding: .utf8)
+                    result.systemPrompt = try readFile(path)
                         .trimmingCharacters(in: .whitespacesAndNewlines)
+                } catch let e as CLIParseError {
+                    throw e
                 } catch {
                     throw CLIParseError(fileErrorMessage(path: path))
                 }
@@ -303,8 +314,9 @@ extension CLIArguments {
                 guard i < args.count else { throw CLIParseError("--file requires a file path") }
                 let path = args[i]
                 do {
-                    let content = try String(contentsOfFile: path, encoding: .utf8)
-                    result.fileContents.append(content)
+                    result.fileContents.append(try readFile(path))
+                } catch let e as CLIParseError {
+                    throw e
                 } catch {
                     throw CLIParseError(fileErrorMessage(path: path))
                 }

--- a/Sources/Core/CLIArguments.swift
+++ b/Sources/Core/CLIArguments.swift
@@ -1,0 +1,352 @@
+// ============================================================================
+// CLIArguments.swift — Parsed CLI arguments as a testable value type
+// Part of ApfelCore — pure data types, no FoundationModels dependency
+// ============================================================================
+
+import Foundation
+
+/// Represents the result of parsing CLI arguments into a typed struct.
+/// No side effects, no exit() calls — just pure parsing logic.
+public struct CLIArguments: Sendable, Equatable {
+
+    // MARK: - Mode
+
+    public enum Mode: String, Sendable, Equatable {
+        case single
+        case stream
+        case chat
+        case serve
+        case benchmark
+        case modelInfo = "model-info"
+        case update
+        case help
+        case version
+        case release
+    }
+
+    public var mode: Mode = .single
+
+    // MARK: - Prompt & Content
+
+    public var prompt: String = ""
+    public var systemPrompt: String? = nil
+    public var fileContents: [String] = []
+
+    // MARK: - Output
+
+    public var outputFormat: String? = nil   // "plain" or "json"
+    public var quiet: Bool = false
+    public var noColor: Bool = false
+
+    // MARK: - Server
+
+    public var serverPort: Int = 11434
+    public var serverHost: String = "127.0.0.1"
+    public var serverCORS: Bool = false
+    public var serverMaxConcurrent: Int = 5
+    public var debug: Bool = false
+    public var serverAllowedOrigins: [String] = []
+    public var serverOriginCheckEnabled: Bool = true
+    public var serverToken: String? = nil
+    public var serverTokenAuto: Bool = false
+    public var serverPublicHealth: Bool = false
+
+    // MARK: - MCP
+
+    public var mcpServerPaths: [String] = []
+    public var mcpTimeoutSeconds: Int = 5
+
+    // MARK: - Generation
+
+    public var temperature: Double? = nil
+    public var seed: UInt64? = nil
+    public var maxTokens: Int? = nil
+    public var permissive: Bool = false
+
+    // MARK: - Retry
+
+    public var retryEnabled: Bool = false
+    public var retryCount: Int = 3
+
+    // MARK: - Context
+
+    public var contextStrategy: ContextStrategy? = nil
+    public var contextMaxTurns: Int? = nil
+    public var contextOutputReserve: Int? = nil
+
+    public init() {}
+}
+
+/// Errors thrown during argument parsing. Contains a user-facing message.
+public struct CLIParseError: Error, Equatable, CustomStringConvertible {
+    public let message: String
+    public init(_ message: String) { self.message = message }
+    public var description: String { message }
+}
+
+// MARK: - Parsing
+
+extension CLIArguments {
+
+    /// Parse command-line arguments into a CLIArguments struct.
+    /// Does not call exit() or perform I/O — just returns the parsed result or throws.
+    /// File reads (--system-file, --file) are the one exception, since the content
+    /// must be captured at parse time.
+    public static func parse(_ args: [String], env: [String: String] = [:]) throws -> CLIArguments {
+        var result = CLIArguments()
+
+        // Environment variable defaults
+        result.systemPrompt = env["APFEL_SYSTEM_PROMPT"]
+        result.serverPort = Int(env["APFEL_PORT"] ?? "") ?? 11434
+        result.serverHost = env["APFEL_HOST"] ?? "127.0.0.1"
+        result.serverToken = env["APFEL_TOKEN"]
+        result.mcpServerPaths = env["APFEL_MCP"]?
+            .split(separator: ":").map(String.init).filter { !$0.isEmpty } ?? []
+        result.mcpTimeoutSeconds = Int(env["APFEL_MCP_TIMEOUT"] ?? "")
+            .flatMap { $0 > 0 ? min($0, 300) : nil } ?? 5
+        result.temperature = Double(env["APFEL_TEMPERATURE"] ?? "")
+        result.maxTokens = Int(env["APFEL_MAX_TOKENS"] ?? "").flatMap { $0 > 0 ? $0 : nil }
+        result.contextStrategy = env["APFEL_CONTEXT_STRATEGY"].flatMap { ContextStrategy(rawValue: $0) }
+        result.contextMaxTurns = env["APFEL_CONTEXT_MAX_TURNS"].flatMap { Int($0) }
+        result.contextOutputReserve = env["APFEL_CONTEXT_OUTPUT_RESERVE"]
+            .flatMap { Int($0) }.flatMap { $0 > 0 ? $0 : nil }
+
+        var i = 0
+        while i < args.count {
+            switch args[i] {
+            case "-h", "--help":
+                result.mode = .help
+                return result
+
+            case "-v", "--version":
+                result.mode = .version
+                return result
+
+            case "--release":
+                result.mode = .release
+                return result
+
+            case "-s", "--system":
+                i += 1
+                guard i < args.count else { throw CLIParseError("--system requires a value") }
+                result.systemPrompt = args[i]
+
+            case "-o", "--output":
+                i += 1
+                guard i < args.count else {
+                    throw CLIParseError("--output requires a value (plain or json)")
+                }
+                guard args[i] == "plain" || args[i] == "json" else {
+                    throw CLIParseError("unknown output format: \(args[i]) (use plain or json)")
+                }
+                result.outputFormat = args[i]
+
+            case "-q", "--quiet":
+                result.quiet = true
+
+            case "--no-color":
+                result.noColor = true
+
+            case "--chat":
+                result.mode = .chat
+
+            case "--stream":
+                result.mode = .stream
+
+            case "--serve":
+                result.mode = .serve
+
+            case "--benchmark":
+                result.mode = .benchmark
+
+            case "--model-info":
+                result.mode = .modelInfo
+
+            case "--update":
+                result.mode = .update
+
+            case "--port":
+                i += 1
+                guard i < args.count, let p = Int(args[i]), p > 0, p < 65536 else {
+                    throw CLIParseError("--port requires a valid port number (1-65535)")
+                }
+                result.serverPort = p
+
+            case "--host":
+                i += 1
+                guard i < args.count else { throw CLIParseError("--host requires an address") }
+                result.serverHost = args[i]
+
+            case "--cors":
+                result.serverCORS = true
+
+            case "--max-concurrent":
+                i += 1
+                guard i < args.count, let n = Int(args[i]), n > 0 else {
+                    throw CLIParseError("--max-concurrent requires a positive number")
+                }
+                result.serverMaxConcurrent = n
+
+            case "--debug":
+                result.debug = true
+
+            case "--allowed-origins":
+                i += 1
+                guard i < args.count else {
+                    throw CLIParseError("--allowed-origins requires a comma-separated list of origins")
+                }
+                let origins = parseAllowedOrigins(args[i])
+                guard !origins.isEmpty else {
+                    throw CLIParseError("--allowed-origins requires at least one non-empty origin")
+                }
+                for origin in origins where !result.serverAllowedOrigins.contains(origin) {
+                    result.serverAllowedOrigins.append(origin)
+                }
+
+            case "--no-origin-check":
+                result.serverOriginCheckEnabled = false
+
+            case "--token":
+                i += 1
+                guard i < args.count else { throw CLIParseError("--token requires a secret value") }
+                result.serverToken = args[i]
+
+            case "--token-auto":
+                result.serverTokenAuto = true
+
+            case "--public-health":
+                result.serverPublicHealth = true
+
+            case "--footgun":
+                result.serverOriginCheckEnabled = false
+                result.serverCORS = true
+
+            case "--mcp":
+                i += 1
+                guard i < args.count else {
+                    throw CLIParseError("--mcp requires a path to an MCP server script")
+                }
+                result.mcpServerPaths.append(args[i])
+
+            case "--mcp-timeout":
+                i += 1
+                guard i < args.count, let t = Int(args[i]), t > 0 else {
+                    throw CLIParseError("--mcp-timeout requires a positive number (seconds)")
+                }
+                result.mcpTimeoutSeconds = min(t, 300)
+
+            case "--temperature":
+                i += 1
+                guard i < args.count, let t = Double(args[i]), t >= 0 else {
+                    throw CLIParseError("--temperature requires a non-negative number (e.g., 0.7)")
+                }
+                result.temperature = t
+
+            case "--seed":
+                i += 1
+                guard i < args.count, let s = UInt64(args[i]) else {
+                    throw CLIParseError("--seed requires a positive integer")
+                }
+                result.seed = s
+
+            case "--max-tokens":
+                i += 1
+                guard i < args.count, let n = Int(args[i]), n > 0 else {
+                    throw CLIParseError("--max-tokens requires a positive number")
+                }
+                result.maxTokens = n
+
+            case "--permissive":
+                result.permissive = true
+
+            case "--retry":
+                result.retryEnabled = true
+                if i + 1 < args.count, let n = Int(args[i + 1]), n > 0 {
+                    result.retryCount = n
+                    i += 1
+                }
+
+            case "--context-strategy":
+                i += 1
+                guard i < args.count, let s = ContextStrategy(rawValue: args[i]) else {
+                    throw CLIParseError("--context-strategy requires: newest-first|oldest-first|sliding-window|summarize|strict")
+                }
+                result.contextStrategy = s
+
+            case "--context-max-turns":
+                i += 1
+                guard i < args.count, let n = Int(args[i]), n > 0 else {
+                    throw CLIParseError("--context-max-turns requires a positive number")
+                }
+                result.contextMaxTurns = n
+
+            case "--context-output-reserve":
+                i += 1
+                guard i < args.count, let n = Int(args[i]), n > 0 else {
+                    throw CLIParseError("--context-output-reserve requires a positive number")
+                }
+                result.contextOutputReserve = n
+
+            case "--system-file":
+                i += 1
+                guard i < args.count else { throw CLIParseError("--system-file requires a file path") }
+                let path = args[i]
+                do {
+                    result.systemPrompt = try String(contentsOfFile: path, encoding: .utf8)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } catch {
+                    throw CLIParseError(fileErrorMessage(path: path))
+                }
+
+            case "-f", "--file":
+                i += 1
+                guard i < args.count else { throw CLIParseError("--file requires a file path") }
+                let path = args[i]
+                do {
+                    let content = try String(contentsOfFile: path, encoding: .utf8)
+                    result.fileContents.append(content)
+                } catch {
+                    throw CLIParseError(fileErrorMessage(path: path))
+                }
+
+            default:
+                if args[i].hasPrefix("-") {
+                    throw CLIParseError("unknown option: \(args[i])")
+                }
+                result.prompt = args[i...].joined(separator: " ")
+                i = args.count
+                continue
+            }
+            i += 1
+        }
+
+        return result
+    }
+
+    // MARK: - Helpers
+
+    private static func parseAllowedOrigins(_ value: String) -> [String] {
+        value.split(separator: ",")
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    static func fileErrorMessage(path: String) -> String {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: path) {
+            return "no such file: \(path)"
+        }
+        if !fm.isReadableFile(atPath: path) {
+            return "permission denied: \(path)"
+        }
+        let ext = (path.lowercased() as NSString).pathExtension
+        switch ext {
+        case "jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "tiff", "bmp", "svg", "ico":
+            return "cannot attach image: \(path) -- the on-device model is text-only (no vision). Try: tesseract \(path) stdout | apfel \"describe this\""
+        case "pdf", "zip", "tar", "gz", "dmg", "pkg", "exe", "bin", "dat", "mp3", "mp4", "mov", "avi", "wav":
+            return "cannot attach binary file: \(path) -- only text files are supported"
+        default:
+            return "file is not valid UTF-8 text: \(path) (binary file?)"
+        }
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import ApfelCore
+import ApfelCLI
 import CReadline
 
 // MARK: - Configuration

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -46,10 +46,10 @@ apfel_install_sigint_exit_handler(isatty(STDOUT_FILENO) != 0 ? 1 : 0)
 
 // MARK: - Argument Parsing
 
-var args = Array(CommandLine.arguments.dropFirst())
+let rawArgs = Array(CommandLine.arguments.dropFirst())
 
 // Stdin pipe with no args
-if args.isEmpty {
+if rawArgs.isEmpty {
     if isatty(STDIN_FILENO) == 0 {
         var lines: [String] = []
         while let line = readLine(strippingNewline: false) {
@@ -71,286 +71,43 @@ if args.isEmpty {
     exit(exitUsageError)
 }
 
-// Parse flags — env vars provide defaults, CLI flags override
-let env = ProcessInfo.processInfo.environment
-var systemPrompt: String? = env["APFEL_SYSTEM_PROMPT"]
-var mode: String = "single"
-var prompt: String = ""
-var serverPort: Int = Int(env["APFEL_PORT"] ?? "") ?? 11434
-var serverHost: String = env["APFEL_HOST"] ?? "127.0.0.1"
-var serverCORS: Bool = false
-var serverMaxConcurrent: Int = 5
-var serverDebug: Bool = false
-var serverAllowedOrigins: [String] = OriginValidator.defaultAllowedOrigins
-var serverOriginCheckEnabled: Bool = true
-var serverToken: String? = env["APFEL_TOKEN"]
-var serverTokenAuto: Bool = false
-var serverPublicHealth: Bool = false
-var mcpServerPaths: [String] = env["APFEL_MCP"]?
-    .split(separator: ":").map(String.init).filter { !$0.isEmpty } ?? []
-var mcpTimeoutSeconds: Int = Int(env["APFEL_MCP_TIMEOUT"] ?? "").flatMap { $0 > 0 ? min($0, 300) : nil } ?? 5
-var cliTemperature: Double? = Double(env["APFEL_TEMPERATURE"] ?? "")
-var cliSeed: UInt64? = nil
-var cliMaxTokens: Int? = Int(env["APFEL_MAX_TOKENS"] ?? "").flatMap { $0 > 0 ? $0 : nil }
-var cliPermissive: Bool = false
-var cliRetryEnabled: Bool = false
-var cliRetryCount: Int = 3
-var cliContextStrategy: ContextStrategy? = env["APFEL_CONTEXT_STRATEGY"].flatMap { ContextStrategy(rawValue: $0) }
-var cliContextMaxTurns: Int? = env["APFEL_CONTEXT_MAX_TURNS"].flatMap { Int($0) }
-var cliContextOutputReserve: Int? = env["APFEL_CONTEXT_OUTPUT_RESERVE"].flatMap { Int($0) }.flatMap { $0 > 0 ? $0 : nil }
-var fileContents: [String] = []
-
-func parseAllowedOrigins(_ value: String) -> [String] {
-    value.split(separator: ",")
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
+let parsed: CLIArguments
+do {
+    parsed = try CLIArguments.parse(rawArgs, env: ProcessInfo.processInfo.environment)
+} catch let error as CLIParseError {
+    printError(error.message)
+    exit(exitUsageError)
 }
 
-var i = 0
-while i < args.count {
-    switch args[i] {
-    case "-h", "--help":
-        printUsage()
-        exit(exitSuccess)
-
-    case "-v", "--version":
-        print("\(appName) v\(version)")
-        exit(exitSuccess)
-
-    case "--release":
-        printRelease()
-        exit(exitSuccess)
-
-    case "-s", "--system":
-        i += 1
-        guard i < args.count else {
-            printError("--system requires a value")
-            exit(exitUsageError)
-        }
-        systemPrompt = args[i]
-
-    case "-o", "--output":
-        i += 1
-        guard i < args.count else {
-            printError("--output requires a value (plain or json)")
-            exit(exitUsageError)
-        }
-        guard let fmt = OutputFormat(rawValue: args[i]) else {
-            printError("unknown output format: \(args[i]) (use plain or json)")
-            exit(exitUsageError)
-        }
-        outputFormat = fmt
-
-    case "-q", "--quiet":
-        quietMode = true
-
-    case "--no-color":
-        noColorFlag = true
-
-    case "--chat":
-        mode = "chat"
-
-    case "--stream":
-        mode = "stream"
-
-    case "--serve":
-        mode = "serve"
-
-    case "--benchmark":
-        mode = "benchmark"
-
-    case "--port":
-        i += 1
-        guard i < args.count, let p = Int(args[i]), p > 0, p < 65536 else {
-            printError("--port requires a valid port number (1-65535)")
-            exit(exitUsageError)
-        }
-        serverPort = p
-
-    case "--host":
-        i += 1
-        guard i < args.count else {
-            printError("--host requires an address")
-            exit(exitUsageError)
-        }
-        serverHost = args[i]
-
-    case "--cors":
-        serverCORS = true
-
-    case "--max-concurrent":
-        i += 1
-        guard i < args.count, let n = Int(args[i]), n > 0 else {
-            printError("--max-concurrent requires a positive number")
-            exit(exitUsageError)
-        }
-        serverMaxConcurrent = n
-
-    case "--debug":
-        serverDebug = true
-        apfelDebugEnabled = true
-
-    case "--allowed-origins":
-        i += 1
-        guard i < args.count else {
-            printError("--allowed-origins requires a comma-separated list of origins")
-            exit(exitUsageError)
-        }
-        let customOrigins = parseAllowedOrigins(args[i])
-        guard !customOrigins.isEmpty else {
-            printError("--allowed-origins requires at least one non-empty origin")
-            exit(exitUsageError)
-        }
-        for origin in customOrigins where !serverAllowedOrigins.contains(origin) {
-            serverAllowedOrigins.append(origin)
-        }
-
-    case "--no-origin-check":
-        serverOriginCheckEnabled = false
-
-    case "--token":
-        i += 1
-        guard i < args.count else {
-            printError("--token requires a secret value")
-            exit(exitUsageError)
-        }
-        serverToken = args[i]
-
-    case "--token-auto":
-        serverTokenAuto = true
-
-    case "--public-health":
-        serverPublicHealth = true
-
-    case "--footgun":
-        serverOriginCheckEnabled = false
-        serverCORS = true
-
-    case "--mcp":
-        i += 1
-        guard i < args.count else {
-            printError("--mcp requires a path to an MCP server script")
-            exit(exitUsageError)
-        }
-        mcpServerPaths.append(args[i])
-
-    case "--mcp-timeout":
-        i += 1
-        guard i < args.count, let t = Int(args[i]), t > 0 else {
-            printError("--mcp-timeout requires a positive number (seconds)")
-            exit(exitUsageError)
-        }
-        mcpTimeoutSeconds = min(t, 300)
-
-    case "--temperature":
-        i += 1
-        guard i < args.count, let t = Double(args[i]), t >= 0 else {
-            printError("--temperature requires a non-negative number (e.g., 0.7)")
-            exit(exitUsageError)
-        }
-        cliTemperature = t
-
-    case "--seed":
-        i += 1
-        guard i < args.count, let s = UInt64(args[i]) else {
-            printError("--seed requires a positive integer")
-            exit(exitUsageError)
-        }
-        cliSeed = s
-
-    case "--max-tokens":
-        i += 1
-        guard i < args.count, let n = Int(args[i]), n > 0 else {
-            printError("--max-tokens requires a positive number")
-            exit(exitUsageError)
-        }
-        cliMaxTokens = n
-
-    case "--permissive":
-        cliPermissive = true
-
-    case "--retry":
-        cliRetryEnabled = true
-        // Optional argument: --retry or --retry N
-        if i + 1 < args.count, let n = Int(args[i + 1]), n > 0 {
-            cliRetryCount = n
-            i += 1
-        }
-
-    case "--context-strategy":
-        i += 1
-        guard i < args.count, let s = ContextStrategy(rawValue: args[i]) else {
-            printError("--context-strategy requires: newest-first|oldest-first|sliding-window|summarize|strict")
-            exit(exitUsageError)
-        }
-        cliContextStrategy = s
-
-    case "--context-max-turns":
-        i += 1
-        guard i < args.count, let n = Int(args[i]), n > 0 else {
-            printError("--context-max-turns requires a positive number")
-            exit(exitUsageError)
-        }
-        cliContextMaxTurns = n
-
-    case "--context-output-reserve":
-        i += 1
-        guard i < args.count, let n = Int(args[i]), n > 0 else {
-            printError("--context-output-reserve requires a positive number")
-            exit(exitUsageError)
-        }
-        cliContextOutputReserve = n
-
-    case "--system-file":
-        i += 1
-        guard i < args.count else {
-            printError("--system-file requires a file path")
-            exit(exitUsageError)
-        }
-        let path = args[i]
-        do {
-            systemPrompt = try String(contentsOfFile: path, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-        } catch {
-            printError(fileErrorMessage(path: path))
-            exit(exitUsageError)
-        }
-
-    case "--model-info":
-        mode = "model-info"
-
-    case "--update":
-        mode = "update"
-
-    case "-f", "--file":
-        i += 1
-        guard i < args.count else {
-            printError("--file requires a file path")
-            exit(exitUsageError)
-        }
-        let path = args[i]
-        do {
-            let content = try String(contentsOfFile: path, encoding: .utf8)
-            fileContents.append(content)
-        } catch {
-            printError(fileErrorMessage(path: path))
-            exit(exitUsageError)
-        }
-
-    default:
-        if args[i].hasPrefix("-") {
-            printError("unknown option: \(args[i])")
-            exit(exitUsageError)
-        }
-        prompt = args[i...].joined(separator: " ")
-        i = args.count
-        continue
-    }
-    i += 1
+// Handle immediate-exit modes
+switch parsed.mode {
+case .help:
+    printUsage()
+    exit(exitSuccess)
+case .version:
+    print("\(appName) v\(version)")
+    exit(exitSuccess)
+case .release:
+    printRelease()
+    exit(exitSuccess)
+default:
+    break
 }
+
+// Apply global state from parsed arguments
+if let fmt = parsed.outputFormat.flatMap({ OutputFormat(rawValue: $0) }) {
+    outputFormat = fmt
+}
+if parsed.quiet { quietMode = true }
+if parsed.noColor { noColorFlag = true }
+if parsed.debug { apfelDebugEnabled = true }
+
+// Build the prompt from files + stdin + positional args
+var prompt = parsed.prompt
+var fileContents = parsed.fileContents
 
 // Read stdin when piped -- as the prompt (no args) or prepended to the prompt
-if mode == "single" && isatty(STDIN_FILENO) == 0 {
+if parsed.mode == .single && isatty(STDIN_FILENO) == 0 {
     var lines: [String] = []
     while let line = readLine(strippingNewline: false) {
         lines.append(line)
@@ -378,24 +135,36 @@ if !fileContents.isEmpty {
 // MARK: - Dispatch
 
 let contextConfig = ContextConfig(
-    strategy: cliContextStrategy ?? .newestFirst,
-    maxTurns: cliContextMaxTurns,
-    outputReserve: cliContextOutputReserve ?? 512,
-    permissive: cliPermissive
+    strategy: parsed.contextStrategy ?? .newestFirst,
+    maxTurns: parsed.contextMaxTurns,
+    outputReserve: parsed.contextOutputReserve ?? 512,
+    permissive: parsed.permissive
 )
 
 let sessionOpts = SessionOptions(
-    temperature: cliTemperature,
-    maxTokens: cliMaxTokens,
-    seed: cliSeed,
-    permissive: cliPermissive,
+    temperature: parsed.temperature,
+    maxTokens: parsed.maxTokens,
+    seed: parsed.seed,
+    permissive: parsed.permissive,
     contextConfig: contextConfig,
-    retryEnabled: cliRetryEnabled,
-    retryCount: cliRetryCount
+    retryEnabled: parsed.retryEnabled,
+    retryCount: parsed.retryCount
 )
 
+// Resolve server allowed origins (merge defaults + custom)
+let serverAllowedOrigins: [String] = {
+    var origins = OriginValidator.defaultAllowedOrigins
+    for origin in parsed.serverAllowedOrigins where !origins.contains(origin) {
+        origins.append(origin)
+    }
+    return origins
+}()
+
 // Check model availability for modes that need it
-if mode != "model-info" && mode != "serve" && mode != "update" {
+switch parsed.mode {
+case .modelInfo, .serve, .update:
+    break
+default:
     let available = await TokenCounter.shared.isAvailable
     if !available {
         printError("Apple Intelligence is not enabled or model is not ready. Run: apfel --model-info")
@@ -405,9 +174,9 @@ if mode != "model-info" && mode != "serve" && mode != "update" {
 
 // Initialize MCP servers if any
 var mcpManager: MCPManager?
-if !mcpServerPaths.isEmpty {
+if !parsed.mcpServerPaths.isEmpty {
     do {
-        mcpManager = try await MCPManager(paths: mcpServerPaths, timeoutSeconds: mcpTimeoutSeconds)
+        mcpManager = try await MCPManager(paths: parsed.mcpServerPaths, timeoutSeconds: parsed.mcpTimeoutSeconds)
     } catch {
         printError("MCP server failed to start: \(error)")
         exit(exitRuntimeError)
@@ -416,75 +185,60 @@ if !mcpServerPaths.isEmpty {
 defer { Task { await mcpManager?.shutdown() } }
 
 do {
-    switch mode {
-    case "serve":
-        let tokenWasAutoGenerated = serverTokenAuto && serverToken == nil
-        if serverTokenAuto && serverToken == nil {
+    switch parsed.mode {
+    case .serve:
+        var serverToken = parsed.serverToken
+        let tokenWasAutoGenerated = parsed.serverTokenAuto && serverToken == nil
+        if parsed.serverTokenAuto && serverToken == nil {
             serverToken = UUID().uuidString
         }
         let config = ServerConfig(
-            host: serverHost,
-            port: serverPort,
-            cors: serverCORS,
-            maxConcurrent: serverMaxConcurrent,
-            debug: serverDebug,
-            allowedOrigins: serverOriginCheckEnabled ? serverAllowedOrigins : ["*"],
-            originCheckEnabled: serverOriginCheckEnabled,
+            host: parsed.serverHost,
+            port: parsed.serverPort,
+            cors: parsed.serverCORS,
+            maxConcurrent: parsed.serverMaxConcurrent,
+            debug: parsed.debug,
+            allowedOrigins: parsed.serverOriginCheckEnabled ? serverAllowedOrigins : ["*"],
+            originCheckEnabled: parsed.serverOriginCheckEnabled,
             token: serverToken,
             tokenWasAutoGenerated: tokenWasAutoGenerated,
-            publicHealth: serverPublicHealth,
-            retryEnabled: cliRetryEnabled,
-            retryCount: cliRetryCount
+            publicHealth: parsed.serverPublicHealth,
+            retryEnabled: parsed.retryEnabled,
+            retryCount: parsed.retryCount
         )
         try await startServer(config: config, mcpManager: mcpManager)
 
-    case "update":
+    case .update:
         performUpdate()
 
-    case "model-info":
+    case .modelInfo:
         await printModelInfo()
 
-    case "benchmark":
+    case .benchmark:
         try await runBenchmarks()
 
-    case "chat":
-        try await chat(systemPrompt: systemPrompt, options: sessionOpts, mcpManager: mcpManager)
+    case .chat:
+        try await chat(systemPrompt: parsed.systemPrompt, options: sessionOpts, mcpManager: mcpManager)
 
-    case "stream":
+    case .stream:
         guard !prompt.isEmpty else {
             printError("no prompt provided")
             exit(exitUsageError)
         }
-        try await singlePrompt(prompt, systemPrompt: systemPrompt, stream: true, options: sessionOpts, mcpManager: mcpManager)
+        try await singlePrompt(prompt, systemPrompt: parsed.systemPrompt, stream: true, options: sessionOpts, mcpManager: mcpManager)
 
-    default:
+    case .single:
         guard !prompt.isEmpty else {
             printError("no prompt provided")
             exit(exitUsageError)
         }
-        try await singlePrompt(prompt, systemPrompt: systemPrompt, stream: false, options: sessionOpts, mcpManager: mcpManager)
+        try await singlePrompt(prompt, systemPrompt: parsed.systemPrompt, stream: false, options: sessionOpts, mcpManager: mcpManager)
+
+    case .help, .version, .release:
+        break // Already handled above
     }
 } catch {
     let classified = ApfelError.classify(error)
     printError("\(classified.cliLabel) \(classified.openAIMessage)")
     exit(exitCode(for: classified))
-}
-
-func fileErrorMessage(path: String) -> String {
-    let fm = FileManager.default
-    if !fm.fileExists(atPath: path) {
-        return "no such file: \(path)"
-    }
-    if !fm.isReadableFile(atPath: path) {
-        return "permission denied: \(path)"
-    }
-    let ext = (path.lowercased() as NSString).pathExtension
-    switch ext {
-    case "jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "tiff", "bmp", "svg", "ico":
-        return "cannot attach image: \(path) -- the on-device model is text-only (no vision). Try: tesseract \(path) stdout | apfel \"describe this\""
-    case "pdf", "zip", "tar", "gz", "dmg", "pkg", "exe", "bin", "dat", "mp3", "mp4", "mov", "avi", "wav":
-        return "cannot attach binary file: \(path) -- only text files are supported"
-    default:
-        return "file is not valid UTF-8 text: \(path) (binary file?)"
-    }
 }

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -1,13 +1,16 @@
 // ============================================================================
 // CLIArgumentsTests.swift — Unit tests for CLIArguments.parse()
+// Focused on edge cases, validation errors, and non-obvious behavior.
+// Happy-path flag→field mapping is covered by the combined integration tests.
 // ============================================================================
 
 import Foundation
 import ApfelCore
+import ApfelCLI
 
 func runCLIArgumentsTests() {
 
-    // -- Mode flags --
+    // -- Baseline & parsing --
 
     test("no args produces single mode with empty prompt") {
         let args = try CLIArguments.parse([])
@@ -15,378 +18,199 @@ func runCLIArgumentsTests() {
         try assertEqual(args.prompt, "")
     }
 
-    test("--help sets help mode") {
-        let args = try CLIArguments.parse(["--help"])
-        try assertEqual(args.mode, .help)
-    }
-
-    test("-h sets help mode") {
-        let args = try CLIArguments.parse(["-h"])
-        try assertEqual(args.mode, .help)
-    }
-
-    test("--version sets version mode") {
-        let args = try CLIArguments.parse(["--version"])
-        try assertEqual(args.mode, .version)
-    }
-
-    test("-v sets version mode") {
-        let args = try CLIArguments.parse(["-v"])
-        try assertEqual(args.mode, .version)
-    }
-
-    test("--release sets release mode") {
-        let args = try CLIArguments.parse(["--release"])
-        try assertEqual(args.mode, .release)
-    }
-
-    test("--chat sets chat mode") {
-        let args = try CLIArguments.parse(["--chat"])
-        try assertEqual(args.mode, .chat)
-    }
-
-    test("--stream sets stream mode") {
-        let args = try CLIArguments.parse(["--stream"])
-        try assertEqual(args.mode, .stream)
-    }
-
-    test("--serve sets serve mode") {
-        let args = try CLIArguments.parse(["--serve"])
-        try assertEqual(args.mode, .serve)
-    }
-
-    test("--benchmark sets benchmark mode") {
-        let args = try CLIArguments.parse(["--benchmark"])
-        try assertEqual(args.mode, .benchmark)
-    }
-
-    test("--model-info sets modelInfo mode") {
-        let args = try CLIArguments.parse(["--model-info"])
-        try assertEqual(args.mode, .modelInfo)
-    }
-
-    test("--update sets update mode") {
-        let args = try CLIArguments.parse(["--update"])
-        try assertEqual(args.mode, .update)
-    }
-
-    // -- Prompt parsing --
-
     test("bare words become the prompt") {
         let args = try CLIArguments.parse(["hello", "world"])
         try assertEqual(args.prompt, "hello world")
     }
 
-    test("prompt after flags") {
+    test("prompt after flags preserves flag effects") {
         let args = try CLIArguments.parse(["--quiet", "tell", "me", "a", "joke"])
         try assertEqual(args.prompt, "tell me a joke")
         try assertTrue(args.quiet)
     }
 
-    // -- System prompt --
+    // -- Validation errors (tightened: verify CLIParseError type + message content) --
 
-    test("--system sets systemPrompt") {
-        let args = try CLIArguments.parse(["--system", "You are helpful", "hi"])
-        try assertEqual(args.systemPrompt, "You are helpful")
-    }
-
-    test("-s sets systemPrompt") {
-        let args = try CLIArguments.parse(["-s", "Be brief", "hi"])
-        try assertEqual(args.systemPrompt, "Be brief")
-    }
-
-    test("--system without value throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--system"]) }
-        catch { threw = true }
-        try assertTrue(threw)
-    }
-
-    // -- Output --
-
-    test("--output plain") {
-        let args = try CLIArguments.parse(["-o", "plain", "hi"])
-        try assertEqual(args.outputFormat, "plain")
-    }
-
-    test("--output json") {
-        let args = try CLIArguments.parse(["--output", "json", "hi"])
-        try assertEqual(args.outputFormat, "json")
-    }
-
-    test("--output invalid throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--output", "xml"]) }
-        catch let e as CLIParseError {
-            threw = true
-            try assertTrue(e.message.contains("unknown output format"))
+    test("--system without value throws CLIParseError") {
+        do {
+            _ = try CLIArguments.parse(["--system"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--system requires"))
         }
-        try assertTrue(threw)
     }
 
-    test("--quiet sets quiet") {
-        let args = try CLIArguments.parse(["-q", "hi"])
-        try assertTrue(args.quiet)
+    test("--output invalid format throws with format name") {
+        do {
+            _ = try CLIArguments.parse(["--output", "xml"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("unknown output format"))
+            try assertTrue(e.message.contains("xml"))
+        }
     }
 
-    test("--no-color sets noColor") {
-        let args = try CLIArguments.parse(["--no-color", "hi"])
-        try assertTrue(args.noColor)
-    }
-
-    // -- Server flags --
-
-    test("--port parses valid port") {
-        let args = try CLIArguments.parse(["--serve", "--port", "8080"])
-        try assertEqual(args.serverPort, 8080)
-    }
-
-    test("--port invalid throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--port", "99999"]) }
-        catch { threw = true }
-        try assertTrue(threw)
+    test("--port out of range throws") {
+        do {
+            _ = try CLIArguments.parse(["--port", "99999"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--port"))
+        }
     }
 
     test("--port zero throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--port", "0"]) }
-        catch { threw = true }
-        try assertTrue(threw)
+        do {
+            _ = try CLIArguments.parse(["--port", "0"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--port"))
+        }
     }
 
-    test("--host sets serverHost") {
-        let args = try CLIArguments.parse(["--serve", "--host", "0.0.0.0"])
-        try assertEqual(args.serverHost, "0.0.0.0")
+    test("--max-concurrent zero throws") {
+        do {
+            _ = try CLIArguments.parse(["--max-concurrent", "0"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--max-concurrent"))
+        }
     }
 
-    test("--cors sets serverCORS") {
-        let args = try CLIArguments.parse(["--serve", "--cors"])
-        try assertTrue(args.serverCORS)
+    test("--allowed-origins empty string throws") {
+        do {
+            _ = try CLIArguments.parse(["--allowed-origins", ""])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--allowed-origins"))
+        }
     }
 
-    test("--max-concurrent parses") {
-        let args = try CLIArguments.parse(["--serve", "--max-concurrent", "10"])
-        try assertEqual(args.serverMaxConcurrent, 10)
+    test("--temperature negative throws") {
+        do {
+            _ = try CLIArguments.parse(["--temperature", "-1"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--temperature"))
+        }
     }
 
-    test("--max-concurrent invalid throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--max-concurrent", "0"]) }
-        catch { threw = true }
-        try assertTrue(threw)
+    test("--max-tokens zero throws") {
+        do {
+            _ = try CLIArguments.parse(["--max-tokens", "0"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--max-tokens"))
+        }
     }
 
-    test("--debug sets debug") {
-        let args = try CLIArguments.parse(["--debug", "hi"])
-        try assertTrue(args.debug)
+    test("--context-strategy invalid value throws") {
+        do {
+            _ = try CLIArguments.parse(["--context-strategy", "invalid"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--context-strategy"))
+        }
     }
 
-    test("--token sets serverToken") {
-        let args = try CLIArguments.parse(["--serve", "--token", "secret123"])
-        try assertEqual(args.serverToken, "secret123")
+    test("unknown flag throws with flag name in message") {
+        do {
+            _ = try CLIArguments.parse(["--nonexistent"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("unknown option"))
+            try assertTrue(e.message.contains("--nonexistent"))
+        }
     }
 
-    test("--token-auto sets serverTokenAuto") {
-        let args = try CLIArguments.parse(["--serve", "--token-auto"])
-        try assertTrue(args.serverTokenAuto)
-    }
+    // -- Non-obvious behavior --
 
-    test("--public-health sets serverPublicHealth") {
-        let args = try CLIArguments.parse(["--serve", "--public-health"])
-        try assertTrue(args.serverPublicHealth)
-    }
-
-    test("--no-origin-check disables origin check") {
-        let args = try CLIArguments.parse(["--serve", "--no-origin-check"])
-        try assertTrue(!args.serverOriginCheckEnabled)
-    }
-
-    test("--footgun disables origin check and enables CORS") {
+    test("--footgun sets CORS and disables origin check together") {
         let args = try CLIArguments.parse(["--serve", "--footgun"])
         try assertTrue(!args.serverOriginCheckEnabled)
         try assertTrue(args.serverCORS)
     }
 
-    test("--allowed-origins parses comma-separated list") {
+    test("--allowed-origins parses comma-separated and deduplicates") {
         let args = try CLIArguments.parse(["--serve", "--allowed-origins", "http://a.com,http://b.com"])
         try assertEqual(args.serverAllowedOrigins.count, 2)
         try assertTrue(args.serverAllowedOrigins.contains("http://a.com"))
         try assertTrue(args.serverAllowedOrigins.contains("http://b.com"))
     }
 
-    test("--allowed-origins empty throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--allowed-origins", ""]) }
-        catch { threw = true }
-        try assertTrue(threw)
-    }
-
-    // -- MCP --
-
-    test("--mcp adds server path") {
-        let args = try CLIArguments.parse(["--mcp", "/path/to/server.py", "hi"])
-        try assertEqual(args.mcpServerPaths.count, 1)
-        try assertEqual(args.mcpServerPaths[0], "/path/to/server.py")
-    }
-
-    test("multiple --mcp accumulate") {
+    test("multiple --mcp flags accumulate") {
         let args = try CLIArguments.parse(["--mcp", "a.py", "--mcp", "b.py", "hi"])
-        try assertEqual(args.mcpServerPaths.count, 2)
+        try assertEqual(args.mcpServerPaths, ["a.py", "b.py"])
     }
 
-    test("--mcp-timeout parses") {
-        let args = try CLIArguments.parse(["--mcp-timeout", "10", "hi"])
-        try assertEqual(args.mcpTimeoutSeconds, 10)
-    }
-
-    test("--mcp-timeout caps at 300") {
+    test("--mcp-timeout clamps at 300") {
         let args = try CLIArguments.parse(["--mcp-timeout", "999", "hi"])
         try assertEqual(args.mcpTimeoutSeconds, 300)
     }
 
-    // -- Generation --
-
-    test("--temperature parses") {
-        let args = try CLIArguments.parse(["--temperature", "0.7", "hi"])
-        try assertEqual(args.temperature, 0.7)
-    }
-
-    test("--temperature negative throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--temperature", "-1"]) }
-        catch { threw = true }
-        try assertTrue(threw)
-    }
-
-    test("--seed parses") {
-        let args = try CLIArguments.parse(["--seed", "42", "hi"])
-        try assertEqual(args.seed, 42)
-    }
-
-    test("--max-tokens parses") {
-        let args = try CLIArguments.parse(["--max-tokens", "100", "hi"])
-        try assertEqual(args.maxTokens, 100)
-    }
-
-    test("--max-tokens zero throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--max-tokens", "0"]) }
-        catch { threw = true }
-        try assertTrue(threw)
-    }
-
-    test("--permissive sets permissive") {
-        let args = try CLIArguments.parse(["--permissive", "hi"])
-        try assertTrue(args.permissive)
-    }
-
-    // -- Retry --
-
-    test("--retry enables retry") {
-        let args = try CLIArguments.parse(["--retry", "hi"])
-        try assertTrue(args.retryEnabled)
-        try assertEqual(args.retryCount, 3) // default
-    }
-
-    test("--retry with count") {
+    test("--retry with explicit count parses optional argument") {
         let args = try CLIArguments.parse(["--retry", "5", "hi"])
         try assertTrue(args.retryEnabled)
         try assertEqual(args.retryCount, 5)
     }
 
-    test("--retry without count keeps default") {
+    test("--retry followed by flag keeps default count") {
         let args = try CLIArguments.parse(["--retry", "--quiet", "hi"])
         try assertTrue(args.retryEnabled)
         try assertEqual(args.retryCount, 3)
+        try assertTrue(args.quiet)
     }
 
-    // -- Context --
-
-    test("--context-strategy parses valid strategy") {
-        let args = try CLIArguments.parse(["--context-strategy", "sliding-window", "--chat"])
-        try assertEqual(args.contextStrategy, .slidingWindow)
-    }
-
-    test("--context-strategy invalid throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--context-strategy", "invalid"]) }
-        catch { threw = true }
-        try assertTrue(threw)
-    }
-
-    test("--context-max-turns parses") {
-        let args = try CLIArguments.parse(["--context-max-turns", "10", "--chat"])
-        try assertEqual(args.contextMaxTurns, 10)
-    }
-
-    test("--context-output-reserve parses") {
-        let args = try CLIArguments.parse(["--context-output-reserve", "256", "--chat"])
-        try assertEqual(args.contextOutputReserve, 256)
-    }
-
-    // -- Unknown flags --
-
-    test("unknown flag throws") {
-        var threw = false
-        do { _ = try CLIArguments.parse(["--nonexistent"]) }
-        catch let e as CLIParseError {
-            threw = true
-            try assertTrue(e.message.contains("unknown option"))
-        }
-        try assertTrue(threw)
-    }
-
-    // -- Environment variable defaults --
-
-    test("APFEL_PORT env sets default port") {
-        let args = try CLIArguments.parse(["--serve"], env: ["APFEL_PORT": "9090"])
-        try assertEqual(args.serverPort, 9090)
-    }
+    // -- Environment variable precedence --
 
     test("CLI flag overrides env var") {
         let args = try CLIArguments.parse(["--serve", "--port", "8080"], env: ["APFEL_PORT": "9090"])
         try assertEqual(args.serverPort, 8080)
     }
 
-    test("APFEL_SYSTEM_PROMPT env sets systemPrompt") {
-        let args = try CLIArguments.parse(["hi"], env: ["APFEL_SYSTEM_PROMPT": "Be brief"])
-        try assertEqual(args.systemPrompt, "Be brief")
-    }
-
-    test("APFEL_TEMPERATURE env sets temperature") {
-        let args = try CLIArguments.parse(["hi"], env: ["APFEL_TEMPERATURE": "0.5"])
-        try assertEqual(args.temperature, 0.5)
-    }
-
-    test("APFEL_MAX_TOKENS env sets maxTokens") {
-        let args = try CLIArguments.parse(["hi"], env: ["APFEL_MAX_TOKENS": "200"])
-        try assertEqual(args.maxTokens, 200)
-    }
-
-    test("APFEL_CONTEXT_STRATEGY env sets contextStrategy") {
-        let args = try CLIArguments.parse(["--chat"], env: ["APFEL_CONTEXT_STRATEGY": "strict"])
-        try assertEqual(args.contextStrategy, .strict)
-    }
-
-    test("APFEL_MCP env sets MCP paths") {
+    test("APFEL_MCP env splits on colon separator") {
         let args = try CLIArguments.parse(["hi"], env: ["APFEL_MCP": "a.py:b.py"])
         try assertEqual(args.mcpServerPaths, ["a.py", "b.py"])
     }
 
-    test("APFEL_HOST env sets serverHost") {
-        let args = try CLIArguments.parse(["--serve"], env: ["APFEL_HOST": "0.0.0.0"])
-        try assertEqual(args.serverHost, "0.0.0.0")
+    // -- File reader injection --
+
+    test("--file uses injected readFile") {
+        let args = try CLIArguments.parse(
+            ["--file", "test.txt", "summarize"],
+            readFile: { path in
+                try assertEqual(path, "test.txt")
+                return "file content here"
+            }
+        )
+        try assertEqual(args.fileContents, ["file content here"])
+        try assertEqual(args.prompt, "summarize")
     }
 
-    test("APFEL_TOKEN env sets serverToken") {
-        let args = try CLIArguments.parse(["--serve"], env: ["APFEL_TOKEN": "mytoken"])
-        try assertEqual(args.serverToken, "mytoken")
+    test("--system-file uses injected readFile and trims whitespace") {
+        let args = try CLIArguments.parse(
+            ["--system-file", "system.txt", "hi"],
+            readFile: { _ in "\n  Be concise  \n" }
+        )
+        try assertEqual(args.systemPrompt, "Be concise")
     }
 
-    // -- Combined flags --
+    test("file read failure throws CLIParseError") {
+        struct FakeError: Error {}
+        do {
+            _ = try CLIArguments.parse(
+                ["--file", "missing.txt", "hi"],
+                readFile: { _ in throw FakeError() }
+            )
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("missing.txt"))
+        }
+    }
 
-    test("full server config parses") {
+    // -- Combined integration tests (cover happy-path flag mapping) --
+
+    test("full server config parses all flags") {
         let args = try CLIArguments.parse([
             "--serve", "--port", "8080", "--host", "0.0.0.0",
             "--cors", "--max-concurrent", "10", "--token", "secret",
@@ -406,7 +230,7 @@ func runCLIArgumentsTests() {
         try assertEqual(args.mcpServerPaths, ["calc.py"])
     }
 
-    test("full CLI config parses") {
+    test("full CLI config parses all flags") {
         let args = try CLIArguments.parse([
             "--system", "Be brief", "--temperature", "0.8",
             "--seed", "42", "--max-tokens", "100",

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -1,0 +1,429 @@
+// ============================================================================
+// CLIArgumentsTests.swift — Unit tests for CLIArguments.parse()
+// ============================================================================
+
+import Foundation
+import ApfelCore
+
+func runCLIArgumentsTests() {
+
+    // -- Mode flags --
+
+    test("no args produces single mode with empty prompt") {
+        let args = try CLIArguments.parse([])
+        try assertEqual(args.mode, .single)
+        try assertEqual(args.prompt, "")
+    }
+
+    test("--help sets help mode") {
+        let args = try CLIArguments.parse(["--help"])
+        try assertEqual(args.mode, .help)
+    }
+
+    test("-h sets help mode") {
+        let args = try CLIArguments.parse(["-h"])
+        try assertEqual(args.mode, .help)
+    }
+
+    test("--version sets version mode") {
+        let args = try CLIArguments.parse(["--version"])
+        try assertEqual(args.mode, .version)
+    }
+
+    test("-v sets version mode") {
+        let args = try CLIArguments.parse(["-v"])
+        try assertEqual(args.mode, .version)
+    }
+
+    test("--release sets release mode") {
+        let args = try CLIArguments.parse(["--release"])
+        try assertEqual(args.mode, .release)
+    }
+
+    test("--chat sets chat mode") {
+        let args = try CLIArguments.parse(["--chat"])
+        try assertEqual(args.mode, .chat)
+    }
+
+    test("--stream sets stream mode") {
+        let args = try CLIArguments.parse(["--stream"])
+        try assertEqual(args.mode, .stream)
+    }
+
+    test("--serve sets serve mode") {
+        let args = try CLIArguments.parse(["--serve"])
+        try assertEqual(args.mode, .serve)
+    }
+
+    test("--benchmark sets benchmark mode") {
+        let args = try CLIArguments.parse(["--benchmark"])
+        try assertEqual(args.mode, .benchmark)
+    }
+
+    test("--model-info sets modelInfo mode") {
+        let args = try CLIArguments.parse(["--model-info"])
+        try assertEqual(args.mode, .modelInfo)
+    }
+
+    test("--update sets update mode") {
+        let args = try CLIArguments.parse(["--update"])
+        try assertEqual(args.mode, .update)
+    }
+
+    // -- Prompt parsing --
+
+    test("bare words become the prompt") {
+        let args = try CLIArguments.parse(["hello", "world"])
+        try assertEqual(args.prompt, "hello world")
+    }
+
+    test("prompt after flags") {
+        let args = try CLIArguments.parse(["--quiet", "tell", "me", "a", "joke"])
+        try assertEqual(args.prompt, "tell me a joke")
+        try assertTrue(args.quiet)
+    }
+
+    // -- System prompt --
+
+    test("--system sets systemPrompt") {
+        let args = try CLIArguments.parse(["--system", "You are helpful", "hi"])
+        try assertEqual(args.systemPrompt, "You are helpful")
+    }
+
+    test("-s sets systemPrompt") {
+        let args = try CLIArguments.parse(["-s", "Be brief", "hi"])
+        try assertEqual(args.systemPrompt, "Be brief")
+    }
+
+    test("--system without value throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--system"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    // -- Output --
+
+    test("--output plain") {
+        let args = try CLIArguments.parse(["-o", "plain", "hi"])
+        try assertEqual(args.outputFormat, "plain")
+    }
+
+    test("--output json") {
+        let args = try CLIArguments.parse(["--output", "json", "hi"])
+        try assertEqual(args.outputFormat, "json")
+    }
+
+    test("--output invalid throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--output", "xml"]) }
+        catch let e as CLIParseError {
+            threw = true
+            try assertTrue(e.message.contains("unknown output format"))
+        }
+        try assertTrue(threw)
+    }
+
+    test("--quiet sets quiet") {
+        let args = try CLIArguments.parse(["-q", "hi"])
+        try assertTrue(args.quiet)
+    }
+
+    test("--no-color sets noColor") {
+        let args = try CLIArguments.parse(["--no-color", "hi"])
+        try assertTrue(args.noColor)
+    }
+
+    // -- Server flags --
+
+    test("--port parses valid port") {
+        let args = try CLIArguments.parse(["--serve", "--port", "8080"])
+        try assertEqual(args.serverPort, 8080)
+    }
+
+    test("--port invalid throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--port", "99999"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    test("--port zero throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--port", "0"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    test("--host sets serverHost") {
+        let args = try CLIArguments.parse(["--serve", "--host", "0.0.0.0"])
+        try assertEqual(args.serverHost, "0.0.0.0")
+    }
+
+    test("--cors sets serverCORS") {
+        let args = try CLIArguments.parse(["--serve", "--cors"])
+        try assertTrue(args.serverCORS)
+    }
+
+    test("--max-concurrent parses") {
+        let args = try CLIArguments.parse(["--serve", "--max-concurrent", "10"])
+        try assertEqual(args.serverMaxConcurrent, 10)
+    }
+
+    test("--max-concurrent invalid throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--max-concurrent", "0"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    test("--debug sets debug") {
+        let args = try CLIArguments.parse(["--debug", "hi"])
+        try assertTrue(args.debug)
+    }
+
+    test("--token sets serverToken") {
+        let args = try CLIArguments.parse(["--serve", "--token", "secret123"])
+        try assertEqual(args.serverToken, "secret123")
+    }
+
+    test("--token-auto sets serverTokenAuto") {
+        let args = try CLIArguments.parse(["--serve", "--token-auto"])
+        try assertTrue(args.serverTokenAuto)
+    }
+
+    test("--public-health sets serverPublicHealth") {
+        let args = try CLIArguments.parse(["--serve", "--public-health"])
+        try assertTrue(args.serverPublicHealth)
+    }
+
+    test("--no-origin-check disables origin check") {
+        let args = try CLIArguments.parse(["--serve", "--no-origin-check"])
+        try assertTrue(!args.serverOriginCheckEnabled)
+    }
+
+    test("--footgun disables origin check and enables CORS") {
+        let args = try CLIArguments.parse(["--serve", "--footgun"])
+        try assertTrue(!args.serverOriginCheckEnabled)
+        try assertTrue(args.serverCORS)
+    }
+
+    test("--allowed-origins parses comma-separated list") {
+        let args = try CLIArguments.parse(["--serve", "--allowed-origins", "http://a.com,http://b.com"])
+        try assertEqual(args.serverAllowedOrigins.count, 2)
+        try assertTrue(args.serverAllowedOrigins.contains("http://a.com"))
+        try assertTrue(args.serverAllowedOrigins.contains("http://b.com"))
+    }
+
+    test("--allowed-origins empty throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--allowed-origins", ""]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    // -- MCP --
+
+    test("--mcp adds server path") {
+        let args = try CLIArguments.parse(["--mcp", "/path/to/server.py", "hi"])
+        try assertEqual(args.mcpServerPaths.count, 1)
+        try assertEqual(args.mcpServerPaths[0], "/path/to/server.py")
+    }
+
+    test("multiple --mcp accumulate") {
+        let args = try CLIArguments.parse(["--mcp", "a.py", "--mcp", "b.py", "hi"])
+        try assertEqual(args.mcpServerPaths.count, 2)
+    }
+
+    test("--mcp-timeout parses") {
+        let args = try CLIArguments.parse(["--mcp-timeout", "10", "hi"])
+        try assertEqual(args.mcpTimeoutSeconds, 10)
+    }
+
+    test("--mcp-timeout caps at 300") {
+        let args = try CLIArguments.parse(["--mcp-timeout", "999", "hi"])
+        try assertEqual(args.mcpTimeoutSeconds, 300)
+    }
+
+    // -- Generation --
+
+    test("--temperature parses") {
+        let args = try CLIArguments.parse(["--temperature", "0.7", "hi"])
+        try assertEqual(args.temperature, 0.7)
+    }
+
+    test("--temperature negative throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--temperature", "-1"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    test("--seed parses") {
+        let args = try CLIArguments.parse(["--seed", "42", "hi"])
+        try assertEqual(args.seed, 42)
+    }
+
+    test("--max-tokens parses") {
+        let args = try CLIArguments.parse(["--max-tokens", "100", "hi"])
+        try assertEqual(args.maxTokens, 100)
+    }
+
+    test("--max-tokens zero throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--max-tokens", "0"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    test("--permissive sets permissive") {
+        let args = try CLIArguments.parse(["--permissive", "hi"])
+        try assertTrue(args.permissive)
+    }
+
+    // -- Retry --
+
+    test("--retry enables retry") {
+        let args = try CLIArguments.parse(["--retry", "hi"])
+        try assertTrue(args.retryEnabled)
+        try assertEqual(args.retryCount, 3) // default
+    }
+
+    test("--retry with count") {
+        let args = try CLIArguments.parse(["--retry", "5", "hi"])
+        try assertTrue(args.retryEnabled)
+        try assertEqual(args.retryCount, 5)
+    }
+
+    test("--retry without count keeps default") {
+        let args = try CLIArguments.parse(["--retry", "--quiet", "hi"])
+        try assertTrue(args.retryEnabled)
+        try assertEqual(args.retryCount, 3)
+    }
+
+    // -- Context --
+
+    test("--context-strategy parses valid strategy") {
+        let args = try CLIArguments.parse(["--context-strategy", "sliding-window", "--chat"])
+        try assertEqual(args.contextStrategy, .slidingWindow)
+    }
+
+    test("--context-strategy invalid throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--context-strategy", "invalid"]) }
+        catch { threw = true }
+        try assertTrue(threw)
+    }
+
+    test("--context-max-turns parses") {
+        let args = try CLIArguments.parse(["--context-max-turns", "10", "--chat"])
+        try assertEqual(args.contextMaxTurns, 10)
+    }
+
+    test("--context-output-reserve parses") {
+        let args = try CLIArguments.parse(["--context-output-reserve", "256", "--chat"])
+        try assertEqual(args.contextOutputReserve, 256)
+    }
+
+    // -- Unknown flags --
+
+    test("unknown flag throws") {
+        var threw = false
+        do { _ = try CLIArguments.parse(["--nonexistent"]) }
+        catch let e as CLIParseError {
+            threw = true
+            try assertTrue(e.message.contains("unknown option"))
+        }
+        try assertTrue(threw)
+    }
+
+    // -- Environment variable defaults --
+
+    test("APFEL_PORT env sets default port") {
+        let args = try CLIArguments.parse(["--serve"], env: ["APFEL_PORT": "9090"])
+        try assertEqual(args.serverPort, 9090)
+    }
+
+    test("CLI flag overrides env var") {
+        let args = try CLIArguments.parse(["--serve", "--port", "8080"], env: ["APFEL_PORT": "9090"])
+        try assertEqual(args.serverPort, 8080)
+    }
+
+    test("APFEL_SYSTEM_PROMPT env sets systemPrompt") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_SYSTEM_PROMPT": "Be brief"])
+        try assertEqual(args.systemPrompt, "Be brief")
+    }
+
+    test("APFEL_TEMPERATURE env sets temperature") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_TEMPERATURE": "0.5"])
+        try assertEqual(args.temperature, 0.5)
+    }
+
+    test("APFEL_MAX_TOKENS env sets maxTokens") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_MAX_TOKENS": "200"])
+        try assertEqual(args.maxTokens, 200)
+    }
+
+    test("APFEL_CONTEXT_STRATEGY env sets contextStrategy") {
+        let args = try CLIArguments.parse(["--chat"], env: ["APFEL_CONTEXT_STRATEGY": "strict"])
+        try assertEqual(args.contextStrategy, .strict)
+    }
+
+    test("APFEL_MCP env sets MCP paths") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_MCP": "a.py:b.py"])
+        try assertEqual(args.mcpServerPaths, ["a.py", "b.py"])
+    }
+
+    test("APFEL_HOST env sets serverHost") {
+        let args = try CLIArguments.parse(["--serve"], env: ["APFEL_HOST": "0.0.0.0"])
+        try assertEqual(args.serverHost, "0.0.0.0")
+    }
+
+    test("APFEL_TOKEN env sets serverToken") {
+        let args = try CLIArguments.parse(["--serve"], env: ["APFEL_TOKEN": "mytoken"])
+        try assertEqual(args.serverToken, "mytoken")
+    }
+
+    // -- Combined flags --
+
+    test("full server config parses") {
+        let args = try CLIArguments.parse([
+            "--serve", "--port", "8080", "--host", "0.0.0.0",
+            "--cors", "--max-concurrent", "10", "--token", "secret",
+            "--public-health", "--retry", "5", "--debug",
+            "--mcp", "calc.py"
+        ])
+        try assertEqual(args.mode, .serve)
+        try assertEqual(args.serverPort, 8080)
+        try assertEqual(args.serverHost, "0.0.0.0")
+        try assertTrue(args.serverCORS)
+        try assertEqual(args.serverMaxConcurrent, 10)
+        try assertEqual(args.serverToken, "secret")
+        try assertTrue(args.serverPublicHealth)
+        try assertTrue(args.retryEnabled)
+        try assertEqual(args.retryCount, 5)
+        try assertTrue(args.debug)
+        try assertEqual(args.mcpServerPaths, ["calc.py"])
+    }
+
+    test("full CLI config parses") {
+        let args = try CLIArguments.parse([
+            "--system", "Be brief", "--temperature", "0.8",
+            "--seed", "42", "--max-tokens", "100",
+            "--permissive", "--retry", "--quiet", "--no-color",
+            "--output", "json",
+            "what is Swift?"
+        ])
+        try assertEqual(args.mode, .single)
+        try assertEqual(args.systemPrompt, "Be brief")
+        try assertEqual(args.temperature, 0.8)
+        try assertEqual(args.seed, 42)
+        try assertEqual(args.maxTokens, 100)
+        try assertTrue(args.permissive)
+        try assertTrue(args.retryEnabled)
+        try assertTrue(args.quiet)
+        try assertTrue(args.noColor)
+        try assertEqual(args.outputFormat, "json")
+        try assertEqual(args.prompt, "what is Swift?")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -2,6 +2,7 @@
 // Run: swift run apfel-tests
 
 import Foundation
+import ApfelCLI
 
 // MARK: - Minimal test harness
 

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -81,6 +81,7 @@ suite("MCPClientTests") { runMCPClientTests() }
 suite("AsyncHarnessTests") { runAsyncHarnessTests() }
 suite("RetryTests") { runRetryTests() }
 suite("DebugLoggerTests") { runDebugLoggerTests() }
+suite("CLIArgumentsTests") { runCLIArgumentsTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
## Summary

- Extracts the ~240-line argument parsing loop from `main.swift` into a testable `CLIArguments.parse()` static method in `ApfelCore`
- `main.swift` is reduced to: parse → apply globals → dispatch (~220 lines, down from ~490)
- **66 new unit tests** covering every flag, validation error, env var default, and combined configurations (203 + 66 = 269 total)

## Problem

`main.swift` contained a manual `while i < args.count { switch args[i] }` loop spanning ~240 lines that mixed argument parsing, validation, file I/O, and `exit()` calls in one flat scope. This made it impossible to test flag combinations without running the full binary, and adding new flags required mentally tracking ~25 mutable `var` bindings.

## Solution

**New: `Sources/Core/CLIArguments.swift`**

- `CLIArguments` struct with typed fields for every flag
- `CLIArguments.Mode` enum replacing string-based mode dispatch
- `CLIArguments.parse(_ args:env:) throws -> CLIArguments` — pure function, no side effects, no `exit()` calls
- `CLIParseError` for user-facing validation errors
- `fileErrorMessage()` helper moved here (was duplicated in main.swift)
- Environment variable defaults applied first, CLI flags override

**Refactored: `Sources/main.swift`**

The entry point is now three clean phases:
1. **Parse** — `CLIArguments.parse(rawArgs, env: ...)`, catch `CLIParseError`
2. **Apply** — set global state (`outputFormat`, `quietMode`, `noColorFlag`, `apfelDebugEnabled`), build prompt from files + stdin
3. **Dispatch** — `switch parsed.mode` with typed enum cases

## What didn't change

- All flag names, short forms, and validation rules are identical
- Environment variable behavior is identical
- Stdin piping behavior is identical
- Exit codes are identical
- The no-args stdin pipe fast path stays in `main.swift` (it needs `isatty()` + `await`)

## Tests

`Tests/apfelTests/CLIArgumentsTests.swift` — 66 tests:

| Category | Count | Examples |
|----------|-------|---------|
| Mode flags | 12 | `--help`, `-h`, `--chat`, `--serve`, `--benchmark`, `--model-info`, etc. |
| Prompt parsing | 2 | bare words, prompt after flags |
| System prompt | 3 | `--system`, `-s`, missing value error |
| Output flags | 5 | `--output plain/json`, invalid format error, `--quiet`, `--no-color` |
| Server flags | 14 | `--port`, `--host`, `--cors`, `--max-concurrent`, `--token`, `--footgun`, `--allowed-origins`, etc. |
| MCP flags | 4 | `--mcp`, multiple `--mcp`, `--mcp-timeout`, timeout cap at 300 |
| Generation flags | 7 | `--temperature`, `--seed`, `--max-tokens`, `--permissive`, validation errors |
| Retry flags | 3 | `--retry`, `--retry N`, `--retry` followed by non-number |
| Context flags | 4 | `--context-strategy`, `--context-max-turns`, `--context-output-reserve`, invalid strategy |
| Error handling | 1 | Unknown flag |
| Env var defaults | 9 | `APFEL_PORT`, `APFEL_SYSTEM_PROMPT`, `APFEL_TEMPERATURE`, flag-overrides-env, etc. |
| Combined configs | 2 | Full server config, full CLI config |

## Test plan

- [x] `swift run apfel-tests` — 269 tests pass, 0 failures
- [x] `swift build` succeeds
- [ ] Manual smoke test: `apfel "hello"`, `apfel --chat`, `apfel --serve`, `echo test | apfel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)