### PR TITLE
README: upgrade #agentswelcome badge to for-the-badge + probot logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![100% On-Device](https://img.shields.io/badge/inference-100%25%20on--device-green)](https://developer.apple.com/documentation/foundationmodels)
 [![Website](https://img.shields.io/badge/web-apfel.franzai.com-16A34A)](https://apfel.franzai.com)
-[![#agentswelcome](https://img.shields.io/badge/%23agentswelcome-AI%20contributions%20welcome-0066cc?labelColor=0d1117)](#contributing)
+[![#agentswelcome](https://img.shields.io/badge/%23agentswelcome-PRs%20welcome-0066cc?style=for-the-badge&labelColor=0d1117&logo=probot&logoColor=white)](#contributing)
 
 Use the free local Apple Intelligence LLM on your Mac as a UNIX tool, an OpenAI-compatible server, and a command-line chat client. No API keys, no cloud, no subscriptions, no per-token billing.
 


### PR DESCRIPTION
Bolder badge. Same concept, better rendering:

Before (default flat, easy to miss):
```
https://img.shields.io/badge/%23agentswelcome-AI%20contributions%20welcome-0066cc?labelColor=0d1117
```

After (for-the-badge + probot logo, confident CTA):
```
https://img.shields.io/badge/%23agentswelcome-PRs%20welcome-0066cc?style=for-the-badge&labelColor=0d1117&logo=probot&logoColor=white
```

Same brand colors (#0066cc on #0d1117). Same link target (#contributing). The probot logo ties the #agentswelcome tag to its visual metaphor, and 'PRs welcome' matches the universal OSS convention.

Docs-only, single-URL edit.