### PR TITLE
feat: remote MCP server support via Streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,17 @@ Native SwiftUI debug inspector with request timeline, MCP protocol viewer, chat,
 
 Attach [MCP](https://modelcontextprotocol.io/) tool servers with `--mcp`. apfel discovers tools, executes them automatically, and returns the final answer. No glue code needed.
 
+Pass a **local path** for stdio servers or an **`http(s)://` URL** for remote servers:
+
 ```bash
+# Local stdio server
 apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
+
+# Remote server (Streamable HTTP transport, MCP spec 2025-03-26)
+apfel --mcp https://mcp.example.com/mcp "Use a tool"
+
+# Remote server with Bearer token auth
+apfel --mcp https://mcp.example.com/mcp --mcp-token mytoken "Use a tool"
 ```
 
 ```
@@ -282,9 +291,9 @@ tool: multiply({"a": 15, "b": 27}) = 405                                        
 Tool info goes to stderr; only the answer goes to stdout. Use `-q` to suppress tool info.
 
 ```bash
-apfel --mcp ./server_a.py --mcp ./server_b.py "Use both tools"  # multiple servers
-apfel --serve --mcp ./mcp/calculator/server.py                   # server mode
-apfel --chat --mcp ./mcp/calculator/server.py                    # chat mode
+apfel --mcp ./server_a.py --mcp https://remote.example.com/mcp "Use both tools"  # mix local + remote
+apfel --serve --mcp ./mcp/calculator/server.py                                    # server mode
+apfel --chat --mcp ./mcp/calculator/server.py                                     # chat mode
 ```
 
 Ships with a calculator MCP server at `mcp/calculator/`. See [docs/mcp-calculator.md](docs/mcp-calculator.md) for details.
@@ -340,8 +349,9 @@ INPUT
   apfel -f, --file <path> <prompt>        Attach file content (repeatable)
   apfel -s, --system <text> <prompt>      Set system prompt
   apfel --system-file <path> <prompt>     Read system prompt from file
-  apfel --mcp <server.py> <prompt>        Attach MCP tool server (repeatable)
+  apfel --mcp <path|url> <prompt>         Attach MCP tool server - local path or http(s) URL (repeatable)
   apfel --mcp-timeout <n> <prompt>       MCP timeout in seconds [default: 5]
+  apfel --mcp-token <token> <prompt>     Bearer token for remote MCP servers
 
 OUTPUT
   -o, --output <fmt>                      Output format: plain, json
@@ -395,9 +405,11 @@ apfel -s "Reply in JSON only" "List 3 colors"
 # --system-file — read system prompt from a file
 apfel --system-file persona.txt "Introduce yourself"
 
-# --mcp — attach MCP tool servers (repeatable)
+# --mcp — attach MCP tool servers (repeatable, local path or http(s) URL)
 apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
 apfel --mcp ./calc.py --mcp ./weather.py "Use both tools"
+apfel --mcp https://mcp.example.com/mcp "Use a remote tool"
+apfel --mcp https://mcp.example.com/mcp --mcp-token mytoken "Use a remote tool"
 
 # -f, --file
 apfel -f main.swift "Explain this code"
@@ -409,10 +421,11 @@ apfel -s "You are a pirate" "What is recursion?"
 # --system-file
 apfel --system-file persona.txt "Introduce yourself"
 
-# --mcp, --mcp-timeout
+# --mcp, --mcp-timeout, --mcp-token
 apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
 apfel --mcp ./calc.py --mcp ./weather.py "Use both tools"
-apfel --mcp-timeout 30 --mcp ./slow-remote-server.py "hello"
+apfel --mcp https://mcp.example.com/mcp --mcp-token mytoken "Use a remote tool"
+apfel --mcp-timeout 30 --mcp ./slow-server.py "hello"
 
 # -o, --output
 apfel -o json "Translate to German: hello" | jq .content
@@ -516,8 +529,9 @@ See [docs/server-security.md](docs/server-security.md) for detailed documentatio
 | `APFEL_CONTEXT_STRATEGY` | Default context strategy |
 | `APFEL_CONTEXT_MAX_TURNS` | Max turns for sliding-window |
 | `APFEL_CONTEXT_OUTPUT_RESERVE` | Tokens reserved for output |
-| `APFEL_MCP` | MCP server paths (colon-separated) |
+| `APFEL_MCP` | MCP server paths or URLs (colon-separated) |
 | `APFEL_MCP_TIMEOUT` | MCP timeout in seconds (default: 5, max: 300) |
+| `APFEL_MCP_TOKEN` | Bearer token for remote MCP servers |
 | `NO_COLOR` | Disable colors ([no-color.org](https://no-color.org)) |
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ No API keys. No cloud. No subscriptions. No per-token billing. The AI is already
 
 ## What is this
 
-Every Mac with Apple Silicon has a **built-in LLM** - Apple's on-device foundation model, shipped as part of Apple Intelligence. Apple provides the [FoundationModels framework](https://developer.apple.com/documentation/foundationmodels) (macOS 26+) to access it, but only exposes it through Siri and system features. **apfel wraps it** in a CLI and an HTTP server - so you can actually use it. All inference runs **on-device**, no network calls.
+Every Mac with Apple Silicon has a **built-in LLM** - Apple's on-device foundation model, shipped as part of Apple Intelligence. Apple provides the [FoundationModels framework](https://developer.apple.com/documentation/foundationmodels) (macOS 26+) to access it, but only exposes it through Siri and system features. **apfel wraps it** in a CLI and an HTTP server - so you can actually use it. All **inference** runs on-device with no network calls for the LLM itself. Optional remote MCP tool servers (`--mcp https://...`) do make network calls for tool arguments — see [MCP Tool Support](#mcp-tool-support).
 
 - **UNIX tool** - `echo "summarize this" | apfel` - pipe-friendly, file attachments, JSON output, exit codes
 - **OpenAI-compatible server** - `apfel --serve` - drop-in replacement at `localhost:11434`, works with any OpenAI SDK
@@ -539,7 +539,7 @@ See [docs/server-security.md](docs/server-security.md) for detailed documentatio
 ```
 CLI (single/stream/chat) ──┐
                            ├─→ FoundationModels.SystemLanguageModel
-HTTP Server (/v1/*) ───────┘   (100% on-device, zero network)
+HTTP Server (/v1/*) ───────┘   (inference: 100% on-device; remote MCP tools make network calls)
                                 ContextManager → Transcript API
                                 SchemaConverter → native ToolDefinitions
                                 TokenCounter → real token counts (SDK 26.4)

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -307,7 +307,7 @@ func printRelease() {
     \(styled("├", .dim)) model:      \(modelName) (FoundationModels framework)
     \(styled("├", .dim)) modes:      single, stream, chat, serve
     \(styled("├", .dim)) server:     OpenAI-compatible (/v1/chat/completions)
-    \(styled("├", .dim)) tools:      function calling + MCP tool servers (--mcp)
+    \(styled("├", .dim)) tools:      function calling + MCP tool servers, local and remote (--mcp)
     \(styled("├", .dim)) formats:    plain, json, streaming SSE
     \(styled("└", .dim)) strategies: newest-first, oldest-first, sliding-window, summarize, strict
 
@@ -439,8 +439,9 @@ func printUsage() {
           --temperature <n>      Sampling temperature (e.g., 0.7)
           --seed <n>             Random seed for reproducible output
           --max-tokens <n>       Maximum response tokens
-          --mcp <path>           Attach MCP tool server (repeatable)
+          --mcp <path|url>       Attach MCP tool server - local path or http(s) URL (repeatable)
           --mcp-timeout <n>      MCP server timeout in seconds [default: 5]
+          --mcp-token <token>    Bearer token for remote MCP servers [env: APFEL_MCP_TOKEN]
           --permissive           Use permissive content guardrails
           --retry [n]            Enable retry with exponential backoff [default: 3 retries]
           --model-info           Print model capabilities and exit

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -58,6 +58,7 @@ public struct CLIArguments: Sendable, Equatable {
 
     public var mcpServerPaths: [String] = []
     public var mcpTimeoutSeconds: Int = 5
+    public var mcpBearerToken: String? = nil
 
     // MARK: - Generation
 
@@ -118,6 +119,7 @@ extension CLIArguments {
             .split(separator: ":").map(String.init).filter { !$0.isEmpty } ?? []
         result.mcpTimeoutSeconds = Int(env["APFEL_MCP_TIMEOUT"] ?? "")
             .flatMap { $0 > 0 ? min($0, 300) : nil } ?? 5
+        result.mcpBearerToken = env["APFEL_MCP_TOKEN"].flatMap { $0.isEmpty ? nil : $0 }
         result.temperature = Double(env["APFEL_TEMPERATURE"] ?? "")
         result.maxTokens = Int(env["APFEL_MAX_TOKENS"] ?? "").flatMap { $0 > 0 ? $0 : nil }
         result.contextStrategy = env["APFEL_CONTEXT_STRATEGY"].flatMap { ContextStrategy(rawValue: $0) }
@@ -288,6 +290,13 @@ extension CLIArguments {
                     throw CLIParseError("--mcp-timeout requires a positive number (seconds)")
                 }
                 result.mcpTimeoutSeconds = min(t, 300)
+
+            case "--mcp-token":
+                i += 1
+                guard i < args.count else {
+                    throw CLIParseError("--mcp-token requires a token value")
+                }
+                result.mcpBearerToken = args[i]
 
             // -- Generation --
 

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -115,8 +115,7 @@ extension CLIArguments {
         result.serverPort = Int(env["APFEL_PORT"] ?? "") ?? 11434
         result.serverHost = env["APFEL_HOST"] ?? "127.0.0.1"
         result.serverToken = env["APFEL_TOKEN"]
-        result.mcpServerPaths = env["APFEL_MCP"]?
-            .split(separator: ":").map(String.init).filter { !$0.isEmpty } ?? []
+        result.mcpServerPaths = env["APFEL_MCP"].map(parseMCPServerPaths) ?? []
         result.mcpTimeoutSeconds = Int(env["APFEL_MCP_TIMEOUT"] ?? "")
             .flatMap { $0 > 0 ? min($0, 300) : nil } ?? 5
         result.mcpBearerToken = env["APFEL_MCP_TOKEN"].flatMap { $0.isEmpty ? nil : $0 }
@@ -388,6 +387,53 @@ extension CLIArguments {
     }
 
     // MARK: - Helpers
+
+    /// Parse a colon- or comma-separated list of MCP server paths/URLs.
+    ///
+    /// Commas are the canonical separator and always work correctly, including
+    /// with `http(s)://` URLs. Colons are supported as a legacy separator for
+    /// local stdio paths only (i.e. when no entry contains `://`). This avoids
+    /// splitting `https://example.com/mcp` on the colon in the scheme.
+    private static func parseMCPServerPaths(_ value: String) -> [String] {
+        // Comma-first: if the value contains a comma, use it as the separator.
+        // This is the recommended format for mixed local + remote lists.
+        if value.contains(",") {
+            return value.split(separator: ",")
+                .map { String($0).trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+        }
+        // Legacy colon-separator: safe only when no entry is a URL.
+        // Split on ":" but rejoin pairs that look like a scheme (http: + //...).
+        let parts = value.split(separator: ":").map(String.init).filter { !$0.isEmpty }
+        var result: [String] = []
+        var i = parts.startIndex
+        while i < parts.endIndex {
+            let part = parts[i]
+            let next = parts.index(after: i)
+            if (part == "http" || part == "https"),
+               next < parts.endIndex,
+               parts[next].hasPrefix("//") {
+                // Reassemble "http" + "://..." → "http://..."
+                // But the URL may have a port too (e.g. "https://host" + "8080/path"),
+                // so keep consuming non-scheme parts that would have been split.
+                var url = part + ":" + parts[next]
+                var j = parts.index(after: next)
+                // If the very next part is a bare port+path (no "//"), it was
+                // split off a port colon: "https://host" "8080/path".
+                while j < parts.endIndex, !parts[j].hasPrefix("//"),
+                      parts[j] != "http", parts[j] != "https" {
+                    url += ":" + parts[j]
+                    j = parts.index(after: j)
+                }
+                result.append(url)
+                i = j
+            } else {
+                result.append(part)
+                i = parts.index(after: i)
+            }
+        }
+        return result.filter { !$0.isEmpty }
+    }
 
     private static func parseAllowedOrigins(_ value: String) -> [String] {
         value.split(separator: ",")

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -142,15 +142,21 @@ final class MCPConnection: @unchecked Sendable {
 private let maxRemoteMCPResponseBytes = 10 * 1024 * 1024
 
 /// A connection to a remote MCP server using the Streamable HTTP transport (MCP spec 2025-03-26).
-final class RemoteMCPConnection: @unchecked Sendable {
-    let urlString: String
-    private(set) var tools: [OpenAITool]
+///
+/// Declared as an `actor` so that `sessionId` and `nextId` mutations are
+/// serialised by the Swift runtime with no manual locking required.
+/// `urlString` and `tools` are `nonisolated` so callers can read them without
+/// an `await` (they are written once during `init` and never mutated again).
+actor RemoteMCPConnection: Sendable {
+    nonisolated let urlString: String
+    // Written once in init, read-only thereafter; nonisolated(unsafe) lets
+    // callers access the tool list synchronously without an await.
+    nonisolated(unsafe) private(set) var tools: [OpenAITool] = []
 
     private let url: URL
     private let bearerToken: String?
     private let timeoutSeconds: Int
     private let session: URLSession
-    private let lock = NSLock()
     private var nextId = 1
     private var sessionId: String?
 
@@ -175,7 +181,6 @@ final class RemoteMCPConnection: @unchecked Sendable {
         let config = URLSessionConfiguration.ephemeral
         config.httpAdditionalHeaders = ["User-Agent": "apfel/\(buildVersion)"]
         self.session = URLSession(configuration: config)
-        self.tools = []
 
         do {
             // Initialize handshake
@@ -185,7 +190,7 @@ final class RemoteMCPConnection: @unchecked Sendable {
             // Send initialized notification (202, no response body needed)
             _ = try? await post(MCPProtocol.initializedNotification())
 
-            // Discover tools
+            // Discover tools (written once; thereafter treated as read-only)
             let toolsResp = try await post(MCPProtocol.toolsListRequest(id: allocId()))
             self.tools = try MCPProtocol.parseToolsListResponse(toolsResp)
         } catch let error as MCPError {
@@ -218,8 +223,6 @@ final class RemoteMCPConnection: @unchecked Sendable {
     // MARK: - Private
 
     private func allocId() -> Int {
-        lock.lock()
-        defer { lock.unlock() }
         let id = nextId
         nextId += 1
         return id
@@ -317,7 +320,9 @@ enum AnyMCPConnection: Sendable {
     func shutdown() {
         switch self {
         case .local(let c): c.shutdown()
-        case .remote(let c): c.shutdown()
+        // Actor methods require await; fire-and-forget via unstructured Task
+        // since shutdown is best-effort (the session will expire on the server).
+        case .remote(let c): Task { await c.shutdown() }
         }
     }
 }

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -150,8 +150,15 @@ final class RemoteMCPConnection: @unchecked Sendable {
     private var sessionId: String?
 
     init(urlString: String, bearerToken: String?, timeoutSeconds: Int = 5) async throws {
-        guard let url = URL(string: urlString) else {
-            throw MCPError.processError("Invalid MCP server URL: \(urlString)")
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme,
+              scheme == "http" || scheme == "https" else {
+            throw MCPError.processError("Invalid MCP server URL: \(urlString) (must be http:// or https://)")
+        }
+        if bearerToken != nil && scheme == "http" {
+            throw MCPError.processError(
+                "refusing to send --mcp-token over plaintext http:// - use https:// to protect credentials"
+            )
         }
         self.urlString = urlString
         self.url = url

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -7,6 +7,8 @@ import Foundation
 import Darwin
 import ApfelCore
 
+// MARK: - Local (stdio) connection
+
 /// A connection to a single MCP server process (stdio transport).
 final class MCPConnection: @unchecked Sendable {
     private let timeoutMilliseconds: Int
@@ -133,26 +135,196 @@ final class MCPConnection: @unchecked Sendable {
     }
 }
 
+// MARK: - Remote (Streamable HTTP) connection
+
+/// A connection to a remote MCP server using the Streamable HTTP transport (MCP spec 2025-03-26).
+final class RemoteMCPConnection: @unchecked Sendable {
+    let urlString: String
+    private(set) var tools: [OpenAITool]
+
+    private let url: URL
+    private let bearerToken: String?
+    private let timeoutSeconds: Int
+    private let lock = NSLock()
+    private var nextId = 1
+    private var sessionId: String?
+
+    init(urlString: String, bearerToken: String?, timeoutSeconds: Int = 5) async throws {
+        guard let url = URL(string: urlString) else {
+            throw MCPError.processError("Invalid MCP server URL: \(urlString)")
+        }
+        self.urlString = urlString
+        self.url = url
+        self.bearerToken = bearerToken
+        self.timeoutSeconds = timeoutSeconds
+        self.tools = []
+
+        do {
+            // Initialize handshake
+            let initResp = try await post(MCPProtocol.initializeRequest(id: allocId()))
+            _ = try MCPProtocol.parseInitializeResponse(initResp)
+
+            // Send initialized notification (202, no response body needed)
+            _ = try? await post(MCPProtocol.initializedNotification())
+
+            // Discover tools
+            let toolsResp = try await post(MCPProtocol.toolsListRequest(id: allocId()))
+            self.tools = try MCPProtocol.parseToolsListResponse(toolsResp)
+        } catch let error as MCPError {
+            throw error
+        } catch {
+            throw MCPError.processError("Remote MCP handshake failed for \(urlString): \(error)")
+        }
+    }
+
+    func callTool(name: String, arguments: String) async throws -> String {
+        let resp = try await post(MCPProtocol.toolsCallRequest(id: allocId(), name: name, arguments: arguments))
+        let result = try MCPProtocol.parseToolCallResponse(resp)
+        if result.isError {
+            throw MCPError.serverError("Tool '\(name)' failed: \(result.text)")
+        }
+        return result.text
+    }
+
+    func shutdown() {
+        guard let sid = sessionId else { return }
+        var req = URLRequest(url: url, timeoutInterval: 5)
+        req.httpMethod = "DELETE"
+        if let token = bearerToken {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        req.setValue(sid, forHTTPHeaderField: "Mcp-Session-Id")
+        URLSession.shared.dataTask(with: req).resume()
+    }
+
+    // MARK: - Private
+
+    private func allocId() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        let id = nextId
+        nextId += 1
+        return id
+    }
+
+    private func post(_ body: String) async throws -> String {
+        var request = URLRequest(url: url, timeoutInterval: TimeInterval(timeoutSeconds))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        if let token = bearerToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let sid = sessionId {
+            request.setValue(sid, forHTTPHeaderField: "Mcp-Session-Id")
+        }
+        request.httpBody = body.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse {
+            // Capture session ID for subsequent requests
+            if let sid = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
+                sessionId = sid
+            }
+            // 202 Accepted = notification delivered, no body to parse
+            if httpResponse.statusCode == 202 {
+                return "{}"
+            }
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                let body = String(data: data, encoding: .utf8) ?? "(no body)"
+                throw MCPError.serverError("HTTP \(httpResponse.statusCode) from \(urlString): \(body)")
+            }
+        }
+
+        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
+        guard let raw = String(data: data, encoding: .utf8), !raw.isEmpty else {
+            return "{}"
+        }
+
+        // Streamable HTTP servers may respond with SSE even for single responses.
+        // Extract the last non-empty `data:` line and use that as the JSON payload.
+        if contentType.contains("text/event-stream") {
+            let payload = raw.components(separatedBy: "\n")
+                .filter { $0.hasPrefix("data:") }
+                .compactMap { line -> String? in
+                    let value = line.dropFirst("data:".count).trimmingCharacters(in: .whitespaces)
+                    return value.isEmpty ? nil : value
+                }
+                .last
+            return payload ?? "{}"
+        }
+
+        return raw
+    }
+}
+
+// MARK: - Unified connection wrapper
+
+/// Wraps either a local (stdio) or remote (HTTP) MCP connection.
+enum AnyMCPConnection: Sendable {
+    case local(MCPConnection)
+    case remote(RemoteMCPConnection)
+
+    var tools: [OpenAITool] {
+        switch self {
+        case .local(let c): return c.tools
+        case .remote(let c): return c.tools
+        }
+    }
+
+    var identifier: String {
+        switch self {
+        case .local(let c): return c.path
+        case .remote(let c): return c.urlString
+        }
+    }
+
+    func callTool(name: String, arguments: String) async throws -> String {
+        switch self {
+        case .local(let c):
+            // Run blocking stdio I/O off the cooperative thread pool
+            return try await Task.detached { try c.callTool(name: name, arguments: arguments) }.value
+        case .remote(let c):
+            return try await c.callTool(name: name, arguments: arguments)
+        }
+    }
+
+    func shutdown() {
+        switch self {
+        case .local(let c): c.shutdown()
+        case .remote(let c): c.shutdown()
+        }
+    }
+}
+
+// MARK: - Manager
+
 /// Manages multiple MCP server connections and routes tool calls.
 actor MCPManager {
-    private var connections: [MCPConnection] = []
-    private var toolMap: [String: MCPConnection] = [:]
+    private var connections: [AnyMCPConnection] = []
+    private var toolMap: [String: AnyMCPConnection] = [:]
 
-    init(paths: [String], timeoutSeconds: Int = 5) async throws {
+    init(paths: [String], bearerToken: String? = nil, timeoutSeconds: Int = 5) async throws {
         for path in paths {
-            let absPath: String
-            if path.hasPrefix("/") {
-                absPath = path
+            let conn: AnyMCPConnection
+            if path.hasPrefix("http://") || path.hasPrefix("https://") {
+                let remote = try await RemoteMCPConnection(
+                    urlString: path, bearerToken: bearerToken, timeoutSeconds: timeoutSeconds)
+                conn = .remote(remote)
             } else {
-                absPath = FileManager.default.currentDirectoryPath + "/" + path
+                let absPath = path.hasPrefix("/")
+                    ? path
+                    : FileManager.default.currentDirectoryPath + "/" + path
+                let local = try await MCPConnection(path: absPath, timeoutSeconds: timeoutSeconds)
+                conn = .local(local)
             }
-            let conn = try await MCPConnection(path: absPath, timeoutSeconds: timeoutSeconds)
             connections.append(conn)
             for tool in conn.tools {
                 toolMap[tool.function.name] = conn
             }
             if !quietMode {
-                printStderr("\(styled("mcp:", .cyan)) \(conn.path) - \(conn.tools.map(\.function.name).joined(separator: ", "))")
+                printStderr("\(styled("mcp:", .cyan)) \(conn.identifier) - \(conn.tools.map(\.function.name).joined(separator: ", "))")
             }
         }
     }
@@ -161,11 +333,11 @@ actor MCPManager {
         connections.flatMap(\.tools)
     }
 
-    func execute(name: String, arguments: String) throws -> String {
+    func execute(name: String, arguments: String) async throws -> String {
         guard let conn = toolMap[name] else {
             throw MCPError.toolNotFound("No MCP server provides tool '\(name)'")
         }
-        return try conn.callTool(name: name, arguments: arguments)
+        return try await conn.callTool(name: name, arguments: arguments)
     }
 
     func shutdown() {

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -353,6 +353,9 @@ actor MCPManager {
                 toolMap[tool.function.name] = conn
             }
             if !quietMode {
+                if case .remote = conn {
+                    printStderr("warning: remote MCP server attached (\(conn.identifier)) - tool arguments will be sent to this server")
+                }
                 printStderr("\(styled("mcp:", .cyan)) \(conn.identifier) - \(conn.tools.map(\.function.name).joined(separator: ", "))")
             }
         }

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -137,6 +137,10 @@ final class MCPConnection: @unchecked Sendable {
 
 // MARK: - Remote (Streamable HTTP) connection
 
+/// Maximum number of bytes accepted from a single remote MCP response (10 MB).
+/// Prevents a malicious server from OOM-ing the client via an unbounded response.
+private let maxRemoteMCPResponseBytes = 10 * 1024 * 1024
+
 /// A connection to a remote MCP server using the Streamable HTTP transport (MCP spec 2025-03-26).
 final class RemoteMCPConnection: @unchecked Sendable {
     let urlString: String
@@ -145,6 +149,7 @@ final class RemoteMCPConnection: @unchecked Sendable {
     private let url: URL
     private let bearerToken: String?
     private let timeoutSeconds: Int
+    private let session: URLSession
     private let lock = NSLock()
     private var nextId = 1
     private var sessionId: String?
@@ -164,6 +169,12 @@ final class RemoteMCPConnection: @unchecked Sendable {
         self.url = url
         self.bearerToken = bearerToken
         self.timeoutSeconds = timeoutSeconds
+        // Ephemeral session: no shared cookie jar, no disk cache, isolated from
+        // other URLSession.shared traffic. User-Agent identifies apfel to remote
+        // server operators. Timeout is set per-request via URLRequest.
+        let config = URLSessionConfiguration.ephemeral
+        config.httpAdditionalHeaders = ["User-Agent": "apfel/\(buildVersion)"]
+        self.session = URLSession(configuration: config)
         self.tools = []
 
         do {
@@ -201,7 +212,7 @@ final class RemoteMCPConnection: @unchecked Sendable {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         req.setValue(sid, forHTTPHeaderField: "Mcp-Session-Id")
-        URLSession.shared.dataTask(with: req).resume()
+        session.dataTask(with: req).resume()
     }
 
     // MARK: - Private
@@ -227,7 +238,13 @@ final class RemoteMCPConnection: @unchecked Sendable {
         }
         request.httpBody = body.data(using: .utf8)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
+
+        guard data.count <= maxRemoteMCPResponseBytes else {
+            throw MCPError.serverError(
+                "Response from \(urlString) exceeded size limit (\(maxRemoteMCPResponseBytes / (1024 * 1024)) MB)"
+            )
+        }
 
         if let httpResponse = response as? HTTPURLResponse {
             // Capture session ID for subsequent requests

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -184,7 +184,7 @@ default:
 var mcpManager: MCPManager?
 if !parsed.mcpServerPaths.isEmpty {
     do {
-        mcpManager = try await MCPManager(paths: parsed.mcpServerPaths, timeoutSeconds: parsed.mcpTimeoutSeconds)
+        mcpManager = try await MCPManager(paths: parsed.mcpServerPaths, bearerToken: parsed.mcpBearerToken, timeoutSeconds: parsed.mcpTimeoutSeconds)
     } catch {
         printError("MCP server failed to start: \(error)")
         exit(exitRuntimeError)

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -326,6 +326,57 @@ func runCLIArgumentsTests() {
         }
     }
 
+    test("--mcp-token sets mcpBearerToken") {
+        let args = try CLIArguments.parse(["--mcp", "https://remote.example.com/mcp", "--mcp-token", "secret123"])
+        try assertEqual(args.mcpBearerToken, "secret123")
+    }
+
+    test("--mcp-token without value throws") {
+        do {
+            _ = try CLIArguments.parse(["--mcp-token"])
+            try assertTrue(false, "should have thrown")
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("--mcp-token"))
+        }
+    }
+
+    test("--mcp accepts http URL") {
+        let args = try CLIArguments.parse(["--mcp", "http://localhost:9000/mcp"])
+        try assertEqual(args.mcpServerPaths, ["http://localhost:9000/mcp"])
+    }
+
+    test("--mcp accepts https URL") {
+        let args = try CLIArguments.parse(["--mcp", "https://mcp.example.com/v1/mcp"])
+        try assertEqual(args.mcpServerPaths, ["https://mcp.example.com/v1/mcp"])
+    }
+
+    test("--mcp and --mcp-token together set both fields") {
+        let args = try CLIArguments.parse([
+            "--mcp", "https://remote.example.com/mcp",
+            "--mcp-token", "mytoken",
+        ])
+        try assertEqual(args.mcpServerPaths, ["https://remote.example.com/mcp"])
+        try assertEqual(args.mcpBearerToken, "mytoken")
+    }
+
+    test("APFEL_MCP_TOKEN env sets mcpBearerToken") {
+        let args = try CLIArguments.parse([], env: ["APFEL_MCP_TOKEN": "envtoken"])
+        try assertEqual(args.mcpBearerToken, "envtoken")
+    }
+
+    test("APFEL_MCP_TOKEN empty string produces nil") {
+        let args = try CLIArguments.parse([], env: ["APFEL_MCP_TOKEN": ""])
+        try assertTrue(args.mcpBearerToken == nil)
+    }
+
+    test("--mcp-token CLI flag overrides APFEL_MCP_TOKEN env") {
+        let args = try CLIArguments.parse(
+            ["--mcp-token", "cli-token"],
+            env: ["APFEL_MCP_TOKEN": "env-token"]
+        )
+        try assertEqual(args.mcpBearerToken, "cli-token")
+    }
+
     // ========================================================================
     // MARK: - Generation flags
     // ========================================================================

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -513,9 +513,38 @@ func runCLIArgumentsTests() {
         try assertEqual(args.contextOutputReserve, 1024)
     }
 
-    test("APFEL_MCP env splits on colon separator") {
+    test("APFEL_MCP env splits on colon separator (legacy paths)") {
         let args = try CLIArguments.parse(["hi"], env: ["APFEL_MCP": "a.py:b.py"])
         try assertEqual(args.mcpServerPaths, ["a.py", "b.py"])
+    }
+
+    test("APFEL_MCP env single URL is not split") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_MCP": "https://mcp.example.com/mcp"])
+        try assertEqual(args.mcpServerPaths, ["https://mcp.example.com/mcp"])
+    }
+
+    test("APFEL_MCP env two colon-separated URLs are preserved as two entries") {
+        let args = try CLIArguments.parse(
+            ["hi"],
+            env: ["APFEL_MCP": "https://a.example.com/mcp:https://b.example.com/mcp"]
+        )
+        try assertEqual(args.mcpServerPaths, ["https://a.example.com/mcp", "https://b.example.com/mcp"])
+    }
+
+    test("APFEL_MCP env URL with port is not mangled") {
+        let args = try CLIArguments.parse(
+            ["hi"],
+            env: ["APFEL_MCP": "https://localhost:8080/mcp"]
+        )
+        try assertEqual(args.mcpServerPaths, ["https://localhost:8080/mcp"])
+    }
+
+    test("APFEL_MCP env comma separator works for mixed local and remote") {
+        let args = try CLIArguments.parse(
+            ["hi"],
+            env: ["APFEL_MCP": "/path/calc.py,https://remote.example.com/mcp"]
+        )
+        try assertEqual(args.mcpServerPaths, ["/path/calc.py", "https://remote.example.com/mcp"])
     }
 
     test("APFEL_MCP_TIMEOUT env sets mcpTimeoutSeconds") {

--- a/Tests/integration/mcp_remote_test.py
+++ b/Tests/integration/mcp_remote_test.py
@@ -1,0 +1,265 @@
+"""
+apfel Integration Tests -- Remote MCP server (Streamable HTTP transport)
+
+Validates that apfel --serve can connect to a remote MCP server over HTTP and
+auto-execute tool calls, returning the final text answer to the client.
+
+All infrastructure (HTTP MCP server + apfel --serve instance) is started by
+pytest fixtures using random ports so this file can run in parallel with the
+other integration tests and does not conflict with ports 11434/11435.
+
+Requires: pip install pytest httpx
+Requires: .build/release/apfel binary (run `swift build -c release` first)
+
+Run: python3 -m pytest Tests/integration/mcp_remote_test.py -v
+"""
+
+import contextlib
+import json
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BINARY = ROOT / ".build" / "release" / "apfel"
+HTTP_MCP_SERVER = ROOT / "mcp" / "http-test-server" / "server.py"
+
+MODEL = "apple-foundationmodel"
+TIMEOUT = 90
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_http(url: str, timeout: int = 20) -> bool:
+    """Poll url until it returns HTTP 200 or timeout expires. Returns True on success."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            resp = httpx.get(url, timeout=1)
+            if resp.status_code == 200:
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.25)
+    return False
+
+
+@contextlib.contextmanager
+def _popen(*cmd, **kwargs):
+    """Context manager that starts a subprocess and terminates it on exit."""
+    proc = subprocess.Popen(list(cmd), **kwargs)
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+# ============================================================================
+# Session-scoped fixtures: start the HTTP MCP server and apfel --serve once
+# per test session, shared by all tests in this file.
+# ============================================================================
+
+@pytest.fixture(scope="module")
+def http_mcp_server_url():
+    """Start the HTTP calculator MCP server on a random port."""
+    if not BINARY.exists():
+        pytest.skip(f"apfel binary not found at {BINARY}")
+    if not HTTP_MCP_SERVER.exists():
+        pytest.skip(f"HTTP MCP server not found at {HTTP_MCP_SERVER}")
+
+    port = find_free_port()
+    url = f"http://127.0.0.1:{port}/mcp"
+
+    with _popen(
+        sys.executable, str(HTTP_MCP_SERVER), "--port", str(port),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ):
+        # Wait for the MCP server HTTP port to accept connections
+        deadline = time.time() + 10
+        ready = False
+        while time.time() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                if s.connect_ex(("127.0.0.1", port)) == 0:
+                    ready = True
+                    break
+            time.sleep(0.2)
+        if not ready:
+            pytest.skip("HTTP MCP server did not start in time")
+        yield url
+
+
+@pytest.fixture(scope="module")
+def apfel_remote_mcp_url(http_mcp_server_url):
+    """Start apfel --serve pointed at the HTTP MCP server on a random port."""
+    apfel_port = find_free_port()
+    base = f"http://127.0.0.1:{apfel_port}"
+
+    with _popen(
+        str(BINARY), "--serve",
+        "--port", str(apfel_port),
+        "--mcp", http_mcp_server_url,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ):
+        if not wait_for_http(f"{base}/health", timeout=20):
+            pytest.skip("apfel --serve with remote MCP did not become healthy in time")
+        yield f"{base}/v1"
+
+
+# ============================================================================
+# Fixtures: make one LLM call, share the response across related tests
+# ============================================================================
+
+@pytest.fixture(scope="module")
+def remote_multiply_response(apfel_remote_mcp_url):
+    """Non-streaming multiply via remote HTTP MCP -- shared across result tests."""
+    resp = httpx.post(
+        f"{apfel_remote_mcp_url}/chat/completions",
+        json={
+            "model": MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Use the multiply tool to compute 247 times 83. "
+                        "Reply with just the number."
+                    ),
+                }
+            ],
+            "seed": 42,
+        },
+        timeout=TIMEOUT,
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text}"
+    return resp.json()
+
+
+@pytest.fixture(scope="module")
+def remote_add_response(apfel_remote_mcp_url):
+    """Non-streaming add via remote HTTP MCP -- shared across result tests."""
+    resp = httpx.post(
+        f"{apfel_remote_mcp_url}/chat/completions",
+        json={
+            "model": MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Use the add tool to add 100 and 200. "
+                        "Reply with just the number."
+                    ),
+                }
+            ],
+            "seed": 42,
+        },
+        timeout=TIMEOUT,
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text}"
+    return resp.json()
+
+
+# ============================================================================
+# Prerequisites
+# ============================================================================
+
+def test_remote_mcp_apfel_healthy(apfel_remote_mcp_url):
+    """apfel --serve with remote MCP must report healthy with model available."""
+    base = apfel_remote_mcp_url.rsplit("/v1", 1)[0]
+    resp = httpx.get(f"{base}/health", timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["model_available"] is True, f"Model not available: {data}"
+
+
+def test_remote_mcp_tools_visible(apfel_remote_mcp_url):
+    """Calculator tools from the remote MCP server must appear in /v1/models... 
+    
+    We check indirectly via a /v1/chat/completions call with tool_choice=none
+    and a system prompt that asks what tools are available, since /v1/models
+    does not expose tool lists. A simpler proxy: just verify the server is
+    running and healthy (prerequisite for all subsequent tests).
+    """
+    resp = httpx.get(f"{apfel_remote_mcp_url}/models", timeout=10)
+    assert resp.status_code == 200
+
+
+# ============================================================================
+# Core: remote MCP tool auto-execution
+# ============================================================================
+
+def test_remote_mcp_multiply_auto_execute(remote_multiply_response):
+    """Server auto-executes remote MCP tool call and returns final text answer.
+
+    finish_reason must be 'stop' (not 'tool_calls') proving apfel ran the
+    tool, got the result, and completed the generation.
+    """
+    data = remote_multiply_response
+    choice = data["choices"][0]
+    assert choice["finish_reason"] == "stop", (
+        f"Expected 'stop' but got '{choice['finish_reason']}' -- "
+        f"server may not have auto-executed the remote tool"
+    )
+    content = choice["message"]["content"]
+    assert content is not None, "Response content is None"
+    assert '"tool_calls"' not in content, (
+        f"Response leaked raw tool_calls JSON (tool was not executed): {content[:200]}"
+    )
+
+
+def test_remote_mcp_multiply_correct_result(remote_multiply_response):
+    """247 * 83 = 20501 must appear in the response."""
+    content = remote_multiply_response["choices"][0]["message"]["content"]
+    assert content is not None
+    assert "20501" in content or "20,501" in content, (
+        f"Expected '20501' in response but got: {content}"
+    )
+
+
+def test_remote_mcp_add_auto_execute(remote_add_response):
+    """Remote MCP add tool returns 300 for 100+200."""
+    data = remote_add_response
+    choice = data["choices"][0]
+    assert choice["finish_reason"] == "stop", (
+        f"Expected 'stop' but got '{choice['finish_reason']}'"
+    )
+    content = choice["message"]["content"]
+    assert content is not None
+    assert '"tool_calls"' not in content, (
+        f"Response leaked raw tool_calls JSON: {content[:200]}"
+    )
+    assert "300" in content, f"Expected '300' in response but got: {content}"
+
+
+# ============================================================================
+# Response structure
+# ============================================================================
+
+def test_remote_mcp_response_has_id(remote_multiply_response):
+    """Response from remote MCP flow has a non-empty id field."""
+    assert remote_multiply_response.get("id"), "Response missing 'id'"
+
+
+def test_remote_mcp_response_has_usage(remote_multiply_response):
+    """Response from remote MCP flow includes token usage."""
+    usage = remote_multiply_response.get("usage", {})
+    assert usage.get("total_tokens", 0) > 0, f"Missing or zero usage: {usage}"

--- a/mcp/http-test-server/server.py
+++ b/mcp/http-test-server/server.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+apfel-calc-http - MCP calculator server over Streamable HTTP transport
+
+Same tools as mcp/calculator/server.py but served over HTTP instead of stdio.
+Useful for testing apfel's remote MCP support.
+
+Transport: Streamable HTTP (MCP spec 2025-03-26)
+Protocol: MCP 2025-06-18
+
+Usage:
+    python3 mcp/http-test-server/server.py [--port 8765] [--token mytoken]
+
+Then test with:
+    apfel --mcp http://localhost:8765/mcp "what is 247 multiplied by 83?"
+    apfel --mcp http://localhost:8765/mcp --mcp-token mytoken "what is sqrt of 144?"
+"""
+
+import argparse
+import json
+import math
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PROTOCOL_VERSION = "2025-06-18"
+SERVER_NAME = "apfel-calc-http"
+SERVER_VERSION = "1.0.0"
+
+NUM_SCHEMA = {"type": "number"}
+
+TOOLS = [
+    {
+        "name": "add",
+        "description": "Add two numbers. Example: add(a=10, b=3) returns 13",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"]
+        }
+    },
+    {
+        "name": "subtract",
+        "description": "Subtract b from a. Example: subtract(a=10, b=3) returns 7",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"]
+        }
+    },
+    {
+        "name": "multiply",
+        "description": "Multiply two numbers. Example: multiply(a=247, b=83) returns 20501",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"]
+        }
+    },
+    {
+        "name": "divide",
+        "description": "Divide a by b. Example: divide(a=10, b=3) returns 3.3333",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"]
+        }
+    },
+    {
+        "name": "sqrt",
+        "description": "Square root of a number. Example: sqrt(a=144) returns 12",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA},
+            "required": ["a"]
+        }
+    },
+    {
+        "name": "power",
+        "description": "Raise a to the power of b. Example: power(a=2, b=10) returns 1024",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"]
+        }
+    },
+    {
+        "name": "round_number",
+        "description": "Round a number to n decimal places. Example: round_number(a=3.14159, decimals=2) returns 3.14",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "decimals": {"type": "integer"}},
+            "required": ["a"]
+        }
+    },
+]
+
+
+def get_nums(args):
+    """Extract numbers from whatever keys the model used."""
+    nums = []
+    for v in args.values():
+        if isinstance(v, (int, float)):
+            nums.append(v)
+        elif isinstance(v, str):
+            try:
+                nums.append(float(v) if "." in v else int(v))
+            except ValueError:
+                pass
+        elif isinstance(v, list):
+            for item in v:
+                if isinstance(item, (int, float)):
+                    nums.append(item)
+    return nums
+
+
+def to_num(v):
+    """Convert a value to int or float if it is a numeric string."""
+    if isinstance(v, (int, float)):
+        return v
+    if isinstance(v, str):
+        try:
+            return float(v) if "." in v else int(v)
+        except ValueError:
+            pass
+    return v
+
+
+def execute(name, args):
+    """Execute a tool by name. Tolerates improvised argument keys."""
+    nums = get_nums(args)
+    a = to_num(args.get("a", nums[0] if nums else 0))
+    b = to_num(args.get("b", nums[1] if len(nums) > 1 else 0))
+
+    try:
+        if name == "add":
+            r = a + b
+        elif name == "subtract":
+            r = a - b
+        elif name == "multiply":
+            r = a * b
+        elif name == "divide":
+            if b == 0:
+                return "Error: division by zero"
+            r = a / b
+        elif name == "sqrt":
+            r = math.sqrt(a)
+        elif name == "power":
+            r = a ** b
+        elif name == "round_number":
+            decimals = int(args.get("decimals", args.get("n", nums[1] if len(nums) > 1 else 0)))
+            r = round(a, decimals)
+        else:
+            return f"Error: unknown tool '{name}'"
+
+        if isinstance(r, float) and r == int(r) and not math.isinf(r):
+            r = int(r)
+        return str(r)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def handle_request(body: dict) -> tuple[dict | None, int]:
+    """Returns (response_body, http_status)."""
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params", {})
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION}
+            }
+        }, 200
+
+    if method == "notifications/initialized":
+        return None, 202
+
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {}}, 200
+
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}, 200
+
+    if method == "tools/call":
+        name = params.get("name", "")
+        args = params.get("arguments", {})
+        tool_names = {t["name"] for t in TOOLS}
+        if name in tool_names:
+            result = execute(name, args)
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "content": [{"type": "text", "text": result}],
+                    "isError": result.startswith("Error:")
+                }
+            }, 200
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32602, "message": f"Unknown tool: {name}"}
+        }, 200
+
+    if req_id is not None:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Method not found: {method}"}
+        }, 200
+
+    return None, 202
+
+
+def make_handler(token: str | None, path: str):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            print(f"  {self.address_string()} {format % args}", file=sys.stderr)
+
+        def do_POST(self):
+            if self.path != path:
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            if token:
+                auth = self.headers.get("Authorization", "")
+                if auth != f"Bearer {token}":
+                    self.send_response(401)
+                    self.end_headers()
+                    self.wfile.write(b'{"error":"unauthorized"}')
+                    return
+
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length)
+            try:
+                body = json.loads(raw)
+            except json.JSONDecodeError:
+                self.send_response(400)
+                self.end_headers()
+                return
+
+            response, status = handle_request(body)
+
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            if response is not None:
+                self.wfile.write(json.dumps(response).encode())
+
+        def do_DELETE(self):
+            self.send_response(200)
+            self.end_headers()
+
+    return Handler
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MCP calculator server (HTTP transport)")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--token", type=str, default=None, help="Required Bearer token (optional)")
+    args = parser.parse_args()
+
+    endpoint = "/mcp"
+    print(f"apfel-calc-http running on http://localhost:{args.port}{endpoint}")
+    if args.token:
+        print(f"Auth: Bearer {args.token}")
+    print(f"Tools: {', '.join(t['name'] for t in TOOLS)}")
+    print()
+
+    server = HTTPServer(("localhost", args.port), make_handler(args.token, endpoint))
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/http-test-server/test_round_trip.py
+++ b/mcp/http-test-server/test_round_trip.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Full tool-calling round trip: apfel --serve + HTTP MCP calculator.
+
+Mirrors mcp/calculator/test_round_trip.py but uses the HTTP MCP server
+instead of the stdio calculator. The apfel server auto-executes MCP tools
+internally, so a single /v1/chat/completions request returns the final answer.
+
+Prerequisites:
+    pip install httpx
+
+Usage:
+    # Terminal 1: start the HTTP calc server
+    python3 mcp/http-test-server/server.py [--port 8765] [--token TOKEN]
+
+    # Terminal 2: start the apfel server with the HTTP MCP server attached
+    apfel --serve --port 11436 --mcp http://localhost:8765/mcp [--mcp-token TOKEN]
+
+    # Terminal 3: run this test
+    python3 mcp/http-test-server/test_round_trip.py [apfel_port] [question]
+"""
+
+import re
+import sys
+import time
+
+import httpx
+
+APFEL_PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 11436
+QUESTION   = sys.argv[2] if len(sys.argv) > 2 else "What is 247 times 83?"
+
+BASE = f"http://localhost:{APFEL_PORT}"
+API  = f"{BASE}/v1"
+TIMEOUT = 120
+
+
+def wait_for_server(base_url: str, timeout: int = 20) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=1)
+            if resp.status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.5)
+    raise TimeoutError(f"apfel server not ready at {base_url}")
+
+
+def main():
+    print(f"apfel server: {BASE}")
+    print(f"Question:     {QUESTION}")
+    print()
+
+    wait_for_server(BASE)
+
+    # Single request — apfel auto-executes MCP tools and returns the final answer
+    resp = httpx.post(f"{API}/chat/completions", json={
+        "model": "apple-foundationmodel",
+        "messages": [{"role": "user", "content": QUESTION}],
+    }, timeout=TIMEOUT)
+    resp.raise_for_status()
+    data = resp.json()
+
+    choice = data["choices"][0]
+    finish = choice["finish_reason"]
+    answer = choice["message"].get("content", "")
+
+    print(f"finish_reason: {finish}")
+    print(f"Answer: {answer}")
+    print()
+
+    if '"tool_calls"' in answer:
+        print("FAIL: answer is a raw tool_calls blob - tool was not executed.")
+        sys.exit(1)
+
+    if not answer.strip():
+        print("FAIL: empty answer.")
+        sys.exit(1)
+
+    if not re.search(r"\d", answer):
+        print("WARNING: answer contains no digits - tool may not have executed.")
+        sys.exit(1)
+
+    print("Round trip complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Extends `--mcp` to accept `http(s)://` URLs in addition to local paths; local stdio servers are unaffected
- Remote servers connect via the MCP Streamable HTTP transport (spec 2025-03-26)
- New `--mcp-token <token>` flag and `APFEL_MCP_TOKEN` env var adds `Authorization: Bearer` for remote servers
- Adds `mcp/http-test-server/` — an HTTP equivalent of the stdio calculator server for local testing, plus a round-trip test script