### PR TITLE
[test] Synthetic PR to verify routine fires (will close)

### DIFF
--- a/docs/routines.md
+++ b/docs/routines.md
@@ -47,6 +47,10 @@ For the operator-level guide - how prompts are version-controlled, how kill-swit
 | 3 | Distribution-channel sync watch | Deferred until Phase 2 is stable |
 | - | Stale issue sweep, first-time CI approval as standalone, post-release verify | Not planned |
 
+## Status
+
+Phase 1 went live 2026-04-14.
+
 ## Security note
 
 The Claude GitHub App is installed on `Arthur-Ficial/apfel` **only**, with minimum GitHub permissions: Contents (Read), Issues (Read + Write), Pull requests (Read + Write). It is explicitly NOT installed on `Arthur-Ficial/homebrew-tap`, `Arthur-Ficial/nixpkgs`, or `NixOS/nixpkgs` - those are release-side repos and routines must never reach them.


### PR DESCRIPTION
**This is a synthetic test PR to verify the new Claude Code PR auto-review routine fires correctly.** It will be closed without merging as soon as the routine posts its review.

Expected routine behavior:
- Fires on \`pull_request.opened\`
- Posts a \`COMMENTED\` review (not \`APPROVED\`)
- Review body ends with \`cc @franzenzenhofer\`
- Classifies as docs-only (no security audit needed)
- Explicitly discloses "functional correctness not verified"

Trivial docs-only change: adds a Phase 1 go-live date to \`docs/routines.md\`.

cc @franzenzenhofer - routine verification in progress.