### PR TITLE
chore: verify PR auto-review routine fires

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -172,3 +172,5 @@ Then invoke them as `apfel-cmd "find large files"`, `apfel-port 3000`, etc.
 - The symlinks point at your current clone. If you move or delete the `apfel/` directory, the symlinks break - re-run the loop from the new location.
 - Make sure `$HOME/.local/bin` is on your `$PATH` (`echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc`).
 - To remove later: `for d in cmd explain gitsum mac-narrator naming oneliner port wtd; do rm -f "$HOME/.local/bin/apfel-$d"; done`
+
+<!-- routine-fire verify: this line is temporary for PR auto-review trigger test -->


### PR DESCRIPTION
Single-line harmless change. Opening to verify the 02-pr-auto-review routine triggers the webhook after I recreated it with both pull_request.opened + pull_request.synchronize events. Will close/revert after the routine posts a review.

cc @franzenzenhofer