### PR TITLE
chore: Install demo scripts to bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PREFIX ?= /usr/local
 BINARY = apfel
 VERSION_FILE = .version
 
-.PHONY: check-toolchain build install uninstall clean bump-patch bump-minor bump-major generate-build-info update-readme version release release-patch release-minor release-major package-release-asset print-release-asset print-release-sha256 update-homebrew-formula preflight benchmark test
+.PHONY: check-toolchain build install uninstall install-demo-scripts uninstall-demo-scripts clean bump-patch bump-minor bump-major generate-build-info update-readme version release release-patch release-minor release-major package-release-asset print-release-asset print-release-sha256 update-homebrew-formula preflight benchmark test
+
+DEMO_SCRIPTS = cmd explain gitsum mac-narrator naming oneliner port wtd
 
 # --- Environment checks ---
 
@@ -202,6 +204,32 @@ uninstall:
 			brew link apfel 2>/dev/null || true; \
 		fi; \
 	fi
+
+install-demo-scripts:
+	@repo_root=$$(pwd); \
+	for script in $(DEMO_SCRIPTS); do \
+		src="$$repo_root/demo/$$script"; \
+		dest="$(PREFIX)/bin/$$script"; \
+		if [ -w "$(PREFIX)/bin" ]; then \
+			ln -sf "$$src" "$$dest"; \
+		else \
+			sudo ln -sf "$$src" "$$dest"; \
+		fi; \
+		echo "✓ linked: $$script → $(PREFIX)/bin/$$script"; \
+	done
+
+uninstall-demo-scripts:
+	@for script in $(DEMO_SCRIPTS); do \
+		dest="$(PREFIX)/bin/$$script"; \
+		if [ -L "$$dest" ] || [ -f "$$dest" ]; then \
+			if [ -w "$(PREFIX)/bin" ]; then \
+				rm -f "$$dest"; \
+			else \
+				sudo rm -f "$$dest"; \
+			fi; \
+			echo "✓ removed: $(PREFIX)/bin/$$script"; \
+		fi; \
+	done
 
 clean:
 	swift package clean


### PR DESCRIPTION
## Summary

This change installs the demo scripts to bin dir via make.

The project was quite intriguing. I gave it a go. Unfortunately, the local model is not powerful enough to be useful.
However, it maybe possible that the next set of local models can come in handy in everyday workflows.

```bash
~/workspace/apfel >>> docker image ls                                               
REPOSITORY                       TAG           IMAGE ID       CREATED         SIZE
pgvector/pgvector                pg14          23c2907fbff1   8 months ago    627MB
mongo                            6.0           e6ea23317a13   8 months ago    1GB
redis                            6.2           37440b1f783e   9 months ago    179MB
timescale/timescaledb            latest-pg14   0f5553d37abb   11 months ago   1.68GB
prom/prometheus                  v2.53.4       502ad90314c7   13 months ago   369MB
temporalio/auto-setup            1.24.2        10e8c557ace5   21 months ago   546MB
temporalio/ui                    2.28.0        629b3e444f0b   21 months ago   126MB
rediscommander/redis-commander   latest        19cd0c49f418   4 years ago     133MB

~/workspace/apfel >>> cmd "how do i get all image ids in docker image ls command"                                                                                                                              
$ docker image ls | grep ID

~/workspace/apfel >>> cmd "how do i get the 3rd column of a command output"                                                                                                                                    
$ column -s 3 <output>

~/workspace/apfel >>> docker image ls | column -s 3                                                                                                                                                        
REPOSITORY                       TAG           IMAGE ID       CREATED         SIZE      timescale/timescaledb            latest-pg14   0f5553d37abb   11 months ago   1.68GB
scrollmark-api                   latest        4f41e1fb3f15   6 hours ago     6.6GB     prom/prometheus                  v2.53.4       502ad90314c7   13 months ago   369MB
pgvector/pgvector                pg14          23c2907fbff1   8 months ago    627MB     temporalio/auto-setup            1.24.2        10e8c557ace5   21 months ago   546MB
mongo                            6.0           e6ea23317a13   8 months ago    1GB       temporalio/ui                    2.28.0        629b3e444f0b   21 months ago   126MB
redis                            6.2           37440b1f783e   9 months ago    179MB     rediscommander/redis-commander   latest        19cd0c49f418   4 years ago     133MB

~/workspace/apfel >>> cmd "how do i get the 3rd column of a command output"                                                                                                                                    
$ `echo $1 | head -n 1 | awk '{print $3}'`

~/workspace/apfel >>> docker image ls | echo $1 | head -n 1 | awk '{print $3}'                                                                                                                             
# empty

~/workspace/apfel >>> docker image ls | awk '{print $3}'                                                                                                                                                   
IMAGE
4f41e1fb3f15
23c2907fbff1
e6ea23317a13
37440b1f783e
0f5553d37abb
502ad90314c7
10e8c557ace5
629b3e444f0b
19cd0c49f418                                                                                                                                                                            

~/workspace/apfel >>> explain "docker image ls | awk '{print $3}' "                                                                                                                                        
The command `docker image ls | awk '{print }'` is used to list all Docker images stored in a Docker registry
or local Docker container. The `docker image ls` command retrieves a list of all Docker images present in the
registry or the local Docker environment. The `awk` command is then used to filter out the output, which in
this case is simply printing the image names without any additional formatting.

This command will output a list of all Docker images, each on a new line, but since the `awk` command only
prints the output, it does not modify the output further, and you'll see the image names directly from the
Docker command's output.
```