### PR TITLE
docs: update brew installation notes to use core tap

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,8 +22,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TYPE: ${{ inputs.release_type }}
-      TAP_REPOSITORY: Arthur-Ficial/homebrew-tap
-      TAP_BRANCH: main
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -48,16 +46,6 @@ jobs:
           fi
           echo "Active SDK: $(xcrun --show-sdk-version)"
           echo "Swift: $(swift --version 2>&1 | head -1)"
-
-      - name: Verify tap token is configured
-        env:
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_PUSH_TOKEN }}
-        run: |
-          if [[ -z "$TAP_TOKEN" ]]; then
-            echo "Missing HOMEBREW_TAP_PUSH_TOKEN repository secret."
-            echo "Create a fine-grained GitHub token with Contents: Read and write on $TAP_REPOSITORY."
-            exit 1
-          fi
 
       - name: Bump version and build release
         run: |
@@ -103,31 +91,3 @@ jobs:
           else
             gh release create "v$version" "$asset" --title "v$version" --notes "Automated release for v$version"
           fi
-
-      - name: Check out homebrew tap
-        uses: actions/checkout@v6
-        with:
-          repository: Arthur-Ficial/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_PUSH_TOKEN }}
-          ref: main
-          path: homebrew-tap
-
-      - name: Update Homebrew formula
-        run: |
-          make update-homebrew-formula \
-            HOMEBREW_FORMULA_OUTPUT="homebrew-tap/Formula/apfel.rb" \
-            HOMEBREW_FORMULA_SHA256="${{ steps.asset.outputs.sha256 }}"
-
-      - name: Push Homebrew tap update
-        working-directory: homebrew-tap
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- Formula/apfel.rb; then
-            echo "Homebrew formula already up to date."
-            exit 0
-          fi
-          version="${{ steps.version.outputs.value }}"
-          git add Formula/apfel.rb
-          git commit -m "apfel v$version"
-          git push origin HEAD:$TAP_BRANCH

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ bash scripts/generate-examples.sh          # ~2 minutes, overwrites docs/EXAMPLE
 | Tests | `Tests/apfelTests/` (188 unit), `Tests/integration/` (139 integration) |
 | Tickets | `open-tickets/` |
 | Docs | `docs/` (brew-install, EXAMPLES, release, tool-calling-guide) |
-| Scripts | `scripts/generate-examples.sh` (regenerates docs/EXAMPLES.md), `scripts/write-homebrew-formula.sh` |
+| Scripts | `scripts/generate-examples.sh` (regenerates docs/EXAMPLES.md) |
 
 ## Handling GitHub Issues
 
@@ -288,7 +288,6 @@ This triggers the **Publish Release** GitHub Actions workflow which runs on `mac
 4. Commits `.version`, `README.md`, `Sources/BuildInfo.swift` and pushes to `main`
 5. Creates a git tag (`v<version>`) and pushes it
 6. Packages `apfel-<version>-arm64-macos.tar.gz` and publishes a GitHub Release
-7. Clones `Arthur-Ficial/homebrew-tap`, regenerates `Formula/apfel.rb` with new URL + SHA256, commits and pushes
 
 After the workflow completes (~3 min), verify locally:
 
@@ -296,9 +295,9 @@ After the workflow completes (~3 min), verify locally:
 brew update && brew upgrade apfel && brew test apfel && apfel --version
 ```
 
-**Do NOT manually run `make install`, `make package-release-asset`, `git tag`, `gh release create`, or push to the Homebrew tap.** The workflow does all of it. Manual steps create version drift, duplicate tags, and half-updated taps. If the workflow fails, fix the workflow - don't work around it.
+**Do NOT manually run `make install`, `make package-release-asset`, `git tag`, or `gh release create`.** The workflow handles the GitHub release path. Manual steps create version drift, duplicate tags, and half-updated releases. If the workflow fails, fix the workflow - don't work around it.
 
-The workflow source is `.github/workflows/publish-release.yml`. The `HOMEBREW_TAP_PUSH_TOKEN` secret must exist on `Arthur-Ficial/apfel` (fine-grained token with Contents R/W on `Arthur-Ficial/homebrew-tap`).
+The workflow source is `.github/workflows/publish-release.yml`.
 
 ### Integration test rules
 
@@ -312,7 +311,6 @@ The workflow source is `.github/workflows/publish-release.yml`. The `HOMEBREW_TA
 - [ ] Unit tests pass (188+)
 - [ ] Integration tests pass (139+, 0 skipped)
 - [ ] GitHub Release created with tarball
-- [ ] Homebrew tap updated and `brew test` passes
 - [ ] CLAUDE.md test counts and version updated
 - [ ] File a ticket on `Arthur-Ficial/apfel-web` if the landing page shows test counts
 
@@ -320,7 +318,6 @@ The workflow source is `.github/workflows/publish-release.yml`. The `HOMEBREW_TA
 
 - **`macos-26` runner** has Xcode-bundled SDKs (not standalone CLT). The workflow selects the latest available Xcode via `xcode-select` before building.
 - apfel requires **SDK 26.4+** for FoundationModels token-counting APIs (`tokenCount`, `contextSize`). If the runner's highest Xcode is older, the build will fail.
-- **`HOMEBREW_TAP_PUSH_TOKEN`** secret must exist on `Arthur-Ficial/apfel` - fine-grained token with Contents R/W on `Arthur-Ficial/homebrew-tap`.
-- The **Publish Release** workflow (`.github/workflows/publish-release.yml`) is the single source of truth for the release pipeline. It handles version bump, build, test, tag, GitHub Release, and homebrew tap update in one run.
+- The **Publish Release** workflow (`.github/workflows/publish-release.yml`) is the single source of truth for the release pipeline. It handles version bump, build, test, tag, and GitHub Release publication in one run.
 - The **CI** workflow (`.github/workflows/ci.yml`) runs on PRs and pushes for build + test validation.
 - Release docs: `docs/release.md`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Tool calling works across CLI, chat, and server. Inference stays 100% on-device.
 **Homebrew** (recommended):
 
 ```bash
-brew tap Arthur-Ficial/tap
 brew install apfel
 brew upgrade apfel
 ```
@@ -324,7 +323,7 @@ Everything that grows out of apfel. Each project ships as its own repo, its own 
 - **apfel** — on-device Apple FoundationModels CLI and OpenAI-compatible server. The root of the tree; every other project uses it for inference.
   - Site: [https://apfel.franzai.com](https://apfel.franzai.com)
   - Repo: [https://github.com/Arthur-Ficial/apfel](https://github.com/Arthur-Ficial/apfel)
-  - Install: `brew install Arthur-Ficial/tap/apfel`
+  - Install: `brew install apfel`
 
 ### Apps
 

--- a/docs/brew-install.md
+++ b/docs/brew-install.md
@@ -1,9 +1,8 @@
 # Install with Homebrew
 
-`apfel` is available through the `Arthur-Ficial/tap` tap:
+`apfel` is available in `homebrew-core`:
 
 ```bash
-brew tap Arthur-Ficial/tap
 brew install apfel
 ```
 
@@ -39,4 +38,4 @@ brew --prefix
 
 ## Maintainers
 
-See [release.md](release.md) for the release workflow and Homebrew tap maintenance.
+See [release.md](release.md) for the release workflow.

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,6 @@
 ## Option 1: Homebrew (recommended)
 
 ```bash
-brew tap Arthur-Ficial/tap
 brew install apfel
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,4 +1,4 @@
-# Release & Homebrew Tap Maintenance
+# Release & Homebrew Packaging
 
 ## How releases work
 
@@ -10,19 +10,6 @@ The `Publish Release` GitHub Actions workflow handles everything:
 4. Regenerates `Sources/BuildInfo.swift` and updates the README version badge
 5. Commits the release files and pushes the Git tag
 6. Publishes `apfel-<version>-arm64-macos.tar.gz` on GitHub Releases
-7. Rewrites and pushes `Formula/apfel.rb` in `Arthur-Ficial/homebrew-tap`
-
-Do not hand-edit `Arthur-Ficial/homebrew-tap` for normal releases.
-
-## One-time setup
-
-Add the `HOMEBREW_TAP_PUSH_TOKEN` secret to `Arthur-Ficial/apfel`:
-
-1. Create a fine-grained GitHub token with **Contents: Read and write** access to `Arthur-Ficial/homebrew-tap`
-2. Store it:
-   ```bash
-   gh secret set HOMEBREW_TAP_PUSH_TOKEN --repo Arthur-Ficial/apfel
-   ```
 
 ## Publishing a release
 
@@ -36,12 +23,11 @@ After the workflow completes:
 
 ```bash
 brew update
-brew tap Arthur-Ficial/tap
-brew reinstall Arthur-Ficial/tap/apfel
-brew test Arthur-Ficial/tap/apfel
-brew audit --strict Arthur-Ficial/tap/apfel
+brew reinstall apfel
+brew test apfel
+brew audit --strict apfel
 ```
 
 ## Local builds
 
-`make build` and `make install` still handle the normal auto-version bump and local release build. The tap is only updated by the publish workflow when a release is actually published (because the formula needs the final published asset SHA).
+`make build` and `make install` still handle the normal auto-version bump and local release build.


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/276365

the following version bumps can be handled via [autobump process](https://github.com/Homebrew/homebrew-core/actions/workflows/autobump.yml)