### PR TITLE
README: restore the wow (demos, rich MCP, full API table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,41 +46,65 @@ cd apfel
 make install
 ```
 
-Update with `brew upgrade apfel` or `apfel --update`.
-
-Troubleshooting, alternative install methods, and Apple Intelligence setup notes: [docs/install.md](docs/install.md)
+Update with `brew upgrade apfel` or `apfel --update`. Troubleshooting and Apple Intelligence setup notes: [docs/install.md](docs/install.md).
 
 ## Quick Start
 
 ### UNIX tool
 
-Shell note: if your prompt contains `!`, prefer single quotes in `zsh` or `bash` so history expansion does not break copy-paste.
+Shell note: if your prompt contains `!`, prefer single quotes in `zsh`/`bash` so history expansion does not break copy-paste. Example: `apfel 'Hello, Mac!'`
 
 ```bash
+# Single prompt
 apfel "What is the capital of Austria?"
-apfel --permissive "Write a dramatic opening for a thriller novel"
-apfel --stream "Write a haiku about code"
-echo "Summarize: $(cat README.md)" | apfel
-apfel -f README.md "Summarize this project"
-apfel -f old.swift -f new.swift "What changed between these two files?"
-apfel -o json "Translate to German: hello" | jq .content
-apfel -s "You are a pirate" "What is recursion?"
-```
 
-More on `--system-file`, quiet mode, retries, exit codes, and environment variables: [docs/cli-reference.md](docs/cli-reference.md)
+# Permissive mode -- reduces guardrail false positives for creative/long prompts
+apfel --permissive "Write a dramatic opening for a thriller novel"
+
+# Stream output
+apfel --stream "Write a haiku about code"
+
+# Pipe input
+echo "Summarize: $(cat README.md)" | apfel
+
+# Attach file content to prompt
+apfel -f README.md "Summarize this project"
+
+# Attach multiple files
+apfel -f old.swift -f new.swift "What changed between these two files?"
+
+# Combine files with piped input
+git diff HEAD~1 | apfel -f CONVENTIONS.md "Review this diff against our conventions"
+
+# JSON output for scripting
+apfel -o json "Translate to German: hello" | jq .content
+
+# System prompt
+apfel -s "You are a pirate" "What is recursion?"
+
+# System prompt from file
+apfel --system-file persona.txt "Explain TCP/IP"
+
+# Quiet mode for shell scripts
+result=$(apfel -q "Capital of France? One word.")
+```
 
 ### OpenAI-compatible server
 
 ```bash
-apfel --serve
-brew services start apfel
+apfel --serve                              # foreground
+brew services start apfel                  # background (like Ollama)
 ```
+
+Then in another terminal:
 
 ```bash
 curl http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"apple-foundationmodel","messages":[{"role":"user","content":"Hello"}]}'
 ```
+
+Works with the official Python client:
 
 ```python
 from openai import OpenAI
@@ -93,42 +117,147 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-Background operation, service configuration, and security settings: [docs/background-service.md](docs/background-service.md), [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md), [docs/server-security.md](docs/server-security.md)
+Run in background (auto-restarts, starts at login - [docs/background-service.md](docs/background-service.md)):
 
-### Command-line chat
+```bash
+brew services start apfel
+brew services stop apfel
+APFEL_TOKEN=$(uuidgen) APFEL_MCP=/path/to/tools.py brew services start apfel
+```
+
+### Interactive chat
 
 ```bash
 apfel --chat
 apfel --chat -s "You are a helpful coding assistant"
-apfel --chat --mcp ./mcp/calculator/server.py
-apfel --chat --debug
+apfel --chat --mcp ./mcp/calculator/server.py      # chat with MCP tools
+apfel --chat --debug                                # debug output to stderr
 ```
 
-Ctrl-C exits cleanly. Context rotation, history trimming, and output reserves: [docs/context-strategies.md](docs/context-strategies.md)
-
-## MCP Tool Support
-
-Attach [https://modelcontextprotocol.io/](https://modelcontextprotocol.io/) servers with `--mcp`. `apfel` discovers tools, executes them automatically, and returns the final answer.
-
-```bash
-apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
-apfel --mcp ./server_a.py --mcp ./server_b.py "Use both tools"
-apfel --serve --mcp ./mcp/calculator/server.py
-```
-
-`mcp/calculator/` ships with the repo. Remote `https://` MCP servers, bearer-token handling, timeout tuning, server-mode auto-execution, and protocol details live in [docs/mcp-calculator.md](docs/mcp-calculator.md) and [docs/tool-calling-guide.md](docs/tool-calling-guide.md).
-
-**Want web search and URL fetching?** [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) ships three token-budget-optimized MCP servers for apfel's 4096-token context window: `url-fetch` (Readability article extraction with SSRF guards), `ddg-search` (DuckDuckGo web search, no API key), and `search-and-fetch` (the flagship compound tool - search AND fetch the top N pages in ONE tool call). Install with `brew install Arthur-Ficial/tap/apfel-mcp`. The repo is open for contributions of new apfel-optimized MCPs - ideas and rules at [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/#contribute).
-
-## OpenAI API Compatibility
-
-`apfel` exposes `http://localhost:11434/v1` with `POST /v1/chat/completions`, `GET /v1/models`, `GET /health`, streaming, tool calling, and `response_format: json_object`. Unsupported surfaces such as embeddings, legacy completions, and multimodal inputs return honest `501` or `400` errors. Full compatibility matrix: [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md)
+Ctrl-C exits cleanly. Context window is managed automatically with configurable strategies ([docs/context-strategies.md](docs/context-strategies.md)).
 
 ## Demos
 
-- [docs/demos.md](docs/demos.md) - longer walkthroughs for `demo/cmd`, `demo/oneliner`, `demo/mac-narrator`, and the reusable `cmd()` shell function
-- [demo/README.md](demo/README.md) - quick overview of every shipped demo
-- [demo/wtd](demo/wtd), [demo/explain](demo/explain), [demo/naming](demo/naming), [demo/port](demo/port), and [demo/gitsum](demo/gitsum) cover project orientation, explanation, naming, port inspection, and git summaries
+See [`demo/`](./demo/) for real-world shell scripts powered by apfel.
+
+**[cmd](./demo/cmd)** — natural language to shell command:
+
+```bash
+demo/cmd "find all .log files modified today"
+# $ find . -name "*.log" -type f -mtime -1
+
+demo/cmd -x "show disk usage sorted by size"   # -x = execute after confirm
+demo/cmd -c "list open ports"                   # -c = copy to clipboard
+```
+
+**Shell function version** — add to your `.zshrc` and use `cmd` from anywhere:
+
+```bash
+# cmd - natural language to shell command (apfel). Add to .zshrc:
+cmd(){ local x c r a; while [[ $1 == -* ]]; do case $1 in -x)x=1;shift;; -c)c=1;shift;; *)break;; esac; done; r=$(apfel -q -s 'Output only a shell command.' "$*" | sed '/^```/d;/^#/d;s/\x1b\[[0-9;]*[a-zA-Z]//g;s/^[[:space:]]*//;/^$/d' | head -1); [[ $r ]] || { echo "no command generated"; return 1; }; printf '\e[32m$\e[0m %s\n' "$r"; [[ $c ]] && printf %s "$r" | pbcopy && echo "(copied)"; [[ $x ]] && { printf 'Run? [y/N] '; read -r a; [[ $a == y ]] && eval "$r"; }; return 0; }
+```
+
+```bash
+cmd find all swift files larger than 1MB     # shows: $ find . -name "*.swift" -size +1M
+cmd -c show disk usage sorted by size        # shows command + copies to clipboard
+cmd -x what process is using port 3000       # shows command + asks to run it
+cmd list all git branches merged into main
+cmd count lines of code by language
+```
+
+**[oneliner](./demo/oneliner)** — complex pipe chains from plain English:
+
+```bash
+demo/oneliner "sum the third column of a CSV"
+# $ awk -F',' '{sum += $3} END {print sum}' file.csv
+
+demo/oneliner "count unique IPs in access.log"
+# $ awk '{print $1}' access.log | sort | uniq -c | sort -rn
+```
+
+**[mac-narrator](./demo/mac-narrator)** — your Mac's inner monologue:
+
+```bash
+demo/mac-narrator              # one-shot: what's happening right now?
+demo/mac-narrator --watch      # continuous narration every 60s
+```
+
+Also in `demo/`:
+
+- **[wtd](./demo/wtd)** — "what's this directory?" instant project orientation
+- **[explain](./demo/explain)** — explain a command, error, or code snippet
+- **[naming](./demo/naming)** — naming suggestions for functions, variables, files
+- **[port](./demo/port)** — what's using this port?
+- **[gitsum](./demo/gitsum)** — summarize recent git activity
+
+Longer walkthroughs: [docs/demos.md](docs/demos.md).
+
+## MCP Tool Support
+
+Attach [Model Context Protocol](https://modelcontextprotocol.io/) tool servers with `--mcp`. apfel discovers tools, executes them automatically, and returns the final answer. No glue code needed.
+
+```bash
+apfel --mcp ./mcp/calculator/server.py "What is 15 times 27?"
+```
+
+```
+mcp: ./mcp/calculator/server.py - add, subtract, multiply, divide, sqrt, power    ← stderr
+tool: multiply({"a": 15, "b": 27}) = 405                                          ← stderr
+15 times 27 is 405.                                                                ← stdout
+```
+
+Tool info goes to stderr; only the answer goes to stdout. Use `-q` to suppress tool info.
+
+```bash
+apfel --mcp ./server_a.py --mcp ./server_b.py "Use both tools"  # multiple servers
+apfel --serve --mcp ./mcp/calculator/server.py                   # server mode
+apfel --chat --mcp ./mcp/calculator/server.py                    # chat mode
+```
+
+Ships with a calculator MCP server at [`mcp/calculator/`](./mcp/calculator/). See [docs/mcp-calculator.md](docs/mcp-calculator.md) for details.
+
+**Remote MCP servers** (Streamable HTTP transport, MCP spec 2025-03-26):
+
+```bash
+# Remote MCP server over HTTPS
+apfel --mcp https://mcp.example.com/v1 "what tools do you have?"
+
+# With bearer token auth - prefer the env var (flag is visible in ps aux)
+APFEL_MCP_TOKEN=mytoken apfel --mcp https://mcp.example.com/v1 "..."
+apfel --mcp https://mcp.example.com/v1 --mcp-token mytoken "..."
+
+# Mixed local + remote
+apfel --mcp /path/to/local.py --mcp https://remote.example.com/v1 "..."
+```
+
+> **Security:** Use `APFEL_MCP_TOKEN` env var rather than `--mcp-token` — CLI flags are visible in `ps aux`. apfel refuses to send a bearer token over plaintext `http://` (use `https://`).
+
+**Ready-made MCPs.** [apfel-mcp.franzai.com](https://apfel-mcp.franzai.com/) ships three token-budget-optimized MCP servers designed for apfel's 4096-token window: `url-fetch` (Readability article extraction with SSRF guards), `ddg-search` (DuckDuckGo web search, no API key), and the flagship compound `search-and-fetch` tool. Install with `brew install Arthur-Ficial/tap/apfel-mcp`. The repo is open for contributions of new apfel-optimized MCPs — rules at [apfel-mcp.franzai.com/#contribute](https://apfel-mcp.franzai.com/#contribute).
+
+## OpenAI API Compatibility
+
+**Base URL:** `http://localhost:11434/v1`
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| `POST /v1/chat/completions` | Supported | Streaming + non-streaming |
+| `GET /v1/models` | Supported | Returns `apple-foundationmodel` |
+| `GET /health` | Supported | Model availability, context window, languages |
+| `GET /v1/logs`, `/v1/logs/stats` | Debug only | Requires `--debug` |
+| Tool calling | Supported | Native `ToolDefinition` + JSON detection. See [docs/tool-calling-guide.md](docs/tool-calling-guide.md) |
+| `response_format: json_object` | Supported | Via system prompt injection |
+| `temperature`, `max_tokens`, `seed` | Supported | Mapped to `GenerationOptions` |
+| `stream: true` | Supported | SSE with usage stats in final chunk |
+| `finish_reason` | Supported | `stop`, `tool_calls`, `length` |
+| Context strategies | Supported | `x_context_strategy`, `x_context_max_turns`, `x_context_output_reserve` extension fields |
+| CORS | Supported | Enable with `--cors` |
+| `POST /v1/completions` | 501 | Legacy text completions not supported |
+| `POST /v1/embeddings` | 501 | Embeddings not available on-device |
+| `logprobs=true`, `n>1`, `stop`, `presence_penalty`, `frequency_penalty` | 400 | Rejected explicitly. `n=1` and `logprobs=false` are accepted as no-ops |
+| Multi-modal (images) | 400 | Rejected with clear error |
+| `Authorization` header | Supported | Required when `--token` is set. See [docs/server-security.md](docs/server-security.md) |
+
+Full API spec: [openai/openai-openapi](https://github.com/openai/openai-openapi).
 
 ## Limitations
 
@@ -137,22 +266,24 @@ apfel --serve --mcp ./mcp/calculator/server.py
 | Context window | **4096 tokens** (input + output combined) |
 | Platform | macOS 26+, Apple Silicon only |
 | Model | One model (`apple-foundationmodel`), not configurable |
-| Guardrails | Apple's safety system may block benign prompts. `--permissive` reduces false positives: [docs/PERMISSIVE.md](docs/PERMISSIVE.md) |
-| Speed | On-device, not cloud-scale |
+| Guardrails | Apple's safety system may block benign prompts. `--permissive` reduces false positives ([docs/PERMISSIVE.md](docs/PERMISSIVE.md)) |
+| Speed | On-device, not cloud-scale — a few seconds per response |
 | No embeddings / vision | Not available on-device |
 
 ## Reference Docs
 
-- [docs/install.md](docs/install.md) - install, troubleshooting, and Apple Intelligence setup
-- [docs/cli-reference.md](docs/cli-reference.md) - modes, flags, exit codes, and environment variables
-- [docs/background-service.md](docs/background-service.md) - `brew services` and launchd usage
-- [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md) - `/v1/*` support matrix
-- [docs/server-security.md](docs/server-security.md) - origin checks, CORS, tokens, and `--footgun`
-- [docs/context-strategies.md](docs/context-strategies.md) - chat trimming strategies
-- [docs/mcp-calculator.md](docs/mcp-calculator.md) - local and remote MCP usage
-- [docs/tool-calling-guide.md](docs/tool-calling-guide.md) - detailed tool-calling behavior
-- [docs/integrations.md](docs/integrations.md) - third-party tool integrations
-- [docs/EXAMPLES.md](docs/EXAMPLES.md) - 50+ real prompts with unedited output
+- [docs/install.md](docs/install.md) — install, troubleshooting, and Apple Intelligence setup
+- [docs/cli-reference.md](docs/cli-reference.md) — every flag, exit code, and environment variable
+- [docs/background-service.md](docs/background-service.md) — `brew services` and launchd usage
+- [docs/openai-api-compatibility.md](docs/openai-api-compatibility.md) — `/v1/*` support matrix in depth
+- [docs/server-security.md](docs/server-security.md) — origin checks, CORS, tokens, and `--footgun`
+- [docs/context-strategies.md](docs/context-strategies.md) — chat trimming strategies
+- [docs/mcp-calculator.md](docs/mcp-calculator.md) — local and remote MCP usage
+- [docs/tool-calling-guide.md](docs/tool-calling-guide.md) — detailed tool-calling behavior
+- [docs/integrations.md](docs/integrations.md) — third-party tool integrations (opencode, etc.)
+- [docs/local-setup-with-vs-code.md](docs/local-setup-with-vs-code.md) — local review with apfel + a second edit/apply model in VS Code
+- [docs/demos.md](docs/demos.md) — longer walkthroughs of the shell demos
+- [docs/EXAMPLES.md](docs/EXAMPLES.md) — 50+ real prompts with unedited output
 
 ## Architecture
 
@@ -180,12 +311,7 @@ python3 -m pytest Tests/integration/ -v  # integration tests
 apfel --benchmark -o json                # performance report
 ```
 
-Every `make build` or `make install` auto-bumps the patch version, updates the README badge, and generates build metadata. `.version` is the single source of truth.
-
-## Integrations
-
-- [docs/integrations.md](docs/integrations.md) - verified configs for tools such as opencode
-- [docs/local-setup-with-vs-code.md](docs/local-setup-with-vs-code.md) - local review with `apfel` plus a second edit/apply model in Visual Studio Code
+Every `make build`/`make install` auto-bumps the patch version, updates the README badge, and generates build metadata. `.version` is the single source of truth.
 
 ## The apfel tree
 
@@ -193,41 +319,41 @@ Everything that grows out of apfel. Each project ships as its own repo, its own 
 
 ### Trunk
 
-- **apfel** - on-device Apple FoundationModels CLI and OpenAI-compatible server. The root of the tree; every other project uses it for inference.
+- **apfel** — on-device Apple FoundationModels CLI and OpenAI-compatible server. The root of the tree; every other project uses it for inference.
   - Site: [https://apfel.franzai.com](https://apfel.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfel](https://github.com/Arthur-Ficial/apfel)
   - Install: `brew install Arthur-Ficial/tap/apfel`
 
 ### Apps
 
-- **apfel-chat** - multi-conversation macOS chat client. Streaming markdown, speech I/O, image analysis via Apple Vision. Runs 100% on-device.
+- **apfel-chat** — multi-conversation macOS chat client. Streaming markdown, speech I/O, image analysis via Apple Vision. Runs 100% on-device.
   - Site: [https://apfel-chat.franzai.com](https://apfel-chat.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfel-chat](https://github.com/Arthur-Ficial/apfel-chat)
   - Install: `brew install Arthur-Ficial/tap/apfel-chat`
 
-- **apfel-clip** - AI clipboard actions from the macOS menu bar. Summarize, translate, rewrite, and reshape whatever you just copied, without leaving the keyboard.
+- **apfel-clip** — AI clipboard actions from the macOS menu bar. Summarize, translate, rewrite, and reshape whatever you just copied, without leaving the keyboard.
   - Site: [https://apfel-clip.franzai.com](https://apfel-clip.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfel-clip](https://github.com/Arthur-Ficial/apfel-clip)
   - Install: `brew install Arthur-Ficial/tap/apfel-clip`
 
-- **apfel-quick** - instant AI overlay for macOS. Press a key, ask anything, get an on-device answer - then dismiss.
+- **apfel-quick** — instant AI overlay for macOS. Press a key, ask anything, get an on-device answer — then dismiss.
   - Site: [https://apfel-quick.franzai.com](https://apfel-quick.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfel-quick](https://github.com/Arthur-Ficial/apfel-quick)
   - Install: `brew install Arthur-Ficial/tap/apfel-quick`
 
-- **apfelpad** - a formula notepad for thinking. On-device AI as a first-class function you can call inline from cells, the way a spreadsheet treats `SUM`.
+- **apfelpad** — a formula notepad for thinking. On-device AI as a first-class function you can call inline from cells, the way a spreadsheet treats `SUM`.
   - Site: [https://apfelpad.franzai.com](https://apfelpad.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfelpad](https://github.com/Arthur-Ficial/apfelpad)
   - Install: `brew install Arthur-Ficial/tap/apfelpad`
 
 ### Extensions
 
-- **apfel-mcp** - three token-budget-optimized MCP (Model Context Protocol) servers for apfel's 4096-token context window. `url-fetch` (Readability article extraction with SSRF guards), `ddg-search` (DuckDuckGo web search, no API key), and the flagship compound `search-and-fetch` tool. Open for contributions of more apfel-optimized MCPs.
+- **apfel-mcp** — three token-budget-optimized MCP servers for apfel's 4096-token context window: `url-fetch` (Readability article extraction with SSRF guards), `ddg-search` (DuckDuckGo web search, no API key), and the flagship compound `search-and-fetch` tool. Open for contributions of more apfel-optimized MCPs.
   - Site: [https://apfel-mcp.franzai.com](https://apfel-mcp.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp)
   - Install: `brew install Arthur-Ficial/tap/apfel-mcp`
 
-- **apfel-gui** - native SwiftUI debug inspector for apfel with request timeline, MCP protocol viewer, chat, and TTS/STT. Built for developers who want to watch exactly what apfel sends to the model.
+- **apfel-gui** — native SwiftUI debug inspector for apfel with request timeline, MCP protocol viewer, chat, and TTS/STT. Built for developers who want to watch exactly what apfel sends to the model.
   - Repo: [https://github.com/Arthur-Ficial/apfel-gui](https://github.com/Arthur-Ficial/apfel-gui)
   - Install: `brew install Arthur-Ficial/tap/apfel-gui`
 
@@ -235,19 +361,15 @@ Everything that grows out of apfel. Each project ships as its own repo, its own 
 
 Built something on top of apfel? Open an issue and it can be added here.
 
-- [https://apfelclaw.yamanlabs.com/](https://apfelclaw.yamanlabs.com/), [https://github.com/julianyaman/apfelclaw](https://github.com/julianyaman/apfelclaw), by [https://github.com/julianYaman](https://github.com/julianYaman) - local AI agent that reads files, calendar, mail, and Mac status via read-only tools
+- [https://apfelclaw.yamanlabs.com/](https://apfelclaw.yamanlabs.com/), [https://github.com/julianyaman/apfelclaw](https://github.com/julianyaman/apfelclaw), by [https://github.com/julianYaman](https://github.com/julianYaman) — local AI agent that reads files, calendar, mail, and Mac status via read-only tools
 
 ## Contributing
 
 Bug reports, feature ideas, pull requests, and new community projects all welcome. Open an issue or a PR on the relevant repo.
 
-**#agentswelcome** - AI agent contributions are welcome across the entire apfel tree - apfel itself and every `Arthur-Ficial/apfel-*` repo. Claude Code, Codex, Cursor, Aider, any autonomous coding agent: if you can read the repo's `CLAUDE.md`, run the tests, and open a pull request, you can contribute. Credit your tool in the commit trailer (e.g. `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`), include a passing test suite, and submit. Humans and agents are reviewed on the same bar: clean code, passing tests, honesty about limits.
+**#agentswelcome** — AI agent contributions are welcome across the entire apfel tree — apfel itself and every `Arthur-Ficial/apfel-*` repo. Claude Code, Codex, Cursor, Aider, any autonomous coding agent: if you can read the repo's `CLAUDE.md`, run the tests, and open a pull request, you can contribute. Credit your tool in the commit trailer (e.g. `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`), include a passing test suite, and submit. Humans and agents are reviewed on the same bar: clean code, passing tests, honesty about limits.
 
-The most agent-friendly entry point is [apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) - its contribution rules and idea list at [apfel-mcp.franzai.com/#contribute](https://apfel-mcp.franzai.com/#contribute) are written to be unambiguous enough for an agent to follow without human translation.
-
-## Examples
-
-See [docs/EXAMPLES.md](docs/EXAMPLES.md) for 50+ real prompts with unedited model output.
+The most agent-friendly entry point is [apfel-mcp](https://github.com/Arthur-Ficial/apfel-mcp) — its contribution rules and idea list at [apfel-mcp.franzai.com/#contribute](https://apfel-mcp.franzai.com/#contribute) are written to be unambiguous enough for an agent to follow without human translation.
 
 ## License
 


### PR DESCRIPTION
## Summary

The previous slim pass cut too deep. This PR is the ultimate compromise:

- **376 lines** (vs 254 current, 599 original)
- Keeps **every new development we made today**: #agentswelcome badge, The apfel tree section, Contributing section, apfel-mcp callout in the MCP section
- Restores the three big 'show don't tell' sections users need to see in the first scroll

### What comes back

- **Demos section** — full \`cmd\`/\`oneliner\`/\`mac-narrator\` walkthroughs, the ~50-line shell function one-liner readers can paste into their \`.zshrc\`, plus the \`wtd\`/\`explain\`/\`naming\`/\`port\`/\`gitsum\` mini-list. This is the wow a new reader needs.
- **MCP Tool Support** — shows the actual stderr/stdout split from a real calculator call, plus remote-MCP examples with the bearer-token security note.
- **OpenAI API Compatibility** — the full feature matrix table. 'Is this drop-in for my existing OpenAI code?' is the #1 question readers ask, and a one-paragraph pointer was too thin.

### What stays in docs/ (not reverted)

- Full CLI Reference stays in \`docs/cli-reference.md\` — the 200-line flag dump was the worst offender
- 'Model unavailable' deep dive stays in \`docs/install.md\`
- Architecture / Build / Test stay brief and link out

### Relationship to #71

Supersedes #71 (Codex's draft). This PR cherry-picks the *intent* of Codex's 'restore richer README flow' commit but layers all the new developments from today (#agentswelcome badge, apfel tree, apfel-mcp link) on top.

Closing #71 after this merges.

## Test plan

- [x] Markdown renders cleanly (verified locally)
- [x] All internal links resolve (anchors + docs/*.md files exist)
- [x] All external links are HTTPS and correct
- [x] Header badges row unchanged