### PR TITLE
docs: link to apfel-mcp.franzai.com from MCP section and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,32 @@
 [![100% On-Device](https://img.shields.io/badge/inference-100%25%20on--device-green)](https://developer.apple.com/documentation/foundationmodels)
 [![Website](https://img.shields.io/badge/web-apfel.franzai.com-16A34A)](https://apfel.franzai.com)
 
-Use the **FREE** local Apple Intelligence LLM on your Mac - your model, your machine, your way.
+Use the free local Apple Intelligence LLM on your Mac as a UNIX tool, an OpenAI-compatible server, and a command-line chat client. No API keys, no cloud, no subscriptions, no per-token billing.
 
-No API keys. No cloud. No subscriptions. No per-token billing. The AI is already on your computer - apfel lets you use it.
+## What It Is
 
-## What is this
+Every Apple Silicon Mac with Apple Intelligence includes Apple's on-device foundation model. `apfel` exposes it through [https://developer.apple.com/documentation/foundationmodels](https://developer.apple.com/documentation/foundationmodels) so you can use it directly from the shell and from OpenAI-compatible clients.
 
-Every Mac with Apple Silicon has a **built-in LLM** - Apple's on-device foundation model, shipped as part of Apple Intelligence. Apple provides the [FoundationModels framework](https://developer.apple.com/documentation/foundationmodels) (macOS 26+) to access it, but only exposes it through Siri and system features. **apfel wraps it** in a CLI and an HTTP server - so you can actually use it.
+| Mode | Command | What you get |
+|------|---------|--------------|
+| UNIX tool | `apfel "prompt"` / `echo "text" \| apfel` | Pipe-friendly answers, file attachments, JSON output, exit codes |
+| OpenAI-compatible server | `apfel --serve` | Drop-in local `http://localhost:11434/v1` backend for OpenAI SDKs |
+| Command-line chat | `apfel --chat` | Multi-turn chat with context-window management |
 
-- **UNIX tool** - `echo "summarize this" | apfel` - pipe-friendly, file attachments, JSON output, exit codes
-- **Interactive chat** - `apfel --chat` - multi-turn conversation with context window management
-- **OpenAI-compatible server** - `apfel --serve` - drop-in replacement at `localhost:11434`, works with any OpenAI SDK
-- **Tool calling** - function calling with schema conversion, full round-trip support
-- **Zero cost** - no API keys, no cloud, no subscriptions, 4096-token context window
-- **GUI apps** - chat client [apfel-chat](https://apfel-chat.franzai.com) ([gh](https://github.com/Arthur-Ficial/apfel-chat)), clipboard actions [apfel-clip](https://apfel-clip.franzai.com) ([gh](https://github.com/Arthur-Ficial/apfel-clip)), debug inspector [apfel-gui](https://github.com/Arthur-Ficial/apfel-gui) ([gh](https://github.com/Arthur-Ficial/apfel-gui))
+Tool calling works across CLI, chat, and server. Inference stays 100% on-device. The context window is 4096 tokens.
 
 ![apfel CLI](screenshots/cli.png)
 
 ## Requirements & Install
 
-- **macOS 26 Tahoe or newer**, Apple Silicon (M1+), [Apple Intelligence enabled](https://support.apple.com/en-us/121115). Older macOS is not supported - Apple's FoundationModels framework does not exist before macOS 26.
-- Building from source requires Command Line Tools with macOS 26.4 SDK (ships Swift 6.3). No Xcode required.
+- **macOS 26 Tahoe or newer**, Apple Silicon (M1+), and Apple Intelligence enabled: [https://support.apple.com/en-us/121115](https://support.apple.com/en-us/121115)
+- Building from source requires Command Line Tools with the macOS 26.4 SDK (Swift 6.3). No Xcode required.
 
 **Homebrew** (recommended):
 
 ```bash
 brew tap Arthur-Ficial/tap
 brew install apfel
-brew upgrade apfel
-```
-
-**Update:**
-
-```bash
 brew upgrade apfel
 ```
 
@@ -52,65 +45,41 @@ cd apfel
 make install
 ```
 
-Troubleshooting: [docs/install.md](docs/install.md)
+Update with `brew upgrade apfel` or `apfel --update`.
+
+Troubleshooting, alternative install methods, and Apple Intelligence setup notes: [docs/install.md](docs/install.md)
 
 ## Quick Start
 
 ### UNIX tool
 
-Shell note: if your prompt contains `!`, prefer single quotes in `zsh`/`bash` so history expansion does not break copy-paste. Example: `apfel 'Hello, Mac!'`
+Shell note: if your prompt contains `!`, prefer single quotes in `zsh` or `bash` so history expansion does not break copy-paste.
 
 ```bash
-# Single prompt
 apfel "What is the capital of Austria?"
-
-# Permissive mode -- reduces guardrail false positives for creative/long prompts
 apfel --permissive "Write a dramatic opening for a thriller novel"
-
-# Stream output
 apfel --stream "Write a haiku about code"
-
-# Pipe input
 echo "Summarize: $(cat README.md)" | apfel
-
-# Attach file content to prompt
 apfel -f README.md "Summarize this project"
-
-# Attach multiple files
 apfel -f old.swift -f new.swift "What changed between these two files?"
-
-# Combine files with piped input
-git diff HEAD~1 | apfel -f CONVENTIONS.md "Review this diff against our conventions"
-
-# JSON output for scripting
 apfel -o json "Translate to German: hello" | jq .content
-
-# System prompt
 apfel -s "You are a pirate" "What is recursion?"
-
-# System prompt from file
-apfel --system-file persona.txt "Explain TCP/IP"
-
-# Quiet mode for shell scripts
-result=$(apfel -q "Capital of France? One word.")
 ```
+
+More on `--system-file`, quiet mode, retries, exit codes, and environment variables: [docs/cli-reference.md](docs/cli-reference.md)
 
 ### OpenAI-compatible server
 
 ```bash
-apfel --serve                              # foreground
-brew services start apfel                  # background (like Ollama)
+apfel --serve
+brew services start apfel
 ```
-
-Then in another terminal:
 
 ```bash
 curl http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"apple-foundationmodel","messages":[{"role":"user","content":"Hello"}]}'
 ```
-
-Works with the official Python client:
 
 ```python
 from openai import OpenAI
@@ -123,190 +92,40 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-Run in background (auto-restarts, starts at login - [docs/background-service.md](docs/background-service.md)):
+Background operation, service configuration, and security settings: [docs/background-service.md](docs/background-service.md), [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md), [docs/server-security.md](docs/server-security.md)
 
-```bash
-brew services start apfel
-brew services stop apfel
-APFEL_TOKEN=$(uuidgen) APFEL_MCP=/path/to/tools.py brew services start apfel
-```
-
-### Interactive chat
+### Command-line chat
 
 ```bash
 apfel --chat
 apfel --chat -s "You are a helpful coding assistant"
-apfel --chat --mcp ./mcp/calculator/server.py      # chat with MCP tools
-apfel --chat --debug                                # debug output to stderr
+apfel --chat --mcp ./mcp/calculator/server.py
+apfel --chat --debug
 ```
 
-Ctrl-C exits cleanly. Context window is managed automatically with configurable strategies: [docs/context-strategies.md](docs/context-strategies.md).
-
-### Updating
-
-```bash
-apfel --update
-```
-
-Or directly via Homebrew: `brew upgrade apfel`
-
-### Benchmarking
-
-Measure internal overhead on the installed release binary:
-
-```bash
-apfel --benchmark -o json
-make benchmark
-```
-
-### File attachments (`-f/--file`)
-
-Attach files to any prompt with `-f` (repeatable). Contents are prepended to your prompt.
-
-```bash
-apfel -f main.swift "Explain what this code does"
-apfel -f before.txt -f after.txt "What are the differences?"
-git diff HEAD~1 | apfel -f style-guide.md "Any style violations in this diff?"
-apfel -f data.csv -o json "Extract the top 5 rows" | jq .content
-```
-
-Files, stdin, and prompt arguments all compose:
-
-```bash
-apfel -f poem.txt                                    # file only
-apfel -f poem.txt "Translate this to German"          # file + prompt
-echo "some text" | apfel "Summarize this"             # stdin + prompt
-echo "ctx" | apfel -f code.swift "Explain with context" # all three
-```
-
-## Demos
-
-See [`demo/`](./demo/) for real-world shell scripts powered by apfel.
-
-**[cmd](./demo/cmd)** - natural language to shell command:
-
-```bash
-demo/cmd "find all .log files modified today"
-# $ find . -name "*.log" -type f -mtime -1
-
-demo/cmd -x "show disk usage sorted by size"   # -x = execute after confirm
-demo/cmd -c "list open ports"                   # -c = copy to clipboard
-```
-
-**Shell function version** - add to your `.zshrc` and use `cmd` from anywhere:
-
-```bash
-# cmd - natural language to shell command (apfel). Add to .zshrc:
-cmd(){ local x c r a; while [[ $1 == -* ]]; do case $1 in -x)x=1;shift;; -c)c=1;shift;; *)break;; esac; done; r=$(apfel -q -s 'Output only a shell command.' "$*" | sed '/^```/d;/^#/d;s/\x1b\[[0-9;]*[a-zA-Z]//g;s/^[[:space:]]*//;/^$/d' | head -1); [[ $r ]] || { echo "no command generated"; return 1; }; printf '\e[32m$\e[0m %s\n' "$r"; [[ $c ]] && printf %s "$r" | pbcopy && echo "(copied)"; [[ $x ]] && { printf 'Run? [y/N] '; read -r a; [[ $a == y ]] && eval "$r"; }; return 0; }
-```
-
-```bash
-cmd find all swift files larger than 1MB     # shows: $ find . -name "*.swift" -size +1M
-cmd -c show disk usage sorted by size        # shows command + copies to clipboard
-cmd -x what process is using port 3000       # shows command + asks to run it
-cmd list all git branches merged into main
-cmd count lines of code by language
-```
-
-**[oneliner](./demo/oneliner)** - complex pipe chains from plain English:
-
-```bash
-demo/oneliner "sum the third column of a CSV"
-# $ awk -F',' '{sum += $3} END {print sum}' file.csv
-
-demo/oneliner "count unique IPs in access.log"
-# $ awk '{print $1}' access.log | sort | uniq -c | sort -rn
-```
-
-**[mac-narrator](./demo/mac-narrator)** - your Mac's inner monologue:
-
-```bash
-demo/mac-narrator              # one-shot: what's happening right now?
-demo/mac-narrator --watch      # continuous narration every 60s
-```
-
-Also in `demo/`:
-- **[wtd](./demo/wtd)** - "what's this directory?" - instant project orientation
-- **[explain](./demo/explain)** - explain a command, error, or code snippet
-- **[naming](./demo/naming)** - naming suggestions for functions, variables, files
-- **[port](./demo/port)** - what's using this port?
-- **[gitsum](./demo/gitsum)** - summarize recent git activity
-
-### Debug GUI
-
-```bash
-brew install Arthur-Ficial/tap/apfel-gui
-```
-
-![apfel GUI](screenshots/gui-chat.png)
-
-Native SwiftUI debug inspector with request timeline, MCP protocol viewer, chat, TTS/STT - all on-device. **[apfel-gui repo ->](https://github.com/Arthur-Ficial/apfel-gui)**
+Ctrl-C exits cleanly. Context rotation, history trimming, and output reserves: [docs/context-strategies.md](docs/context-strategies.md)
 
 ## MCP Tool Support
 
-Attach [MCP](https://modelcontextprotocol.io/) tool servers with `--mcp`. apfel discovers tools, executes them automatically, and returns the final answer. No glue code needed.
+Attach [https://modelcontextprotocol.io/](https://modelcontextprotocol.io/) servers with `--mcp`. `apfel` discovers tools, executes them automatically, and returns the final answer.
 
 ```bash
 apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
+apfel --mcp ./server_a.py --mcp ./server_b.py "Use both tools"
+apfel --serve --mcp ./mcp/calculator/server.py
 ```
 
-```
-mcp: ./mcp/calculator/server.py - add, subtract, multiply, divide, sqrt, power    ← stderr
-tool: multiply({"a": 15, "b": 27}) = 405                                          ← stderr
-15 times 27 is 405.                                                                ← stdout
-```
-
-Tool info goes to stderr; only the answer goes to stdout. Use `-q` to suppress tool info.
-
-```bash
-apfel --mcp ./server_a.py --mcp ./server_b.py "Use both tools"  # multiple servers
-apfel --serve --mcp ./mcp/calculator/server.py                   # server mode
-apfel --chat --mcp ./mcp/calculator/server.py                    # chat mode
-```
-
-Ships with a calculator MCP server at `mcp/calculator/`. See [docs/mcp-calculator.md](docs/mcp-calculator.md) for details.
-
-**Remote MCP servers** (Streamable HTTP transport, MCP spec 2025-03-26):
-
-```bash
-# Remote MCP server over HTTPS
-apfel --mcp https://mcp.example.com/v1 "what tools do you have?"
-
-# With bearer token auth - prefer the env var (flag is visible in ps aux)
-APFEL_MCP_TOKEN=mytoken apfel --mcp https://mcp.example.com/v1 "..."
-apfel --mcp https://mcp.example.com/v1 --mcp-token mytoken "..."
-
-# Mixed local + remote
-apfel --mcp /path/to/local.py --mcp https://remote.example.com/v1 "..."
-```
-
-> **Security:** Use `APFEL_MCP_TOKEN` env var rather than `--mcp-token` — CLI flags are visible in `ps aux`. apfel refuses to send a bearer token over plaintext `http://` (use `https://`).
+`mcp/calculator/` ships with the repo. Remote `https://` MCP servers, bearer-token handling, timeout tuning, server-mode auto-execution, and protocol details live in [docs/mcp-calculator.md](docs/mcp-calculator.md) and [docs/tool-calling-guide.md](docs/tool-calling-guide.md).
 
 ## OpenAI API Compatibility
 
-**Base URL:** `http://localhost:11434/v1`
+`apfel` exposes `http://localhost:11434/v1` with `POST /v1/chat/completions`, `GET /v1/models`, `GET /health`, streaming, tool calling, and `response_format: json_object`. Unsupported surfaces such as embeddings, legacy completions, and multimodal inputs return honest `501` or `400` errors. Full compatibility matrix: [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md)
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| `POST /v1/chat/completions` | Supported | Streaming + non-streaming |
-| `GET /v1/models` | Supported | Returns `apple-foundationmodel` |
-| `GET /health` | Supported | Model availability, context window, languages |
-| `GET /v1/logs`, `/v1/logs/stats` | Debug only | Requires `--debug` |
-| Tool calling | Supported | Native `ToolDefinition` + JSON detection. See [docs/tool-calling-guide.md](docs/tool-calling-guide.md) |
-| `response_format: json_object` | Supported | Via system prompt injection |
-| `temperature`, `max_tokens`, `seed` | Supported | Mapped to `GenerationOptions` |
-| `stream: true` | Supported | SSE with usage stats in final chunk |
-| `finish_reason` | Supported | `stop`, `tool_calls`, `length` |
-| Context strategies | Supported | `x_context_strategy`, `x_context_max_turns`, `x_context_output_reserve` extension fields |
-| CORS | Supported | Enable with `--cors` |
-| `POST /v1/completions` | 501 | Legacy text completions not supported |
-| `POST /v1/embeddings` | 501 | Embeddings not available on-device |
-| `logprobs=true`, `n>1`, `stop`, `presence_penalty`, `frequency_penalty` | 400 | Rejected explicitly. `n=1` and `logprobs=false` are accepted as no-ops |
-| Multi-modal (images) | 400 | Rejected with clear error |
-| `Authorization` header | Supported | Required when `--token` is set. See [docs/server-security.md](docs/server-security.md) |
+## Demos
 
-Full API spec: [openai/openai-openapi](https://github.com/openai/openai-openapi)
-
+- [docs/demos.md](docs/demos.md) - longer walkthroughs for `demo/cmd`, `demo/oneliner`, `demo/mac-narrator`, and the reusable `cmd()` shell function
+- [demo/README.md](demo/README.md) - quick overview of every shipped demo
+- [demo/wtd](demo/wtd), [demo/explain](demo/explain), [demo/naming](demo/naming), [demo/port](demo/port), and [demo/gitsum](demo/gitsum) cover project orientation, explanation, naming, port inspection, and git summaries
 
 ## Limitations
 
@@ -315,211 +134,26 @@ Full API spec: [openai/openai-openapi](https://github.com/openai/openai-openapi)
 | Context window | **4096 tokens** (input + output combined) |
 | Platform | macOS 26+, Apple Silicon only |
 | Model | One model (`apple-foundationmodel`), not configurable |
-| Guardrails | Apple's safety system may block benign prompts (use `--permissive` to reduce false positives). See [docs/PERMISSIVE.md](docs/PERMISSIVE.md) |
-| Speed | On-device, not cloud-scale - a few seconds per response |
+| Guardrails | Apple's safety system may block benign prompts. `--permissive` reduces false positives: [docs/PERMISSIVE.md](docs/PERMISSIVE.md) |
+| Speed | On-device, not cloud-scale |
 | No embeddings / vision | Not available on-device |
 
-## CLI Reference
+## Reference Docs
 
-```
-MODES
-  apfel <prompt>                          Single prompt (default)
-  apfel --stream <prompt>                 Stream response tokens
-  apfel --chat                            Interactive conversation
-  apfel --serve                           Start OpenAI-compatible server
-  apfel --benchmark                       Run internal performance benchmarks
-
-INPUT
-  apfel -f, --file <path> <prompt>        Attach file content (repeatable)
-  apfel -s, --system <text> <prompt>      Set system prompt
-  apfel --system-file <path> <prompt>     Read system prompt from file
-  apfel --mcp <path|url> <prompt>         Attach local or remote MCP tool server (repeatable)
-  apfel --mcp-token <token> <prompt>     Bearer token for remote MCP servers
-  apfel --mcp-timeout <n> <prompt>       MCP timeout in seconds [default: 5]
-
-OUTPUT
-  -o, --output <fmt>                      Output format: plain, json
-  -q, --quiet                             Suppress non-essential output
-  --no-color                              Disable ANSI colors
-
-MODEL
-  --temperature <n>                       Sampling temperature (e.g., 0.7)
-  --seed <n>                              Random seed for reproducibility
-  --max-tokens <n>                        Maximum response tokens
-  --permissive                            Relaxed guardrails (reduces false positives)
-  --retry [n]                             Retry transient errors with backoff (default: 3)
-  --debug                                 Enable debug logging to stderr (all modes)
-
-CONTEXT (--chat)
-  --context-strategy <s>                  newest-first, oldest-first, sliding-window, summarize, strict
-  --context-max-turns <n>                 Max history turns (sliding-window only)
-  --context-output-reserve <n>            Tokens reserved for output (default: 512)
-
-SERVER (--serve)
-  --port <n>                              Server port (default: 11434)
-  --host <addr>                           Bind address (default: 127.0.0.1)
-  --cors                                  Enable CORS headers
-  --allowed-origins <origins>             Comma-separated allowed origins
-  --no-origin-check                       Disable origin checking
-  --token <secret>                        Require Bearer token auth
-  --token-auto                            Generate random Bearer token
-  --public-health                         Keep /health unauthenticated
-  --footgun                               Disable all protections
-  --max-concurrent <n>                    Max concurrent requests (default: 5)
-
-META
-  -v, --version                           Print version
-  -h, --help                              Show help
-  --release                               Detailed build info
-  --model-info                            Print model capabilities
-  --update                                Check for updates via Homebrew
-```
-
-**Examples by flag:**
-
-```bash
-# -f, --file — attach file content to prompt (repeatable)
-apfel -f main.swift "Explain this code"
-apfel -f before.txt -f after.txt "What changed?"
-
-# -s, --system — set a system prompt
-apfel -s "You are a pirate" "What is recursion?"
-apfel -s "Reply in JSON only" "List 3 colors"
-
-# --system-file — read system prompt from a file
-apfel --system-file persona.txt "Introduce yourself"
-
-# --mcp — attach MCP tool servers (repeatable)
-apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
-apfel --mcp ./calc.py --mcp ./weather.py "Use both tools"
-
-# -f, --file
-apfel -f main.swift "Explain this code"
-apfel -f before.txt -f after.txt "What changed?"
-
-# -s, --system
-apfel -s "You are a pirate" "What is recursion?"
-
-# --system-file
-apfel --system-file persona.txt "Introduce yourself"
-
-# --mcp, --mcp-token, --mcp-timeout
-apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
-apfel --mcp ./calc.py --mcp ./weather.py "Use both tools"
-apfel --mcp https://mcp.example.com/v1 "Remote MCP server"
-APFEL_MCP_TOKEN=mytoken apfel --mcp https://mcp.example.com/v1 "With auth"
-apfel --mcp-timeout 30 --mcp ./slow-remote-server.py "hello"
-
-# -o, --output
-apfel -o json "Translate to German: hello" | jq .content
-
-# -q, --quiet
-apfel -q "Give me a UUID"
-
-# --no-color
-NO_COLOR=1 apfel "Hello"
-
-# --temperature
-apfel --temperature 0.0 "What is 2+2?"
-apfel --temperature 1.5 "Write a wild poem"
-
-# --seed
-apfel --seed 42 "Tell me a joke"
-
-# --max-tokens
-apfel --max-tokens 50 "Explain quantum computing"
-
-# --permissive — relaxed guardrails (see docs/PERMISSIVE.md for comparison)
-apfel --permissive "Write a villain monologue"
-apfel --permissive -f long-document.md "Summarize this"
-
-# --retry
-apfel --retry "What is 2+2?"
-
-# --debug
-apfel --debug "Hello world"
-
-# --stream
-apfel --stream "Write a haiku about code"
-
-# --chat
-apfel --chat
-apfel --chat -s "You are a helpful coding assistant"
-
-# --context-strategy
-apfel --chat --context-strategy newest-first      # default
-apfel --chat --context-strategy sliding-window --context-max-turns 6
-apfel --chat --context-strategy summarize          # compress old turns
-
-# --serve
-apfel --serve
-apfel --serve --port 3000 --host 0.0.0.0
-
-# --cors, --token, --footgun
-apfel --serve --cors
-apfel --serve --token "my-secret-token"
-apfel --serve --footgun   # only for local development!
-
-# --token-auto, --public-health
-apfel --serve --token-auto --host 0.0.0.0 --public-health
-
-# --allowed-origins, --no-origin-check
-apfel --serve --allowed-origins "https://myapp.com,https://staging.myapp.com"
-apfel --serve --no-origin-check
-
-# --max-concurrent
-apfel --serve --max-concurrent 2
-
-# --debug (server: also enables /v1/logs)
-apfel --serve --debug
-
-# --context-output-reserve
-apfel --chat --context-output-reserve 256
-
-# --benchmark, --model-info, --update, --release, --version, --help
-apfel --benchmark -o json | jq '.benchmarks[] | {name, speedup_ratio}'
-apfel --model-info
-apfel --update
-apfel --release
-apfel --version
-apfel --help
-```
-
-See [docs/server-security.md](docs/server-security.md) for detailed documentation on security options.
-
-### Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | Runtime error |
-| 2 | Usage error (bad flags) |
-| 3 | Guardrail blocked |
-| 4 | Context overflow |
-| 5 | Model unavailable |
-| 6 | Rate limited |
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `APFEL_SYSTEM_PROMPT` | Default system prompt |
-| `APFEL_HOST` | Server bind address |
-| `APFEL_PORT` | Server port |
-| `APFEL_TOKEN` | Bearer token for server authentication |
-| `APFEL_TEMPERATURE` | Default temperature |
-| `APFEL_MAX_TOKENS` | Default max tokens |
-| `APFEL_CONTEXT_STRATEGY` | Default context strategy |
-| `APFEL_CONTEXT_MAX_TURNS` | Max turns for sliding-window |
-| `APFEL_CONTEXT_OUTPUT_RESERVE` | Tokens reserved for output |
-| `APFEL_MCP` | MCP server paths — colon-separated for local paths, comma-separated for mixed local+remote URLs |
-| `APFEL_MCP_TOKEN` | Bearer token for remote HTTP MCP servers (preferred over `--mcp-token`; not visible in `ps aux`) |
-| `APFEL_MCP_TIMEOUT` | MCP timeout in seconds (default: 5, max: 300) |
-| `NO_COLOR` | Disable colors ([no-color.org](https://no-color.org)) |
+- [docs/install.md](docs/install.md) - install, troubleshooting, and Apple Intelligence setup
+- [docs/cli-reference.md](docs/cli-reference.md) - modes, flags, exit codes, and environment variables
+- [docs/background-service.md](docs/background-service.md) - `brew services` and launchd usage
+- [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md) - `/v1/*` support matrix
+- [docs/server-security.md](docs/server-security.md) - origin checks, CORS, tokens, and `--footgun`
+- [docs/context-strategies.md](docs/context-strategies.md) - chat trimming strategies
+- [docs/mcp-calculator.md](docs/mcp-calculator.md) - local and remote MCP usage
+- [docs/tool-calling-guide.md](docs/tool-calling-guide.md) - detailed tool-calling behavior
+- [docs/integrations.md](docs/integrations.md) - third-party tool integrations
+- [docs/EXAMPLES.md](docs/EXAMPLES.md) - 50+ real prompts with unedited output
 
 ## Architecture
 
-```
+```text
 CLI (single/stream/chat) ──┐
                            ├─→ FoundationModels.SystemLanguageModel
 HTTP Server (/v1/*) ───────┘   (100% on-device, zero network)
@@ -528,8 +162,7 @@ HTTP Server (/v1/*) ───────┘   (100% on-device, zero network)
                                 TokenCounter → real token counts (SDK 26.4)
 ```
 
-Swift 6.3 strict concurrency. Three targets: `ApfelCore` (pure logic, unit-testable), `apfel` (CLI + server), `apfel-tests` (pure Swift runner, no XCTest). **No Xcode required.**
-
+Swift 6.3 strict concurrency. Three targets: `ApfelCore` (pure logic, unit-testable), `apfel` (CLI + server), and `apfel-tests` (pure Swift runner, no XCTest).
 
 ## Build & Test
 
@@ -540,31 +173,29 @@ make version                             # print current version
 make release-minor                       # bump minor: 0.6.x -> 0.7.0
 swift build                              # quick debug build (no version bump)
 swift run apfel-tests                    # unit tests
-python3 -m pytest Tests/integration/ -v  # integration tests (auto-starts servers)
+python3 -m pytest Tests/integration/ -v  # integration tests
 apfel --benchmark -o json                # performance report
 ```
 
-Every `make build`/`make install` auto-bumps the patch version, updates the README badge, and generates build metadata (`.version` is the single source of truth).
+Every `make build` or `make install` auto-bumps the patch version, updates the README badge, and generates build metadata. `.version` is the single source of truth.
 
 ## Integrations
 
-apfel works with any tool that speaks the OpenAI API. Verified configs:
-
-- **opencode** - AI coding assistant with apfel as local backend. [docs/integrations.md](docs/integrations.md)
-- **Visual Studio Code + Continue** - local review/chat model paired with a hosted model for edit/apply. [docs/local-setup-with-vs-code.md](docs/local-setup-with-vs-code.md)
+- [docs/integrations.md](docs/integrations.md) - verified configs for tools such as opencode
+- [docs/local-setup-with-vs-code.md](docs/local-setup-with-vs-code.md) - local review with `apfel` plus a second edit/apply model in Visual Studio Code
 
 ## Related Projects
 
-- [apfel-chat](https://github.com/Arthur-Ficial/apfel-chat) - Multi-conversation macOS chat client. Private, on-device, no API keys. Streaming markdown, speech I/O, image analysis. Install: `brew install Arthur-Ficial/tap/apfel-chat`
-- [apfel-clip](https://github.com/Arthur-Ficial/apfel-clip) - AI clipboard actions from the menu bar
-- [apfel-gui](https://github.com/Arthur-Ficial/apfel-gui) - Native macOS debug GUI (inspector, MCP viewer, TTS/STT)
-- [apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) - Three token-budget-optimized MCP servers (url-fetch, ddg-search, compound search+fetch) tuned for apfel's 4096-token context window. Install: `brew install Arthur-Ficial/tap/apfel-mcp`
+- [https://apfel-chat.franzai.com](https://apfel-chat.franzai.com) and [https://github.com/Arthur-Ficial/apfel-chat](https://github.com/Arthur-Ficial/apfel-chat) - multi-conversation macOS chat client. Private, on-device, no API keys. Streaming markdown, speech I/O, image analysis. Install with `brew install Arthur-Ficial/tap/apfel-chat`
+- [https://apfel-clip.franzai.com](https://apfel-clip.franzai.com) and [https://github.com/Arthur-Ficial/apfel-clip](https://github.com/Arthur-Ficial/apfel-clip) - AI clipboard actions from the menu bar
+- [https://github.com/Arthur-Ficial/apfel-gui](https://github.com/Arthur-Ficial/apfel-gui) - native SwiftUI debug inspector with request timeline, MCP protocol viewer, chat, and TTS/STT. Install with `brew install Arthur-Ficial/tap/apfel-gui`
+- [https://github.com/Arthur-Ficial/apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) - token-budget-optimized MCP servers for apfel's 4096-token context window. Install with `brew install Arthur-Ficial/tap/apfel-mcp`
 
 ## Community Projects
 
-Things the community has built on top of apfel. Built something? Open an issue and we will add it.
+Built something on top of apfel? Open an issue and it can be added here.
 
-- [apfelclaw](https://apfelclaw.yamanlabs.com/) ([gh](https://github.com/julianyaman/apfelclaw)) by [@julianYaman](https://github.com/julianYaman) - Local AI agent that reads files, calendar, mail, and Mac status via read-only tools. Swift + Vapor backend, Bun TUI, optional Telegram remote.
+- [https://apfelclaw.yamanlabs.com/](https://apfelclaw.yamanlabs.com/), [https://github.com/julianyaman/apfelclaw](https://github.com/julianyaman/apfelclaw), by [https://github.com/julianYaman](https://github.com/julianYaman) - local AI agent that reads files, calendar, mail, and Mac status via read-only tools
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ apfel --serve --mcp ./mcp/calculator/server.py
 
 `mcp/calculator/` ships with the repo. Remote `https://` MCP servers, bearer-token handling, timeout tuning, server-mode auto-execution, and protocol details live in [docs/mcp-calculator.md](docs/mcp-calculator.md) and [docs/tool-calling-guide.md](docs/tool-calling-guide.md).
 
+**Want web search and URL fetching?** [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) ships three token-budget-optimized MCP servers for apfel's 4096-token context window: `url-fetch` (Readability article extraction with SSRF guards), `ddg-search` (DuckDuckGo web search, no API key), and `search-and-fetch` (the flagship compound tool - search AND fetch the top N pages in ONE tool call). Install with `brew install Arthur-Ficial/tap/apfel-mcp`. The repo is open for contributions of new apfel-optimized MCPs - ideas and rules at [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/#contribute).
+
 ## OpenAI API Compatibility
 
 `apfel` exposes `http://localhost:11434/v1` with `POST /v1/chat/completions`, `GET /v1/models`, `GET /health`, streaming, tool calling, and `response_format: json_object`. Unsupported surfaces such as embeddings, legacy completions, and multimodal inputs return honest `501` or `400` errors. Full compatibility matrix: [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,183 @@
+# CLI Reference
+
+`apfel` has four primary modes: single prompt, `--stream`, `--chat`, and `--serve`. This page is the full flag, exit-code, and environment reference for the installed CLI.
+
+## Modes
+
+```text
+MODES
+  apfel <prompt>                          Single prompt (default)
+  apfel --stream <prompt>                 Stream response tokens
+  apfel --chat                            Interactive conversation
+  apfel --serve                           Start OpenAI-compatible server
+  apfel --benchmark                       Run internal performance benchmarks
+
+INPUT
+  apfel -f, --file <path> <prompt>        Attach file content (repeatable)
+  apfel -s, --system <text> <prompt>      Set system prompt
+  apfel --system-file <path> <prompt>     Read system prompt from file
+  apfel --mcp <path|url> <prompt>         Attach local or remote MCP tool server (repeatable)
+  apfel --mcp-token <token> <prompt>      Bearer token for remote MCP servers
+  apfel --mcp-timeout <n> <prompt>        MCP timeout in seconds [default: 5]
+
+OUTPUT
+  -o, --output <fmt>                      Output format: plain, json
+  -q, --quiet                             Suppress non-essential output
+  --no-color                              Disable ANSI colors
+
+MODEL
+  --temperature <n>                       Sampling temperature (e.g., 0.7)
+  --seed <n>                              Random seed for reproducibility
+  --max-tokens <n>                        Maximum response tokens
+  --permissive                            Relaxed guardrails (reduces false positives)
+  --retry [n]                             Retry transient errors with backoff (default: 3)
+  --debug                                 Enable debug logging to stderr (all modes)
+
+CONTEXT (--chat)
+  --context-strategy <s>                  newest-first, oldest-first, sliding-window, summarize, strict
+  --context-max-turns <n>                 Max history turns (sliding-window only)
+  --context-output-reserve <n>            Tokens reserved for output (default: 512)
+
+SERVER (--serve)
+  --port <n>                              Server port (default: 11434)
+  --host <addr>                           Bind address (default: 127.0.0.1)
+  --cors                                  Enable CORS headers
+  --allowed-origins <origins>             Comma-separated allowed origins
+  --no-origin-check                       Disable origin checking
+  --token <secret>                        Require Bearer token auth
+  --token-auto                            Generate random Bearer token
+  --public-health                         Keep /health unauthenticated
+  --footgun                               Disable all protections
+  --max-concurrent <n>                    Max concurrent requests (default: 5)
+
+META
+  -v, --version                           Print version
+  -h, --help                              Show help
+  --release                               Detailed build info
+  --model-info                            Print model capabilities
+  --update                                Check for updates via Homebrew
+```
+
+## Examples By Flag
+
+```bash
+# -f, --file — attach file content to prompt (repeatable)
+apfel -f main.swift "Explain this code"
+apfel -f before.txt -f after.txt "What changed?"
+
+# -s, --system — set a system prompt
+apfel -s "You are a pirate" "What is recursion?"
+apfel -s "Reply in JSON only" "List 3 colors"
+
+# --system-file — read system prompt from a file
+apfel --system-file persona.txt "Introduce yourself"
+
+# --mcp, --mcp-token, --mcp-timeout
+apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
+apfel --mcp ./calc.py --mcp ./weather.py "Use both tools"
+apfel --mcp https://mcp.example.com/v1 "Remote MCP server"
+APFEL_MCP_TOKEN=mytoken apfel --mcp https://mcp.example.com/v1 "With auth"
+apfel --mcp-timeout 30 --mcp ./slow-remote-server.py "hello"
+
+# -o, --output
+apfel -o json "Translate to German: hello" | jq .content
+
+# -q, --quiet
+apfel -q "Give me a UUID"
+
+# --no-color
+NO_COLOR=1 apfel "Hello"
+
+# --temperature
+apfel --temperature 0.0 "What is 2+2?"
+apfel --temperature 1.5 "Write a wild poem"
+
+# --seed
+apfel --seed 42 "Tell me a joke"
+
+# --max-tokens
+apfel --max-tokens 50 "Explain quantum computing"
+
+# --permissive
+apfel --permissive "Write a villain monologue"
+apfel --permissive -f long-document.md "Summarize this"
+
+# --retry
+apfel --retry "What is 2+2?"
+
+# --debug
+apfel --debug "Hello world"
+apfel --serve --debug
+
+# --stream
+apfel --stream "Write a haiku about code"
+
+# --chat
+apfel --chat
+apfel --chat -s "You are a helpful coding assistant"
+
+# --context-strategy
+apfel --chat --context-strategy newest-first
+apfel --chat --context-strategy sliding-window --context-max-turns 6
+apfel --chat --context-strategy summarize
+apfel --chat --context-output-reserve 256
+
+# --serve
+apfel --serve
+apfel --serve --port 3000 --host 0.0.0.0
+
+# --cors, --token, --footgun
+apfel --serve --cors
+apfel --serve --token "my-secret-token"
+apfel --serve --footgun
+
+# --token-auto, --public-health
+apfel --serve --token-auto --host 0.0.0.0 --public-health
+
+# --allowed-origins, --no-origin-check
+apfel --serve --allowed-origins "https://myapp.com,https://staging.myapp.com"
+apfel --serve --no-origin-check
+
+# --max-concurrent
+apfel --serve --max-concurrent 2
+
+# --benchmark, --model-info, --update, --release, --version, --help
+apfel --benchmark -o json | jq '.benchmarks[] | {name, speedup_ratio}'
+apfel --model-info
+apfel --update
+apfel --release
+apfel --version
+apfel --help
+```
+
+Security details live in [server-security.md](server-security.md). Background-service usage lives in [background-service.md](background-service.md).
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Runtime error |
+| 2 | Usage error (bad flags) |
+| 3 | Guardrail blocked |
+| 4 | Context overflow |
+| 5 | Model unavailable |
+| 6 | Rate limited |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `APFEL_SYSTEM_PROMPT` | Default system prompt |
+| `APFEL_HOST` | Server bind address |
+| `APFEL_PORT` | Server port |
+| `APFEL_TOKEN` | Bearer token for server authentication |
+| `APFEL_TEMPERATURE` | Default temperature |
+| `APFEL_MAX_TOKENS` | Default max tokens |
+| `APFEL_CONTEXT_STRATEGY` | Default context strategy |
+| `APFEL_CONTEXT_MAX_TURNS` | Max turns for sliding-window |
+| `APFEL_CONTEXT_OUTPUT_RESERVE` | Tokens reserved for output |
+| `APFEL_MCP` | MCP server paths — colon-separated for local paths, comma-separated for mixed local+remote URLs |
+| `APFEL_MCP_TOKEN` | Bearer token for remote HTTP MCP servers (preferred over `--mcp-token`; not visible in `ps aux`) |
+| `APFEL_MCP_TIMEOUT` | MCP timeout in seconds (default: 5, max: 300) |
+| `NO_COLOR` | Disable colors ([https://no-color.org](https://no-color.org)) |

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -1,0 +1,61 @@
+# Demos
+
+`apfel` ships with real shell wrappers in `demo/`. This page keeps the longer walkthroughs that used to live in `README.md`; the quicker per-script overview stays in [../demo/README.md](../demo/README.md).
+
+## [../demo/cmd](../demo/cmd)
+
+Natural language to shell command:
+
+```bash
+demo/cmd "find all .log files modified today"
+# $ find . -name "*.log" -type f -mtime -1
+
+demo/cmd -x "show disk usage sorted by size"   # -x = execute after confirm
+demo/cmd -c "list open ports"                  # -c = copy to clipboard
+```
+
+### Shell function version
+
+Add this to your `.zshrc` and use `cmd` from anywhere:
+
+```bash
+# cmd - natural language to shell command (apfel). Add to .zshrc:
+cmd(){ local x c r a; while [[ $1 == -* ]]; do case $1 in -x)x=1;shift;; -c)c=1;shift;; *)break;; esac; done; r=$(apfel -q -s 'Output only a shell command.' "$*" | sed '/^```/d;/^#/d;s/\x1b\[[0-9;]*[a-zA-Z]//g;s/^[[:space:]]*//;/^$/d' | head -1); [[ $r ]] || { echo "no command generated"; return 1; }; printf '\e[32m$\e[0m %s\n' "$r"; [[ $c ]] && printf %s "$r" | pbcopy && echo "(copied)"; [[ $x ]] && { printf 'Run? [y/N] '; read -r a; [[ $a == y ]] && eval "$r"; }; return 0; }
+```
+
+```bash
+cmd find all swift files larger than 1MB
+cmd -c show disk usage sorted by size
+cmd -x what process is using port 3000
+cmd list all git branches merged into main
+cmd count lines of code by language
+```
+
+## [../demo/oneliner](../demo/oneliner)
+
+Complex pipe chains from plain English:
+
+```bash
+demo/oneliner "sum the third column of a CSV"
+# $ awk -F',' '{sum += $3} END {print sum}' file.csv
+
+demo/oneliner "count unique IPs in access.log"
+# $ awk '{print $1}' access.log | sort | uniq -c | sort -rn
+```
+
+## [../demo/mac-narrator](../demo/mac-narrator)
+
+Your Mac's inner monologue:
+
+```bash
+demo/mac-narrator
+demo/mac-narrator --watch
+```
+
+## Also In `demo/`
+
+- [../demo/wtd](../demo/wtd) - "what's this directory?" project orientation
+- [../demo/explain](../demo/explain) - explain a command, error, or code snippet
+- [../demo/naming](../demo/naming) - naming suggestions for functions, variables, and files
+- [../demo/port](../demo/port) - identify what is using a port
+- [../demo/gitsum](../demo/gitsum) - summarize recent git activity

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -86,4 +86,4 @@ Why this setup works well:
 
 ---
 
-*Have an integration to share? Open an issue at [github.com/Arthur-Ficial/apfel](https://github.com/Arthur-Ficial/apfel/issues).*
+*Have an integration to share? Open an issue at [https://github.com/Arthur-Ficial/apfel/issues](https://github.com/Arthur-Ficial/apfel/issues).*

--- a/docs/local-setup-with-vs-code.md
+++ b/docs/local-setup-with-vs-code.md
@@ -8,7 +8,7 @@ The shape of the setup is:
 4. Route **edit/apply** to a second model.
 5. Keep `~/.continue/.env` in sync from the shell so Continue can read `OPENAI_API_KEY`.
 
-For the underlying API contract, see the [OpenAI API Compatibility section](../README.md#openai-api-compatibility) in the README and [server-security.md](server-security.md).
+For the underlying API contract, see [openai-api-compatibility.md](openai-api-compatibility.md) and [server-security.md](server-security.md).
 
 ## 1. Start `apfel` as the local server
 

--- a/docs/mcp-calculator.md
+++ b/docs/mcp-calculator.md
@@ -1,8 +1,8 @@
 # MCP Tool Support
 
-apfel natively speaks the [Model Context Protocol](https://modelcontextprotocol.io/). Attach tool servers with `--mcp` and apfel discovers tools, executes them, and returns the final answer.
+apfel natively speaks the [https://modelcontextprotocol.io/](https://modelcontextprotocol.io/). Attach tool servers with `--mcp` and apfel discovers tools, executes them, and returns the final answer.
 
-All inference runs on-device with no network calls for the LLM itself. Optional remote MCP tool servers (`--mcp https://...`) do make network calls for tool arguments - see the [Remote MCP servers section in the README](../README.md#remote-mcp-servers) for details.
+All inference runs on-device with no network calls for the LLM itself. Optional remote MCP tool servers (`--mcp https://...`) do make network calls for tool arguments.
 
 ## Quick start
 
@@ -36,6 +36,24 @@ apfel --mcp-timeout 30 --mcp ./remote-server.py "hello"
 # No --mcp = exactly as before. Zero overhead.
 apfel "Hello"
 ```
+
+## Remote MCP servers
+
+Remote MCP uses Streamable HTTP transport (MCP spec `2025-03-26`):
+
+```bash
+# Remote MCP server over HTTPS
+apfel --mcp https://mcp.example.com/v1 "what tools do you have?"
+
+# With bearer token auth - prefer the env var (flag is visible in ps aux)
+APFEL_MCP_TOKEN=mytoken apfel --mcp https://mcp.example.com/v1 "..."
+apfel --mcp https://mcp.example.com/v1 --mcp-token mytoken "..."
+
+# Mixed local + remote
+apfel --mcp /path/to/local.py --mcp https://remote.example.com/v1 "..."
+```
+
+> **Security:** Prefer `APFEL_MCP_TOKEN` over `--mcp-token` because CLI flags are visible in `ps aux`. apfel refuses to send a bearer token over plaintext `http://`; use `https://`.
 
 ## Calculator tools
 

--- a/docs/mcp-calculator.md
+++ b/docs/mcp-calculator.md
@@ -4,6 +4,8 @@ apfel natively speaks the [https://modelcontextprotocol.io/](https://modelcontex
 
 All inference runs on-device with no network calls for the LLM itself. Optional remote MCP tool servers (`--mcp https://...`) do make network calls for tool arguments.
 
+> **Ready-made MCPs for apfel**: [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) ships three token-budget-optimized MCP servers designed specifically for apfel's 4096-token context window: `url-fetch`, `ddg-search`, and the flagship compound `search-and-fetch` tool. Install with `brew install Arthur-Ficial/tap/apfel-mcp`. Repo is open for contributions of new apfel-optimized MCPs.
+
 ## Quick start
 
 ```bash
@@ -219,3 +221,12 @@ Transport: stdio (JSON-RPC 2.0, one message per line).
 | `ping` | client -> server | Empty result |
 
 See `mcp/calculator/server.py` for a complete working example.
+
+## Ready-made MCPs
+
+- [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) - three token-budget-optimized MCP servers for apfel's 4096-token context window:
+  - `apfel-mcp-url-fetch` - fetch a URL, extract the main article with Readability, return clean Markdown. SSRF blocklist, 6000-char hard cap.
+  - `apfel-mcp-ddg-search` - DuckDuckGo web search via direct HTML scrape. No API key. 2000-char hard cap.
+  - `apfel-mcp-search-and-fetch` - the flagship compound tool. Searches AND fetches the top N result pages in ONE tool call. Saves ~500 tokens of schema/state overhead vs chaining separate tools. Declared as both `search` and `web_search` so the 3B model's hallucinated tool names still route correctly.
+  - Install with `brew install Arthur-Ficial/tap/apfel-mcp`
+  - Repo: [github.com/Arthur-Ficial/apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) - open for contributions of new apfel-optimized MCPs. See [apfel-mcp.franzai.com/#contribute](https://apfel-mcp.franzai.com/#contribute) for the rules and idea list.

--- a/docs/openai-api-compatibility.md
+++ b/docs/openai-api-compatibility.md
@@ -1,0 +1,36 @@
+# OpenAI API Compatibility
+
+**Base URL:** `http://localhost:11434/v1`
+
+`apfel` implements the OpenAI Chat Completions surface for Apple's on-device model. It is intended to be a drop-in local backend for SDKs and tools that can target a custom `base_url`.
+
+## Supported Surface
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| `POST /v1/chat/completions` | Supported | Streaming + non-streaming |
+| `GET /v1/models` | Supported | Returns `apple-foundationmodel` |
+| `GET /health` | Supported | Model availability, context window, languages |
+| `GET /v1/logs`, `/v1/logs/stats` | Debug only | Requires `--debug` |
+| Tool calling | Supported | Native `ToolDefinition` + JSON detection. See [tool-calling-guide.md](tool-calling-guide.md) |
+| `response_format: json_object` | Supported | Via system prompt injection |
+| `temperature`, `max_tokens`, `seed` | Supported | Mapped to `GenerationOptions` |
+| `stream: true` | Supported | SSE with usage stats in final chunk |
+| `finish_reason` | Supported | `stop`, `tool_calls`, `length` |
+| Context strategies | Supported | `x_context_strategy`, `x_context_max_turns`, `x_context_output_reserve` extension fields |
+| CORS | Supported | Enable with `--cors` |
+| `POST /v1/completions` | 501 | Legacy text completions not supported |
+| `POST /v1/embeddings` | 501 | Embeddings not available on-device |
+| `POST /v1/responses` | 501 | Use Chat Completions |
+| `logprobs=true`, `n>1`, `stop`, `presence_penalty`, `frequency_penalty` | 400 | Rejected explicitly. `n=1` and `logprobs=false` are accepted as no-ops |
+| Multi-modal (images) | 400 | Rejected with clear error |
+| `Authorization` header | Supported | Required when `--token` is set. See [server-security.md](server-security.md) |
+
+## Notes
+
+- Use Chat Completions, not the newer Responses API.
+- `GET /health` stays useful for local availability checks even when the rest of the server is token-protected, if you opt into `--public-health`.
+- Debug log endpoints exist only when the server is started with `--debug`.
+- Browser access, origin checks, bearer tokens, and `--footgun` behavior are documented in [server-security.md](server-security.md).
+
+Full upstream schema reference: [https://github.com/openai/openai-openapi](https://github.com/openai/openai-openapi)

--- a/docs/tool-calling-guide.md
+++ b/docs/tool-calling-guide.md
@@ -5,6 +5,8 @@ and apfel's OpenAI-compatible tool calling implementation.
 
 **Tested:** 2026-03-26 | **apfel:** v0.5.0 | **macOS:** 26.3
 
+> **Looking for ready-made MCPs?** [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) ships three token-budget-optimized MCP servers designed for apfel's 4096-token context window: `url-fetch`, `ddg-search`, and the flagship compound `search-and-fetch` tool. `brew install Arthur-Ficial/tap/apfel-mcp`. The repo is open for contributions of new apfel-optimized MCPs - see [apfel-mcp.franzai.com/#contribute](https://apfel-mcp.franzai.com/#contribute).
+
 ---
 
 ## How It Works


### PR DESCRIPTION
## Summary

Three cross-link additions pointing readers at the new [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) landing page:

1. **README.md - MCP Tool Support section**: one paragraph after the calculator example with the install one-liner and the three tool names (url-fetch, ddg-search, search-and-fetch). Calls out the flagship compound tool as 'the one that saves ~500 tokens vs chaining separate calls'.
2. **docs/mcp-calculator.md**: a top-of-page callout so readers land on the ready-made MCPs before they reach the calculator example, AND a 'Ready-made MCPs' section at the bottom with per-server caps and descriptions.
3. **docs/tool-calling-guide.md**: a top-of-page callout so readers looking at how tool calling works in apfel discover that three working MCPs already exist for them to use.

Every link also mentions that the repo is open for contributions, with a direct link to the [#contribute](https://apfel-mcp.franzai.com/#contribute) anchor on the landing page (9 idea cards + 8 contribution rules).

Docs-only change. No code.

## Test plan

- [x] Links work (verified manually against https://apfel-mcp.franzai.com/)
- [x] All three brew commands are correct
- [x] No broken Markdown