### PR TITLE
refactor: extract pure SchemaIR + SchemaParser (#94)

### DIFF
--- a/Sources/Core/SchemaIR.swift
+++ b/Sources/Core/SchemaIR.swift
@@ -1,0 +1,34 @@
+// ============================================================================
+// SchemaIR.swift — Pure intermediate representation for JSON Schema
+// Part of ApfelCore — no FoundationModels dependency
+//
+// The tool-calling surface needs to convert arbitrary OpenAI JSON Schema
+// into FoundationModels' DynamicGenerationSchema. Doing the parsing into this
+// pure IR first lets us unit-test the parser without the FM framework.
+// The adapter from IR -> DynamicGenerationSchema lives in the main target
+// and is mechanical enough to not need dedicated tests.
+// ============================================================================
+
+import Foundation
+
+public indirect enum SchemaIR: Equatable, Sendable {
+    case object(name: String, description: String?, properties: [Property])
+    case string(name: String, description: String?, enumValues: [String]?)
+    case number(name: String, description: String?)   // covers integer + number
+    case bool(name: String, description: String?)
+    case array(itemName: String, items: SchemaIR)
+
+    public struct Property: Equatable, Sendable {
+        public let name: String
+        public let description: String?
+        public let schema: SchemaIR
+        public let isOptional: Bool
+
+        public init(name: String, description: String?, schema: SchemaIR, isOptional: Bool) {
+            self.name = name
+            self.description = description
+            self.schema = schema
+            self.isOptional = isOptional
+        }
+    }
+}

--- a/Sources/Core/SchemaParser.swift
+++ b/Sources/Core/SchemaParser.swift
@@ -1,0 +1,78 @@
+// ============================================================================
+// SchemaParser.swift — Pure JSON Schema -> SchemaIR converter
+// Part of ApfelCore — no FoundationModels dependency
+//
+// Mirrors the subset of JSON Schema that FoundationModels'
+// DynamicGenerationSchema can represent: object, string (with enum),
+// number/integer, boolean, and array-of-something.
+// ============================================================================
+
+import Foundation
+
+public enum SchemaParser {
+    public enum Error: Swift.Error, Equatable {
+        case invalidJSON
+        case unsupportedType(String)
+        case missingArrayItems
+    }
+
+    public static func parse(json: String, name: String) throws -> SchemaIR {
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw Error.invalidJSON
+        }
+        return try parseObject(obj, name: name)
+    }
+
+    /// Parse a single JSON-Schema node. Defaults to `object` when `type` is
+    /// absent (matches OpenAI function-schema conventions where the root
+    /// object sometimes omits its type).
+    private static func parseObject(_ schema: [String: Any], name: String) throws -> SchemaIR {
+        let type = schema["type"] as? String ?? "object"
+        let description = schema["description"] as? String
+
+        switch type {
+        case "object":
+            let propsDict = schema["properties"] as? [String: Any] ?? [:]
+            let required = Set(schema["required"] as? [String] ?? [])
+
+            // Sort keys alphabetically so the IR is deterministic regardless
+            // of JSON dictionary ordering.
+            let sortedKeys = propsDict.keys.sorted()
+            var properties: [SchemaIR.Property] = []
+            properties.reserveCapacity(sortedKeys.count)
+            for key in sortedKeys {
+                guard let propSchema = propsDict[key] as? [String: Any] else { continue }
+                let childIR = try parseObject(propSchema, name: key)
+                let childDesc = propSchema["description"] as? String
+                properties.append(.init(
+                    name: key,
+                    description: childDesc,
+                    schema: childIR,
+                    isOptional: !required.contains(key)
+                ))
+            }
+            return .object(name: name, description: description, properties: properties)
+
+        case "string":
+            let enumValues = schema["enum"] as? [String]
+            return .string(name: name, description: description, enumValues: enumValues)
+
+        case "integer", "number":
+            return .number(name: name, description: description)
+
+        case "boolean":
+            return .bool(name: name, description: description)
+
+        case "array":
+            guard let items = schema["items"] as? [String: Any] else {
+                throw Error.missingArrayItems
+            }
+            let inner = try parseObject(items, name: "\(name)_item")
+            return .array(itemName: name, items: inner)
+
+        default:
+            throw Error.unsupportedType(type)
+        }
+    }
+}

--- a/Sources/SchemaConverter.swift
+++ b/Sources/SchemaConverter.swift
@@ -2,8 +2,12 @@
 // SchemaConverter.swift — Convert OpenAI JSON schemas to native FoundationModels types
 // Part of apfel — Apple Intelligence from the command line
 //
-// Converts OpenAI tool definitions to Transcript.ToolDefinition using
-// DynamicGenerationSchema. Falls back to text injection for unsupported schemas.
+// The pure JSON -> SchemaIR parsing lives in ApfelCore/SchemaParser.swift and
+// is unit-tested there. This file keeps only:
+//   - the SchemaConversionCache actor
+//   - the IR -> DynamicGenerationSchema adapter (a thin, mechanical mapping)
+//   - makeArguments (tool-call argument hydration)
+//   - the convert() / convertUncached() entry points used by callers
 // ============================================================================
 
 import Foundation
@@ -74,22 +78,21 @@ enum SchemaConverter {
         for tool in tools {
             let fn = tool.function
             do {
-                let schema: GenerationSchema
+                let ir: SchemaIR
                 if let paramsJSON = fn.parameters?.value {
-                    let dynSchema = try convertJSONSchema(json: paramsJSON, name: fn.name)
-                    schema = try GenerationSchema(root: dynSchema, dependencies: [])
+                    ir = try SchemaParser.parse(json: paramsJSON, name: fn.name)
                 } else {
-                    // No parameters — empty object schema
-                    let dynSchema = DynamicGenerationSchema(name: fn.name, properties: [])
-                    schema = try GenerationSchema(root: dynSchema, dependencies: [])
+                    ir = .object(name: fn.name, description: nil, properties: [])
                 }
+                let dynSchema = try dynamicSchema(from: ir)
+                let schema = try GenerationSchema(root: dynSchema, dependencies: [])
                 native.append(Transcript.ToolDefinition(
                     name: fn.name,
                     description: fn.description ?? fn.name,
                     parameters: schema
                 ))
             } catch {
-                // Conversion failed — fall back to text injection for this tool
+                // Conversion failed - fall back to text injection for this tool
                 fallback.append(ToolDef(
                     name: fn.name,
                     description: fn.description,
@@ -114,68 +117,38 @@ enum SchemaConverter {
         return nil
     }
 
-    // MARK: - Private
+    // MARK: - IR -> DynamicGenerationSchema adapter
 
-    /// Recursively convert an OpenAI JSON Schema string to DynamicGenerationSchema.
-    private static func convertJSONSchema(json: String, name: String) throws -> DynamicGenerationSchema {
-        guard let data = json.data(using: .utf8),
-              let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw ConversionError.invalidJSON
-        }
-        return try convertObject(obj, name: name)
-    }
-
-    /// Recursively convert a JSON Schema dictionary to DynamicGenerationSchema.
-    private static func convertObject(_ schema: [String: Any], name: String) throws -> DynamicGenerationSchema {
-        let type = schema["type"] as? String ?? "object"
-        let description = schema["description"] as? String
-
-        switch type {
-        case "object":
-            let properties = schema["properties"] as? [String: Any] ?? [:]
-            let required = Set(schema["required"] as? [String] ?? [])
-
-            var dynProps: [DynamicGenerationSchema.Property] = []
-            for (propName, propValue) in properties.sorted(by: { $0.key < $1.key }) {
-                guard let propSchema = propValue as? [String: Any] else { continue }
-                let propDyn = try convertObject(propSchema, name: propName)
-                let propDesc = propSchema["description"] as? String
-                dynProps.append(.init(
-                    name: propName,
-                    description: propDesc,
-                    schema: propDyn,
-                    isOptional: !required.contains(propName)
-                ))
+    /// Thin mechanical adapter. Tested indirectly via integration tests that
+    /// round-trip an OpenAI tool through `convertUncached`. The parsing half
+    /// is covered by SchemaParserTests.
+    private static func dynamicSchema(from ir: SchemaIR) throws -> DynamicGenerationSchema {
+        switch ir {
+        case .object(let name, let description, let properties):
+            let dynProps: [DynamicGenerationSchema.Property] = try properties.map { prop in
+                let childSchema = try dynamicSchema(from: prop.schema)
+                return .init(
+                    name: prop.name,
+                    description: prop.description,
+                    schema: childSchema,
+                    isOptional: prop.isOptional
+                )
             }
             return DynamicGenerationSchema(name: name, description: description, properties: dynProps)
 
-        case "string":
-            if let enumValues = schema["enum"] as? [String] {
-                return DynamicGenerationSchema(name: name, description: description, anyOf: enumValues)
+        case .string(let name, let description, let enumValues):
+            if let values = enumValues {
+                return DynamicGenerationSchema(name: name, description: description, anyOf: values)
             }
-            // Plain string — empty properties object acts as a leaf
             return DynamicGenerationSchema(name: name, description: description, properties: [])
 
-        case "integer", "number":
+        case .number(let name, let description),
+             .bool(let name, let description):
             return DynamicGenerationSchema(name: name, description: description, properties: [])
 
-        case "boolean":
-            return DynamicGenerationSchema(name: name, description: description, properties: [])
-
-        case "array":
-            if let items = schema["items"] as? [String: Any] {
-                let itemSchema = try convertObject(items, name: "\(name)_item")
-                return DynamicGenerationSchema(arrayOf: itemSchema)
-            }
-            throw ConversionError.unsupportedType("array without items")
-
-        default:
-            throw ConversionError.unsupportedType(type)
+        case .array(_, let items):
+            let inner = try dynamicSchema(from: items)
+            return DynamicGenerationSchema(arrayOf: inner)
         }
-    }
-
-    enum ConversionError: Error {
-        case invalidJSON
-        case unsupportedType(String)
     }
 }

--- a/Tests/apfelTests/SchemaParserTests.swift
+++ b/Tests/apfelTests/SchemaParserTests.swift
@@ -1,0 +1,328 @@
+// ============================================================================
+// SchemaParserTests.swift — Unit tests for SchemaParser + SchemaIR
+// Covers JSON Schema -> pure IR parsing. The FoundationModels adapter
+// (SchemaIR -> DynamicGenerationSchema) is covered separately by integration.
+// ============================================================================
+
+import Foundation
+import ApfelCore
+
+func runSchemaParserTests() {
+    // MARK: Primitives
+
+    test("parse string primitive") {
+        let ir = try SchemaParser.parse(json: #"{"type":"string"}"#, name: "s")
+        guard case .string(let name, let desc, let enums) = ir else {
+            throw TestFailure("expected .string, got \(ir)")
+        }
+        try assertEqual(name, "s")
+        try assertNil(desc)
+        try assertNil(enums)
+    }
+
+    test("parse integer primitive") {
+        let ir = try SchemaParser.parse(json: #"{"type":"integer"}"#, name: "i")
+        guard case .number(let name, _) = ir else {
+            throw TestFailure("expected .number for integer, got \(ir)")
+        }
+        try assertEqual(name, "i")
+    }
+
+    test("parse number primitive") {
+        let ir = try SchemaParser.parse(json: #"{"type":"number"}"#, name: "n")
+        guard case .number = ir else {
+            throw TestFailure("expected .number, got \(ir)")
+        }
+    }
+
+    test("parse boolean primitive") {
+        let ir = try SchemaParser.parse(json: #"{"type":"boolean"}"#, name: "b")
+        guard case .bool = ir else {
+            throw TestFailure("expected .bool, got \(ir)")
+        }
+    }
+
+    test("description preserved on primitive") {
+        let ir = try SchemaParser.parse(json: #"{"type":"string","description":"city name"}"#, name: "city")
+        guard case .string(_, let desc, _) = ir else {
+            throw TestFailure("expected .string")
+        }
+        try assertEqual(desc, "city name")
+    }
+
+    // MARK: String enums
+
+    test("string with enum produces enumValues") {
+        let ir = try SchemaParser.parse(
+            json: #"{"type":"string","enum":["celsius","fahrenheit"]}"#,
+            name: "unit"
+        )
+        guard case .string(_, _, let enums) = ir else {
+            throw TestFailure("expected .string with enum")
+        }
+        try assertEqual(enums ?? [], ["celsius", "fahrenheit"])
+    }
+
+    test("string without enum has nil enumValues") {
+        let ir = try SchemaParser.parse(json: #"{"type":"string"}"#, name: "free")
+        guard case .string(_, _, let enums) = ir else {
+            throw TestFailure("expected .string")
+        }
+        try assertNil(enums)
+    }
+
+    // MARK: Objects
+
+    test("empty object") {
+        let ir = try SchemaParser.parse(json: #"{"type":"object"}"#, name: "obj")
+        guard case .object(_, _, let props) = ir else {
+            throw TestFailure("expected .object")
+        }
+        try assertEqual(props.count, 0)
+    }
+
+    test("object with one required property") {
+        let json = #"""
+        {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "weather")
+        guard case .object(_, _, let props) = ir else {
+            throw TestFailure("expected .object")
+        }
+        try assertEqual(props.count, 1)
+        try assertEqual(props[0].name, "city")
+        try assertTrue(!props[0].isOptional, "required property must not be optional")
+    }
+
+    test("object with optional property") {
+        let json = #"""
+        {"type":"object","properties":{"unit":{"type":"string"}}}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "config")
+        guard case .object(_, _, let props) = ir else {
+            throw TestFailure("expected .object")
+        }
+        try assertEqual(props.count, 1)
+        try assertTrue(props[0].isOptional, "property not in required must be optional")
+    }
+
+    test("object properties sorted alphabetically for determinism") {
+        // Parsers that hash dicts must still yield deterministic output.
+        let json = #"""
+        {"type":"object","properties":{"z":{"type":"string"},"a":{"type":"string"},"m":{"type":"string"}}}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "obj")
+        guard case .object(_, _, let props) = ir else {
+            throw TestFailure("expected .object")
+        }
+        try assertEqual(props.map { $0.name }, ["a", "m", "z"])
+    }
+
+    test("object with mix of required and optional") {
+        let json = #"""
+        {"type":"object","properties":{"city":{"type":"string"},"unit":{"type":"string"}},"required":["city"]}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "weather")
+        guard case .object(_, _, let props) = ir else {
+            throw TestFailure("expected .object")
+        }
+        try assertEqual(props.count, 2)
+        let byName = Dictionary(uniqueKeysWithValues: props.map { ($0.name, $0.isOptional) })
+        try assertEqual(byName["city"] ?? true, false)
+        try assertEqual(byName["unit"] ?? false, true)
+    }
+
+    test("object property descriptions preserved") {
+        let json = #"""
+        {"type":"object","properties":{"city":{"type":"string","description":"City name"}}}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "obj")
+        guard case .object(_, _, let props) = ir else { throw TestFailure("expected .object") }
+        try assertEqual(props[0].description, "City name")
+    }
+
+    // MARK: Nested objects
+
+    test("nested object (2 levels)") {
+        let json = #"""
+        {"type":"object","properties":{"location":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}},"required":["location"]}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "root")
+        guard case .object(_, _, let props) = ir, props.count == 1 else {
+            throw TestFailure("expected outer object with 1 property")
+        }
+        guard case .object(_, _, let innerProps) = props[0].schema else {
+            throw TestFailure("expected nested object")
+        }
+        try assertEqual(innerProps.count, 1)
+        try assertEqual(innerProps[0].name, "city")
+        try assertTrue(!innerProps[0].isOptional)
+    }
+
+    test("nested object (3 levels) does not stack overflow") {
+        let json = #"""
+        {"type":"object","properties":{"a":{"type":"object","properties":{"b":{"type":"object","properties":{"c":{"type":"string"}}}}}}}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "root")
+        // Just walking it must not throw or overflow.
+        guard case .object(_, _, let l1) = ir else { throw TestFailure("level 1") }
+        guard case .object(_, _, let l2) = l1[0].schema else { throw TestFailure("level 2") }
+        guard case .object(_, _, let l3) = l2[0].schema else { throw TestFailure("level 3") }
+        try assertEqual(l3[0].name, "c")
+    }
+
+    // MARK: Arrays
+
+    test("array of strings") {
+        let json = #"""
+        {"type":"array","items":{"type":"string"}}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "tags")
+        guard case .array(_, let items) = ir else {
+            throw TestFailure("expected .array, got \(ir)")
+        }
+        guard case .string = items else {
+            throw TestFailure("expected array items to be .string")
+        }
+    }
+
+    test("array of objects") {
+        let json = #"""
+        {"type":"array","items":{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}}
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "users")
+        guard case .array(_, let items) = ir else {
+            throw TestFailure("expected .array")
+        }
+        guard case .object(_, _, let props) = items else {
+            throw TestFailure("expected array items to be .object")
+        }
+        try assertEqual(props[0].name, "id")
+    }
+
+    test("array without items throws missingArrayItems") {
+        do {
+            _ = try SchemaParser.parse(json: #"{"type":"array"}"#, name: "bad")
+            throw TestFailure("expected throw")
+        } catch SchemaParser.Error.missingArrayItems {
+            // expected
+        }
+    }
+
+    // MARK: Error cases
+
+    test("malformed JSON throws invalidJSON") {
+        do {
+            _ = try SchemaParser.parse(json: "{not json}", name: "bad")
+            throw TestFailure("expected throw")
+        } catch SchemaParser.Error.invalidJSON {
+            // expected
+        }
+    }
+
+    test("non-object top-level JSON throws invalidJSON") {
+        do {
+            _ = try SchemaParser.parse(json: "[1,2,3]", name: "bad")
+            throw TestFailure("expected throw")
+        } catch SchemaParser.Error.invalidJSON {
+            // expected
+        }
+    }
+
+    test("unknown type throws unsupportedType") {
+        do {
+            _ = try SchemaParser.parse(json: #"{"type":"bigint"}"#, name: "bad")
+            throw TestFailure("expected throw")
+        } catch SchemaParser.Error.unsupportedType(let t) {
+            try assertEqual(t, "bigint")
+        }
+    }
+
+    test("missing type defaults to object") {
+        // OpenAI function schemas sometimes omit "type" on the root. Treating
+        // root as object matches convertObject's existing behaviour.
+        let ir = try SchemaParser.parse(
+            json: #"{"properties":{"x":{"type":"string"}}}"#,
+            name: "root"
+        )
+        guard case .object = ir else {
+            throw TestFailure("expected .object when type omitted")
+        }
+    }
+
+    // MARK: Real-world fixtures
+
+    test("OpenAI weather function fixture") {
+        let json = #"""
+        {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "The city and state, e.g. San Francisco, CA"
+            },
+            "unit": {
+              "type": "string",
+              "enum": ["celsius", "fahrenheit"]
+            }
+          },
+          "required": ["location"]
+        }
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "get_current_weather")
+        guard case .object(let objName, _, let props) = ir else {
+            throw TestFailure("expected .object")
+        }
+        try assertEqual(objName, "get_current_weather")
+        try assertEqual(props.count, 2)
+        // Alphabetical: location, unit
+        try assertEqual(props[0].name, "location")
+        try assertEqual(props[1].name, "unit")
+        try assertTrue(!props[0].isOptional, "location is required")
+        try assertTrue(props[1].isOptional, "unit is optional")
+        guard case .string(_, _, let unitEnums) = props[1].schema else {
+            throw TestFailure("unit must be string")
+        }
+        try assertEqual(unitEnums ?? [], ["celsius", "fahrenheit"])
+    }
+
+    test("MCP calculator fixture") {
+        let json = #"""
+        {
+          "type": "object",
+          "properties": {
+            "a": {"type": "number", "description": "first operand"},
+            "b": {"type": "number", "description": "second operand"},
+            "op": {"type": "string", "enum": ["add", "sub", "mul", "div"]}
+          },
+          "required": ["a", "b", "op"]
+        }
+        """#
+        let ir = try SchemaParser.parse(json: json, name: "calc")
+        guard case .object(_, _, let props) = ir else { throw TestFailure("expected .object") }
+        try assertEqual(props.count, 3)
+        // All required
+        try assertTrue(props.allSatisfy { !$0.isOptional })
+        // op has enum
+        let op = props.first { $0.name == "op" }!
+        guard case .string(_, _, let opEnums) = op.schema else { throw TestFailure("op must be string") }
+        try assertEqual(opEnums ?? [], ["add", "sub", "mul", "div"])
+    }
+
+    // MARK: Equatable / determinism
+
+    test("identical JSON parses to identical IR (Equatable)") {
+        let json = #"""
+        {"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}
+        """#
+        let a = try SchemaParser.parse(json: json, name: "t")
+        let b = try SchemaParser.parse(json: json, name: "t")
+        try assertTrue(a == b, "parser output not deterministic")
+    }
+
+    test("different JSON parses to different IR (Equatable)") {
+        let a = try SchemaParser.parse(json: #"{"type":"object","properties":{"x":{"type":"string"}}}"#, name: "t")
+        let b = try SchemaParser.parse(json: #"{"type":"object","properties":{"y":{"type":"string"}}}"#, name: "t")
+        try assertTrue(a != b)
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -87,6 +87,7 @@ suite("CLIArgumentsTests") { runCLIArgumentsTests() }
 suite("ModelAvailabilityTests") { runModelAvailabilityTests() }
 suite("CLIErrorsTests") { runCLIErrorsTests() }
 suite("CLIValidateTests") { runCLIValidateTests() }
+suite("SchemaParserTests") { runSchemaParserTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
Closes #94.

## What changed

`SchemaConverter.convertJSONSchema` / `convertObject` was a recursive parser that was entirely untestable because it produced `DynamicGenerationSchema` (FoundationModels-only). Extracted the pure parsing half into `ApfelCore/SchemaParser.swift` + `SchemaIR`, kept the FM-aware adapter in `SchemaConverter.swift`.

- `Sources/Core/SchemaIR.swift` (new, ~30 lines): pure `indirect enum`, `Equatable`, `Sendable`, no FM dep.
- `Sources/Core/SchemaParser.swift` (new, ~70 lines): `parse(json:name:) throws -> SchemaIR`, explicit error cases.
- `Sources/SchemaConverter.swift` (net -20 lines): keeps the actor cache, delegates parsing to `SchemaParser`, adds a thin `dynamicSchema(from: SchemaIR)` adapter.
- `Tests/apfelTests/SchemaParserTests.swift` (new): 26 cases covering primitives, enums, required/optional split, 3-level nesting (no stack overflow), arrays, error paths, determinism, OpenAI + MCP real-world fixtures.

Net: 392 tests (was 366). `swift build` clean. No user-visible changes.

## Why this is a patch release

No CLI flags added. No server-behaviour change. Same subset of JSON Schema supported. Pure internal refactor + test surface.

## Test plan

- [x] `swift build` clean
- [x] `swift run apfel-tests` - 392 pass, 0 fail
- [ ] Integration tests (model-free subset) locally
- [ ] Full integration suite with Apple Intelligence (local only - CI runners lack it)
- [ ] `make preflight` before any release
- [ ] End-to-end smoke on `apfel --serve` with a tool definition exercising every IR branch
- [ ] Post-release verify after tag publish

cc @franzenzenhofer - draft PR conventions aside, I actually want the auto-review routine to pass over this for a second pair of eyes. Human final sign-off + merge stays with you.