### PR TITLE
README: add apfel-mcp to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ apfel works with any tool that speaks the OpenAI API. Verified configs:
 - [apfel-chat](https://github.com/Arthur-Ficial/apfel-chat) - Multi-conversation macOS chat client. Private, on-device, no API keys. Streaming markdown, speech I/O, image analysis. Install: `brew install Arthur-Ficial/tap/apfel-chat`
 - [apfel-clip](https://github.com/Arthur-Ficial/apfel-clip) - AI clipboard actions from the menu bar
 - [apfel-gui](https://github.com/Arthur-Ficial/apfel-gui) - Native macOS debug GUI (inspector, MCP viewer, TTS/STT)
+- [apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) - Three token-budget-optimized MCP servers (url-fetch, ddg-search, compound search+fetch) tuned for apfel's 4096-token context window. Install: `brew install Arthur-Ficial/tap/apfel-mcp`
 
 ## Community Projects
 


### PR DESCRIPTION
## Summary

Adds a one-line link to the new [apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) repo under the existing **Related Projects** section, right after apfel-gui.

apfel-mcp ships three Homebrew-installable MCP servers optimized for apfel's 4096-token context window:

- **apfel-mcp-url-fetch** - URL fetch + Readability extraction, SSRF guards, 6000-char hard cap
- **apfel-mcp-ddg-search** - DuckDuckGo web search (HTML-scrape based, no API key), 2000-char hard cap
- **apfel-mcp-search-and-fetch** - compound tool (search + fetch top N pages in ONE tool call, saves ~500 tokens of schema/state overhead vs chaining separately). Declared under both `search` and `web_search` so the 3B model's hallucinated tool names still route correctly.

Install: `brew install Arthur-Ficial/tap/apfel-mcp` - published on `Arthur-Ficial/homebrew-tap`.

## Test plan

- [x] Live-verified all three MCPs against real network (Wikipedia, apple.com, github.com, DuckDuckGo)
- [x] End-to-end through `apfel --mcp $(which apfel-mcp-search-and-fetch) "use the search tool to find what macos tahoe is"` - 3B model produced an accurate multi-source summary via one compound call
- [x] 136 tests passing (unit + subprocess stdio integration)
- [x] `brew install --build-from-source` succeeds on macOS 26 Tahoe arm64
- [x] `brew test arthur-ficial/tap/apfel-mcp` passes

Docs-only PR - no code change to apfel itself.