### PR TITLE
fix(build): stop regenerating BuildInfo.swift on every local build (#108)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ check-toolchain:
 
 # --- Build ---
 
-build: check-toolchain generate-build-info
+build: check-toolchain
 	swift build -c release
 	@$(MAKE) --no-print-directory generate-man-page
 

--- a/Tests/integration/test_build_info.py
+++ b/Tests/integration/test_build_info.py
@@ -1,0 +1,51 @@
+"""
+apfel Integration Tests - BuildInfo.swift hygiene.
+
+The `build` target must NOT depend on `generate-build-info` so that routine
+local dev commands (`make build`, `make install`, `make test`) do not leave
+Sources/BuildInfo.swift dirty with unrelated commit/date churn.
+
+Only the release targets (`release-patch`, `release-minor`, `release-major`)
+should regenerate build metadata.
+"""
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MAKEFILE = ROOT / "Makefile"
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text()
+
+
+def _target_deps(text: str, target: str) -> list[str]:
+    """Return the dependency list for a Makefile target line like 'target: dep1 dep2'."""
+    pattern = rf"^{re.escape(target)}\s*:(.*?)$"
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match:
+        return []
+    return match.group(1).split()
+
+
+def test_build_target_does_not_depend_on_generate_build_info():
+    """make build must not regenerate BuildInfo.swift - that is release-only."""
+    text = _makefile_text()
+    deps = _target_deps(text, "build")
+    assert "generate-build-info" not in deps, (
+        "The 'build' target depends on 'generate-build-info', which causes "
+        "Sources/BuildInfo.swift to be rewritten on every build. "
+        "This dependency should only exist on release targets."
+    )
+
+
+def test_release_targets_still_depend_on_generate_build_info():
+    """release-patch/minor/major must regenerate BuildInfo.swift."""
+    text = _makefile_text()
+    for target in ("release-patch", "release-minor", "release-major"):
+        deps = _target_deps(text, target)
+        assert "generate-build-info" in deps, (
+            f"The '{target}' target must depend on 'generate-build-info' "
+            "so release builds get fresh commit/date metadata."
+        )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #108.

## Root cause

The `build` Makefile target depended on `generate-build-info`, which rewrites `Sources/BuildInfo.swift` with the current HEAD commit hash and timestamp. Since `buildCommit` and `buildDate` change with every new commit (and `buildDate` changes between runs due to the timestamp), `Sources/BuildInfo.swift` was left dirty after any `make build`, `make install`, or `make test`. The existing `cmp -s` guard only prevents a rewrite when content is byte-identical - but that is never true across commits or even across runs on the same commit.

## The fix

Removed `generate-build-info` from the `build` target's dependency list (Makefile line 49). The release targets (`release-patch`, `release-minor`, `release-major`) already have their own explicit dependency on `generate-build-info`, so release builds continue to get fresh commit/date metadata. Dev builds now use whatever `BuildInfo.swift` is already checked in - which is the last release's metadata, exactly matching the project rule that this file is release-workflow output.

## Test coverage

- Added `Tests/integration/test_build_info.py::test_build_target_does_not_depend_on_generate_build_info` to lock the fix in place.
- Added `Tests/integration/test_build_info.py::test_release_targets_still_depend_on_generate_build_info` to ensure release targets retain the dependency.
- Both tests parse the Makefile statically and verify the dependency chain - no server or binary required.

## What I verified (static only)

- Makefile `build` target no longer lists `generate-build-info` as a dependency.
- Release targets (`release-patch`, `release-minor`, `release-major`) still list `generate-build-info`.
- The `generate-build-info` target itself is unchanged and still listed in `.PHONY`.
- The `test` target chains through `build`, so it also benefits from this fix.
- Diff is limited to `Makefile` (1 line changed) and the new test file - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or `swift build`. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward build-system hygiene bug reported by the repo owner.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._