### PR TITLE
test: lock MCPProtocol edge cases and ChatRequestValidator priority (#105)

### DIFF
--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -38,6 +38,26 @@ func runMCPClientTests() {
         try assertEqual(args["a"] as! Int, 247)
     }
 
+    test("formatToolsCall falls back to empty object when arguments are invalid JSON") {
+        let msg = MCPProtocol.toolsCallRequest(id: 3, name: "multiply", arguments: "{not json}")
+        let data = msg.data(using: .utf8)!
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let params = obj["params"] as! [String: Any]
+        let args = params["arguments"] as! [String: Any]
+        try assertEqual(args.count, 0)
+    }
+
+    test("formatToolsCall preserves JSON array arguments") {
+        let msg = MCPProtocol.toolsCallRequest(id: 3, name: "sum", arguments: "[1,2,3]")
+        let data = msg.data(using: .utf8)!
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let params = obj["params"] as! [String: Any]
+        let args = params["arguments"] as! [Any]
+        try assertEqual(args.count, 3)
+        try assertEqual(args[0] as? Int, 1)
+        try assertEqual(args[2] as? Int, 3)
+    }
+
     test("formatNotificationInitialized has no id") {
         let msg = MCPProtocol.initializedNotification()
         let data = msg.data(using: .utf8)!
@@ -55,6 +75,15 @@ func runMCPClientTests() {
         let info = try MCPProtocol.parseInitializeResponse(json)
         try assertEqual(info.name, "calc")
         try assertEqual(info.version, "1.0")
+    }
+
+    test("parseInitializeResponse defaults missing name and version to unknown") {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"result":{"serverInfo":{}}}
+        """
+        let info = try MCPProtocol.parseInitializeResponse(json)
+        try assertEqual(info.name, "unknown")
+        try assertEqual(info.version, "unknown")
     }
 
     test("parseToolsListResponse extracts tool definitions") {
@@ -78,12 +107,30 @@ func runMCPClientTests() {
         try assertEqual(tools[1].function.name, "multiply")
     }
 
+    test("parseToolsListResponse drops nameless tool entries") {
+        let json = """
+        {"jsonrpc":"2.0","id":2,"result":{"tools":[{"description":"broken","inputSchema":{"type":"object","properties":{}}},{"name":"multiply","description":"Multiply","inputSchema":{"type":"object","properties":{}}}]}}
+        """
+        let tools = try MCPProtocol.parseToolsListResponse(json)
+        try assertEqual(tools.count, 1)
+        try assertEqual(tools[0].function.name, "multiply")
+    }
+
     test("parseToolCallResponse extracts text result") {
         let json = """
         {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"20501"}],"isError":false}}
         """
         let result = try MCPProtocol.parseToolCallResponse(json)
         try assertEqual(result.text, "20501")
+        try assertTrue(!result.isError)
+    }
+
+    test("parseToolCallResponse returns the first content item when multiple are present") {
+        let json = """
+        {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"first"},{"type":"text","text":"second"}],"isError":false}}
+        """
+        let result = try MCPProtocol.parseToolCallResponse(json)
+        try assertEqual(result.text, "first")
         try assertTrue(!result.isError)
     }
 
@@ -103,6 +150,15 @@ func runMCPClientTests() {
         let result = try MCPProtocol.parseToolCallResponse(json)
         try assertTrue(result.isError)
         try assertTrue(result.text.contains("Unknown tool"))
+    }
+
+    test("parseToolCallResponse uses fallback text when JSON-RPC error omits message") {
+        let json = """
+        {"jsonrpc":"2.0","id":5,"error":{"code":-32603}}
+        """
+        let result = try MCPProtocol.parseToolCallResponse(json)
+        try assertTrue(result.isError)
+        try assertEqual(result.text, "Unknown MCP error")
     }
 
     // MARK: - Edge cases

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -83,6 +83,30 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?["type"] as? String, "object")
         try assertNotNil((parsed?["properties"] as? [String: Any])?["city"])
     }
+
+    test("RawJSON decodes scalar JSON string as a quoted JSON literal") {
+        let raw = try decode(RawJSON.self, from: #""hello""#)
+        try assertEqual(raw.value, #""hello""#)
+    }
+
+    test("RawJSON decodes scalar number as a numeric JSON literal") {
+        let raw = try decode(RawJSON.self, from: "42")
+        try assertEqual(raw.value, "42")
+    }
+
+    test("RawJSON decodes scalar boolean as a boolean JSON literal") {
+        let raw = try decode(RawJSON.self, from: "true")
+        try assertEqual(raw.value, "true")
+    }
+
+    test("RawJSON decodes arrays as valid JSON array text") {
+        let raw = try decode(RawJSON.self, from: #"[1,"two",false]"#)
+        let parsed = try JSONSerialization.jsonObject(with: Data(raw.value.utf8)) as? [Any]
+        try assertEqual(parsed?.count, 3)
+        try assertEqual(parsed?[0] as? Int, 1)
+        try assertEqual(parsed?[1] as? String, "two")
+        try assertEqual(parsed?[2] as? Bool, false)
+    }
 }
 
 func runChatRequestValidatorTests() {
@@ -207,6 +231,111 @@ func runChatRequestValidatorTests() {
         if case .invalidParameterValue = ChatRequestValidator.validate(request) { } else {
             throw TestFailure("expected .invalidParameterValue for x_context_output_reserve=-1")
         }
+    }
+
+    test("unsupported parameter detection prefers logprobs over every later unsupported field") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"logprobs":true,"n":2,"stop":"done","presence_penalty":1,"frequency_penalty":1}"#
+        )
+        try assertEqual(UnsupportedChatParameter.detect(in: request), .logprobs)
+    }
+
+    test("unsupported parameter detection prefers n over stop and penalties") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"n":2,"stop":"done","presence_penalty":1,"frequency_penalty":1}"#
+        )
+        try assertEqual(UnsupportedChatParameter.detect(in: request), .n)
+    }
+
+    test("unsupported parameter detection prefers stop over penalties") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"stop":"done","presence_penalty":1,"frequency_penalty":1}"#
+        )
+        try assertEqual(UnsupportedChatParameter.detect(in: request), .stop)
+    }
+
+    test("unsupported parameter detection prefers presence penalty over frequency penalty") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"presence_penalty":1,"frequency_penalty":1}"#
+        )
+        try assertEqual(UnsupportedChatParameter.detect(in: request), .presencePenalty)
+    }
+
+    test("validator prioritizes empty messages before invalid model") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"gpt-4o","messages":[]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .emptyMessages)
+    }
+
+    test("validator prioritizes invalid model before unsupported parameters") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"logprobs":true}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .invalidModel("gpt-4o"))
+    }
+
+    test("validator prioritizes unsupported parameters before invalid last role") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"assistant","content":"hi"}],"logprobs":true}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unsupportedParameter(.logprobs))
+    }
+
+    test("validator prioritizes invalid last role before image content") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"assistant","content":[{"type":"image_url"}]}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .invalidLastRole)
+    }
+
+    test("validator prioritizes image content before numeric parameter validation") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":[{"type":"image_url"}]}],"max_tokens":0,"temperature":-1}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .imageContent)
+    }
+
+    test("validator reports max_tokens before later invalid numeric fields") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"max_tokens":0,"temperature":-1,"x_context_max_turns":0,"x_context_output_reserve":0}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'max_tokens' must be a positive integer, got 0")
+        )
+    }
+
+    test("validator reports temperature before invalid context knobs that follow it") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"temperature":-1,"x_context_max_turns":0,"x_context_output_reserve":0}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'temperature' must be non-negative, got -1.0")
+        )
+    }
+
+    test("validator reports x_context_max_turns before x_context_output_reserve") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"x_context_max_turns":0,"x_context_output_reserve":0}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'x_context_max_turns' must be a positive integer, got 0")
+        )
     }
 }
 


### PR DESCRIPTION
Follow-on coverage for #105 ApfelCore library-grade prep, extending the baseline suite from 52cdaf2 with edge-case behaviour that was not pinned down in the first pass.

## What changes

**Tests only. Zero production code changes.**

- `MCPClientTests.swift` (+6 tests): locks MCPProtocol edge cases that `compactMap`, `?? "unknown"`, `?? "Unknown MCP error"`, and `content.first` already handle - so they cannot silently regress.
- `OpenAIModelsTests.swift` (+14 tests): locks `UnsupportedChatParameter.detect` priority ordering and the full `ChatRequestValidator.validate` priority chain. Also pins `RawJSON` decoding for scalar strings/numbers/bools and JSON arrays.

Suite goes from 519/519 to 541/541 green.

## Why

#105 requires a library-grade public API on `ApfelCore`. Before touching public surface (e.g. `LocalizedError` conformance, `package` access level audits, concurrency refactors), we lock the current observable behaviour with tests so any accidental drift during refactor shows up as a red test rather than a silent breaking change for downstream consumers of `import ApfelCore`.

Every added assertion maps to real production code paths - I walked them against `Sources/Core/MCPProtocol.swift` and `Sources/Core/ChatRequestValidator.swift` before writing the assertions.

## What I verified

- `swift build` clean
- `swift run apfel-tests` → 541/541 pass
- `make test` (unit + 242 integration tests) → all green on an Apple Silicon Mac with Apple Intelligence
- No touches to `Sources/**`, `Makefile`, CI, release infra, policy files, or docs

## Anything suspicious

Nothing. Pure additive test coverage for already-shipping behaviour.

Refs: #105

---

_Draft - needs @franzenzenhofer review before merge._