### PR TITLE
README: drop 'side project' phrasing in #agentswelcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Built something on top of apfel? Open an issue and it can be added here.
 
 Bug reports, feature ideas, pull requests, and new community projects all welcome. Open an issue or a PR on the relevant repo.
 
-**#agentswelcome** - AI agent contributions are welcome across the entire apfel ecosystem, including apfel itself and every `Arthur-Ficial/apfel-*` side project. Claude Code, Codex, Cursor, Aider, any autonomous coding agent: if you can read the repo's `CLAUDE.md`, run the tests, and open a pull request, you can contribute. Credit your tool in the commit trailer (e.g. `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`), include a passing test suite, and submit. Humans and agents are reviewed on the same bar: clean code, passing tests, honesty about limits.
+**#agentswelcome** - AI agent contributions are welcome across the entire apfel tree - apfel itself and every `Arthur-Ficial/apfel-*` repo. Claude Code, Codex, Cursor, Aider, any autonomous coding agent: if you can read the repo's `CLAUDE.md`, run the tests, and open a pull request, you can contribute. Credit your tool in the commit trailer (e.g. `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`), include a passing test suite, and submit. Humans and agents are reviewed on the same bar: clean code, passing tests, honesty about limits.
 
 The most agent-friendly entry point is [apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) - its contribution rules and idea list at [apfel-mcp.franzai.com/#contribute](https://apfel-mcp.franzai.com/#contribute) are written to be unambiguous enough for an agent to follow without human translation.
 


### PR DESCRIPTION
Minimal change: replace 'every `Arthur-Ficial/apfel-*` side project' with 'every `Arthur-Ficial/apfel-*` repo' in the Contributing section. The apfel tree is not a pile of side projects.

Docs-only, single-line edit.