### PR TITLE
refactor: split executeMCPToolCalls into CLI and server paths

### DIFF
--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -205,7 +205,7 @@ private func mcpAutoExecuteResponse(
     // Auto-execute MCP tool calls and re-prompt for plain text answer
     let content: String
     do {
-        if let executed = try await executeMCPToolCalls(
+        if let executed = try await executeMCPToolCallsForServer(
             in: rawContent,
             mcpManager: serverState.mcpManager,
             userPrompt: userPrompt,

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -252,7 +252,7 @@ func processPrompt(
     debugLog("response", "length=\(content.count)")
 
     var toolLog: [ToolLogEntry] = []
-    if let result = try await executeMCPToolCalls(
+    if let result = try await executeMCPToolCallsForCLI(
         in: content, mcpManager: mcpManager, userPrompt: prompt,
         systemPrompt: systemPrompt, options: genOpts
     ) {
@@ -276,20 +276,22 @@ func printToolLog(_ toolLog: [ToolLogEntry]) {
     }
 }
 
-// MARK: - MCP Tool Execution (shared by CLI and server)
+// MARK: - MCP Tool Execution
 
-/// Execute MCP tool calls found in model output and re-prompt for a plain text answer.
+/// Result of detecting and executing MCP tool calls (before re-prompting).
+struct MCPExecutionResult {
+    let toolCalls: [ParsedToolCall]
+    let resultParts: [String]
+    let toolLog: [(name: String, args: String, result: String, isError: Bool)]
+}
+
+/// Detect and execute MCP tool calls found in model output.
 /// Returns nil if no tool calls were detected or mcpManager is nil.
-/// Both CLI and server call this to avoid duplicating the detect-execute-reprompt loop.
-func executeMCPToolCalls(
+/// Does NOT re-prompt — callers choose their own re-prompt strategy.
+func detectAndExecuteMCPTools(
     in content: String,
-    mcpManager: MCPManager?,
-    userPrompt: String,
-    systemPrompt: String? = nil,
-    messages: [OpenAIMessage]? = nil,
-    sessionOptions: SessionOptions? = nil,
-    options: GenerationOptions
-) async throws -> (content: String, toolLog: [(name: String, args: String, result: String, isError: Bool)])? {
+    mcpManager: MCPManager?
+) async throws -> MCPExecutionResult? {
     guard let mcpManager,
           let toolCalls = ToolCallHandler.detectToolCall(in: content) else {
         return nil
@@ -304,42 +306,68 @@ func executeMCPToolCalls(
             toolLog.append((name: call.name, args: call.argumentsString, result: result, isError: false))
         } catch {
             if case .toolNotFound = error as? MCPError {
-                // Model hallucinated a tool name that no MCP server provides.
-                // Include the error as a result so the model can still respond.
                 let msg = "\(error)"
                 resultParts.append("\(call.name): error - \(msg)")
                 toolLog.append((name: call.name, args: call.argumentsString, result: msg, isError: true))
             } else {
-                throw error  // Timeouts, server errors, process errors are fatal.
+                throw error
             }
         }
     }
 
-    let finalContent: String
-    if let messages, let sessionOptions {
-        let followUpMessages = appendExecutedToolResults(
-            to: messages,
-            toolCalls: toolCalls,
-            toolResults: toolLog.map { ($0.name, $0.result) }
-        )
-        let (followUpSession, followUpPrompt) = try await ContextManager.makeSession(
-            messages: followUpMessages,
-            tools: nil,
-            options: sessionOptions,
-            jsonMode: false,
-            toolChoice: nil
-        )
-        finalContent = try await followUpSession.respond(to: followUpPrompt, options: options).content
-    } else {
-        // CLI fallback: no prior transcript, so use a plain follow-up prompt.
-        let plainSession = makeSession(systemPrompt: systemPrompt)
-        let toolResult = resultParts.joined(separator: "\n")
-        finalContent = try await plainSession.respond(
-            to: "The user asked: \(userPrompt)\n\nThe tool returned: \(toolResult)\n\nAnswer the user's question using this result.",
-            options: options
-        ).content
+    return MCPExecutionResult(toolCalls: toolCalls, resultParts: resultParts, toolLog: toolLog)
+}
+
+/// CLI path: execute MCP tool calls and re-prompt with a plain follow-up session.
+/// No conversation history is threaded — the follow-up gets only the user prompt + tool results.
+func executeMCPToolCallsForCLI(
+    in content: String,
+    mcpManager: MCPManager?,
+    userPrompt: String,
+    systemPrompt: String?,
+    options: GenerationOptions
+) async throws -> (content: String, toolLog: [(name: String, args: String, result: String, isError: Bool)])? {
+    guard let executed = try await detectAndExecuteMCPTools(in: content, mcpManager: mcpManager) else {
+        return nil
     }
-    return (content: finalContent, toolLog: toolLog)
+
+    let plainSession = makeSession(systemPrompt: systemPrompt)
+    let toolResult = executed.resultParts.joined(separator: "\n")
+    let finalContent = try await plainSession.respond(
+        to: "The user asked: \(userPrompt)\n\nThe tool returned: \(toolResult)\n\nAnswer the user's question using this result.",
+        options: options
+    ).content
+    return (content: finalContent, toolLog: executed.toolLog)
+}
+
+/// Server path: execute MCP tool calls and re-prompt with full conversation context.
+/// Appends tool call/result messages to the conversation and rebuilds a session via ContextManager.
+func executeMCPToolCallsForServer(
+    in content: String,
+    mcpManager: MCPManager?,
+    userPrompt: String,
+    messages: [OpenAIMessage],
+    sessionOptions: SessionOptions,
+    options: GenerationOptions
+) async throws -> (content: String, toolLog: [(name: String, args: String, result: String, isError: Bool)])? {
+    guard let executed = try await detectAndExecuteMCPTools(in: content, mcpManager: mcpManager) else {
+        return nil
+    }
+
+    let followUpMessages = appendExecutedToolResults(
+        to: messages,
+        toolCalls: executed.toolCalls,
+        toolResults: executed.toolLog.map { ($0.name, $0.result) }
+    )
+    let (followUpSession, followUpPrompt) = try await ContextManager.makeSession(
+        messages: followUpMessages,
+        tools: nil,
+        options: sessionOptions,
+        jsonMode: false,
+        toolChoice: nil
+    )
+    let finalContent = try await followUpSession.respond(to: followUpPrompt, options: options).content
+    return (content: finalContent, toolLog: executed.toolLog)
 }
 
 private func appendExecutedToolResults(


### PR DESCRIPTION
## Summary

Split the dual-mode \`executeMCPToolCalls()\` into three focused functions:

- **\`detectAndExecuteMCPTools()\`** — shared: detect tool calls in model output, execute them, collect results
- **\`executeMCPToolCallsForCLI()\`** — CLI path: re-prompt with a plain follow-up session
- **\`executeMCPToolCallsForServer()\`** — server path: re-prompt with full conversation context via \`ContextManager\`

## Why this matters

### 1. The current function has hidden behavioral divergence

\`executeMCPToolCalls()\` takes two optional parameters (\`messages: [OpenAIMessage]?\` and \`sessionOptions: SessionOptions?\`) that fundamentally change its behavior:

- When **both are nil** (CLI path): creates a fresh session with a hardcoded prompt template, discarding all conversation history
- When **both are set** (server path): rebuilds the full conversation via \`ContextManager.makeSession()\`, appending tool call/result messages as proper OpenAI roles

These are two completely different re-prompting strategies hidden behind optional parameters. A reader of the code has to mentally trace which callers pass nil vs non-nil to understand what the function actually does. This is the kind of implicit control flow that causes bugs during future maintenance — someone changing the server behavior could accidentally break the CLI path, or vice versa, because both live in the same function body.

### 2. Optional parameter pairs are a code smell for "should be two functions"

The \`messages\` and \`sessionOptions\` parameters are always passed together or not at all. They form an implicit "mode selector" — if you pass one without the other, the function silently takes the wrong path (the \`if let messages, let sessionOptions\` guard falls through to the CLI branch). There's no compile-time protection against this misuse. With separate functions, the type signatures enforce correct usage: \`executeMCPToolCallsForServer\` requires \`messages\` and \`sessionOptions\` as non-optional parameters.

### 3. The shared detect-execute logic was duplicated with the re-prompt logic

The tool detection (\`ToolCallHandler.detectToolCall\`) and execution (\`mcpManager.execute\`) loop is identical for both paths — only the re-prompting differs. By extracting \`detectAndExecuteMCPTools()\`, the shared logic lives in one place, and each caller only adds its specific re-prompt strategy. This makes it trivial to add a third re-prompt strategy in the future (e.g., a chat-mode path that threads through the live session transcript instead of rebuilding from OpenAI messages).

### 4. Easier to reason about, test, and review

Each function now does one thing:
- \`detectAndExecuteMCPTools\`: "find tool calls and run them" — no re-prompting, no session creation
- \`executeMCPToolCallsForCLI\`: "given tool results, ask a fresh session for a final answer"
- \`executeMCPToolCallsForServer\`: "given tool results, rebuild the full conversation and ask for a final answer"

A future contributor reading \`processPrompt()\` in Session.swift sees \`executeMCPToolCallsForCLI\` and immediately knows: this is the CLI path, it doesn't thread conversation history. A reader of \`mcpAutoExecuteResponse()\` in Handlers.swift sees \`executeMCPToolCallsForServer\` and knows: this rebuilds full context. No need to trace optional parameter values.

## What changed

| File | Change |
|------|--------|
| \`Sources/Session.swift\` | Split \`executeMCPToolCalls()\` into \`detectAndExecuteMCPTools()\` + \`executeMCPToolCallsForCLI()\` + \`executeMCPToolCallsForServer()\`. Added \`MCPExecutionResult\` struct for the shared return type. Updated \`processPrompt()\` call site. |
| \`Sources/Handlers.swift\` | Updated \`mcpAutoExecuteResponse()\` to call \`executeMCPToolCallsForServer()\` |

## What didn't change

- Zero behavioral changes — both paths produce identical results
- The \`appendExecutedToolResults()\` helper is unchanged
- The \`processPrompt()\` and \`mcpAutoExecuteResponse()\` call sites pass the same data
- All error handling (toolNotFound tolerance, fatal error propagation) is identical

## Test plan

- [x] \`swift run apfel-tests\` — 203 tests pass, 0 failures
- [x] \`swift build\` succeeds
- [ ] Manual smoke test: \`apfel --mcp mcp/calculator/server.py "What is 2+2?"\`
- [ ] Integration tests with MCP calculator server

🤖 Generated with [Claude Code](https://claude.com/claude-code)