### PR TITLE
Expose ApfelCore as a public Swift package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Select latest Xcode
         run: |
@@ -53,3 +55,53 @@ jobs:
 
           # Note: performance_test.py requires Apple Intelligence (benchmark runs inference).
           # It runs locally via make preflight / make release.
+
+  apfelcore-public-api:
+    runs-on: macos-26
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select latest Xcode
+        run: |
+          latest=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          if [[ -n "$latest" ]]; then
+            echo "Selecting $latest"
+            sudo xcode-select -s "$latest/Contents/Developer"
+          fi
+          echo "Active SDK: $(xcrun --show-sdk-version)"
+          echo "Swift: $(swift --version 2>&1 | head -1)"
+
+      - name: Build ApfelCore target
+        run: swift build --target ApfelCore
+
+      - name: Strict concurrency build for ApfelCore
+        run: swift build --target ApfelCore -Xswiftc -strict-concurrency=complete
+
+      - name: Build ApfelCore docs
+        run: |
+          mkdir -p "$RUNNER_TEMP/apfelcore-docs"
+          swift package \
+            --allow-writing-to-directory "$RUNNER_TEMP/apfelcore-docs" \
+            generate-documentation \
+            --target ApfelCore \
+            --disable-indexing \
+            --warnings-as-errors \
+            --output-path "$RUNNER_TEMP/apfelcore-docs"
+
+      - name: Diagnose API breakage for ApfelCore
+        run: |
+          baseline=$(git describe --tags --abbrev=0)
+          if git show "${baseline}:Package.swift" | grep -Fq '.library(name: "ApfelCore"'; then
+            swift package diagnose-api-breaking-changes "$baseline" --products ApfelCore
+          else
+            echo "Skipping API breakage check: ${baseline} predates the ApfelCore product."
+          fi
+
+      - name: Install Python test dependencies
+        run: pip3 install --break-system-packages pytest
+
+      - name: Downstream consumer smoke test
+        run: python3 -m pytest Tests/integration/test_apfelcore_package.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Integration tests (model-free subset)
         run: |
           # GitHub-hosted macos-26 runners are Intel with no Apple Intelligence.
-          # We run every test that does NOT need the model. Full 7-suite
-          # qualification (157 tests) runs locally via `make preflight`/`make release`.
+          # We run every test that does NOT need the model. Full integration
+          # qualification runs locally via `make preflight` / `make release`.
 
           # CLI flag/help/version/file tests (no model needed)
           python3 -m pytest Tests/integration/cli_e2e_test.py \
@@ -105,3 +105,6 @@ jobs:
 
       - name: Downstream consumer smoke test
         run: python3 -m pytest Tests/integration/test_apfelcore_package.py -v --tb=short
+
+      - name: ApfelCore examples smoke test
+        run: python3 -m pytest Tests/integration/test_apfelcore_examples.py -v --tb=short

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+        - ApfelCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [https://keepachangelog.com/en/1.1.0/](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [https://semver.org/](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- `ApfelCore` is now exposed as a public Swift Package library product.
+- Added downstream-consumer smoke coverage for importing `ApfelCore` from another package.
+- Added DocC, examples, and package metadata needed to publish `ApfelCore` cleanly.
+
+### Changed
+
+- Replaced the unsafe global debug flag with `ApfelDebugConfiguration`.
+- Serialized same-reader `BufferedLineReader` access so the type is safely `Sendable`.
+- Narrowed package-only streaming and prompt-processing helpers out of the public semver surface.
+
+## [1.0.5] - 2026-04-22
+
+### Added
+
+- Current released CLI, server, and chat functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 - `ApfelCore` is now exposed as a public Swift Package library product.
 - Added downstream-consumer smoke coverage for importing `ApfelCore` from another package.
+- Added smoke coverage for the runnable `Examples/` targets that back the public `ApfelCore` docs.
 - Added DocC, examples, and package metadata needed to publish `ApfelCore` cleanly.
 
 ### Changed

--- a/Examples/ContextStrategies/main.swift
+++ b/Examples/ContextStrategies/main.swift
@@ -1,0 +1,12 @@
+import ApfelCore
+
+let config = ContextConfig(
+    strategy: .slidingWindow,
+    maxTurns: 8,
+    outputReserve: 512,
+    permissive: false
+)
+
+print("strategy=\(config.strategy.rawValue)")
+print("max_turns=\(config.maxTurns ?? 0)")
+print("output_reserve=\(config.outputReserve)")

--- a/Examples/ErrorHandling/main.swift
+++ b/Examples/ErrorHandling/main.swift
@@ -1,0 +1,11 @@
+import ApfelCore
+
+let errors: [ApfelError] = [
+    .rateLimited,
+    .contextOverflow,
+    .unsupportedLanguage("tlh"),
+]
+
+for error in errors {
+    print("\(error.cliLabel) \(error.localizedDescription)")
+}

--- a/Examples/MCPProtocol/main.swift
+++ b/Examples/MCPProtocol/main.swift
@@ -1,0 +1,4 @@
+import ApfelCore
+
+print(MCPProtocol.initializeRequest(id: 1))
+print(MCPProtocol.toolsListRequest(id: 2))

--- a/Examples/OpenAITypes/main.swift
+++ b/Examples/OpenAITypes/main.swift
@@ -1,0 +1,29 @@
+import ApfelCore
+
+let request = ChatCompletionRequest(
+    model: "apple-foundationmodel",
+    messages: [
+        OpenAIMessage(role: "system", content: .text("Be concise.")),
+        OpenAIMessage(role: "user", content: .text("Say hello")),
+    ],
+    stream: false,
+    stream_options: nil,
+    temperature: 0.2,
+    max_tokens: 64,
+    seed: nil,
+    tools: nil,
+    tool_choice: nil,
+    response_format: nil,
+    logprobs: nil,
+    n: nil,
+    stop: nil,
+    presence_penalty: nil,
+    frequency_penalty: nil,
+    user: "example-user",
+    x_context_strategy: nil,
+    x_context_max_turns: nil,
+    x_context_output_reserve: nil
+)
+
+print("model=\(request.model)")
+print("messages=\(request.messages.count)")

--- a/Examples/ToolCalling/main.swift
+++ b/Examples/ToolCalling/main.swift
@@ -1,0 +1,10 @@
+import ApfelCore
+
+let tool = ToolDef(
+    name: "add",
+    description: "Adds two numbers",
+    parametersJSON: #"{"type":"object","properties":{"a":{"type":"number"},"b":{"type":"number"}},"required":["a","b"]}"#
+)
+
+print(ToolCallHandler.buildOutputFormatInstructions(toolNames: [tool.name]))
+print(ToolCallHandler.buildFallbackPrompt(tools: [tool]))

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,12 @@ let package = Package(
     name: "apfel",
     platforms: [.macOS(.v26)],
     products: [
+        .library(name: "ApfelCore", targets: ["ApfelCore"]),
         .executable(name: "apfel", targets: ["apfel"])
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.6"),
     ],
     targets: [
         .systemLibrary(
@@ -53,6 +55,31 @@ let package = Package(
             name: "apfel-tests",
             dependencies: ["ApfelCore", "ApfelCLI"],
             path: "Tests/apfelTests"
+        ),
+        .executableTarget(
+            name: "apfelcore-context-strategies-example",
+            dependencies: ["ApfelCore"],
+            path: "Examples/ContextStrategies"
+        ),
+        .executableTarget(
+            name: "apfelcore-openai-types-example",
+            dependencies: ["ApfelCore"],
+            path: "Examples/OpenAITypes"
+        ),
+        .executableTarget(
+            name: "apfelcore-tool-calling-example",
+            dependencies: ["ApfelCore"],
+            path: "Examples/ToolCalling"
+        ),
+        .executableTarget(
+            name: "apfelcore-error-handling-example",
+            dependencies: ["ApfelCore"],
+            path: "Examples/ErrorHandling"
+        ),
+        .executableTarget(
+            name: "apfelcore-mcp-protocol-example",
+            dependencies: ["ApfelCore"],
+            path: "Examples/MCPProtocol"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ make install
 
 Update with `brew upgrade apfel` or `apfel --update`. Troubleshooting and Apple Intelligence setup notes: [docs/install.md](docs/install.md).
 
+## Swift Package
+
+`ApfelCore` is a public Swift Package library product for the pure, FoundationModels-free pieces of apfel. It is for downstream Swift developers who want the OpenAI-compatible types, validation, MCP helpers, schema parsing, retry classification, and context-strategy policies without depending on the `apfel` executable target.
+
+Add the package and import `ApfelCore`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Arthur-Ficial/apfel.git", from: "1.0.5")
+]
+```
+
+```swift
+import ApfelCore
+
+let request = ChatCompletionRequest(
+    model: "apple-foundationmodel",
+    messages: [OpenAIMessage(role: "user", content: .text("Hello"))]
+)
+```
+
+Library docs live in [Sources/Core/ApfelCore.docc/](Sources/Core/ApfelCore.docc/). Runnable examples live in [Examples/](Examples/).
+
 ## Quick Start
 
 ### UNIX tool

--- a/README.md
+++ b/README.md
@@ -55,11 +55,19 @@ Update with `brew upgrade apfel` or `apfel --update`. Troubleshooting and Apple 
 
 `ApfelCore` is a public Swift Package library product for the pure, FoundationModels-free pieces of apfel. It is for downstream Swift developers who want the OpenAI-compatible types, validation, MCP helpers, schema parsing, retry classification, and context-strategy policies without depending on the `apfel` executable target.
 
-Add the package and import `ApfelCore`:
+The first tagged release that contains `ApfelCore` is `1.1.0`. Depend on the package product directly:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Arthur-Ficial/apfel.git", from: "1.0.5")
+    .package(url: "https://github.com/Arthur-Ficial/apfel.git", from: "1.1.0")
+],
+targets: [
+    .executableTarget(
+        name: "MyTool",
+        dependencies: [
+            .product(name: "ApfelCore", package: "apfel")
+        ]
+    )
 ]
 ```
 
@@ -331,17 +339,21 @@ Swift 6.3 strict concurrency. Three targets: `ApfelCore` (pure logic, unit-testa
 ## Build & Test
 
 ```bash
+make test                                # release build + all unit/integration tests
+make preflight                           # full release qualification
 make install                             # build release + install to /usr/local/bin
 make build                               # build release only
 make version                             # print current version
-make release-minor                       # bump minor: 0.6.x -> 0.7.0
+make release                             # patch release
+make release TYPE=minor                  # minor release
+make release TYPE=major                  # major release
 swift build                              # quick debug build (no version bump)
 swift run apfel-tests                    # unit tests
 python3 -m pytest Tests/integration/ -v  # integration tests
 apfel --benchmark -o json                # performance report
 ```
 
-`.version` is the single source of truth. Only `make release` (via CI) bumps versions. Local builds do not change the version.
+`.version` is the single source of truth. Only `make release` bumps versions. Local builds do not change the version.
 
 ## The apfel tree
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -14,6 +14,7 @@ These are covered by semantic versioning. Breaking changes require a major versi
 - `brew services` integration
 - Configuration via environment variables (`APFEL_TOKEN`, `APFEL_MCP`, `APFEL_SYSTEM_PROMPT`)
 - Documented unsupported endpoints (501 responses for embeddings, legacy completions)
+- The public `ApfelCore` Swift Package API
 
 ## What is NOT stable (may change without version bump)
 
@@ -29,6 +30,16 @@ apfel follows semantic versioning:
 - **PATCH** (1.0.x): bug fixes, documentation, CI changes
 - **MINOR** (1.x.0): new flags, new endpoints, new features (backward-compatible)
 - **MAJOR** (x.0.0): removed flags, changed exit codes, breaking API changes
+
+`ApfelCore` follows the same version numbers as apfel itself. There is no separate library version line.
+
+## Deprecation Policy
+
+- Public `ApfelCore` APIs deprecate before removal.
+- A deprecation lands in one released version with `@available(*, deprecated, ...)`.
+- The deprecated API remains available through the next compatible release line.
+- Removal happens only in a major release.
+- Public-surface changes must be called out in [CHANGELOG.md](CHANGELOG.md).
 
 Model output changes from macOS updates are NOT version bumps. See "What is NOT stable" above.
 

--- a/Sources/Core/ApfelCore.docc/ApfelCore.md
+++ b/Sources/Core/ApfelCore.docc/ApfelCore.md
@@ -1,0 +1,26 @@
+# ``ApfelCore``
+
+Pure Swift building blocks for exposing Apple's on-device Foundation Models in your own apps and tools.
+
+`ApfelCore` contains the FoundationModels-free parts of apfel: OpenAI-compatible request and message types, context-trimming configuration, tool-calling helpers, MCP wire helpers, schema parsing, retry classification, and request validation.
+
+## Overview
+
+Use `ApfelCore` when you want to:
+
+- build your own FoundationModels client while keeping request/response types OpenAI-compatible
+- reuse apfel's context-strategy and validation logic in another Swift package or app
+- parse MCP and tool-calling payloads without taking a dependency on the apfel executable target
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+
+### Core Areas
+
+- <doc:ContextStrategies>
+- <doc:OpenAITypes>
+- <doc:ToolCalling>
+- <doc:ErrorHandling>

--- a/Sources/Core/ApfelCore.docc/ContextStrategies.md
+++ b/Sources/Core/ApfelCore.docc/ContextStrategies.md
@@ -1,0 +1,18 @@
+# Context Strategies
+
+`ContextStrategy` and `ContextConfig` describe how a caller should trim or preserve conversation history before handing a prompt to a model with a fixed context window.
+
+Use `ContextConfig.defaults` for the executable's default behavior, or construct a custom configuration when your app needs to bias toward recency, strictness, or summarization.
+
+```swift
+import ApfelCore
+
+let config = ContextConfig(
+    strategy: .slidingWindow,
+    maxTurns: 8,
+    outputReserve: 512,
+    permissive: false
+)
+```
+
+`ApfelCore` does not perform FoundationModels calls itself. It gives you the policy types you can apply around your own transcript or prompt-building logic.

--- a/Sources/Core/ApfelCore.docc/ErrorHandling.md
+++ b/Sources/Core/ApfelCore.docc/ErrorHandling.md
@@ -1,0 +1,15 @@
+# Error Handling
+
+`ApfelError` provides a stable, typed classification layer around runtime failures that matter to callers:
+
+- user-facing labels via ``ApfelError/cliLabel``
+- OpenAI-compatible error types and HTTP statuses
+- retryability via ``ApfelError/isRetryable``
+
+For MCP and request validation, use:
+
+- ``MCPError``
+- ``ChatRequestValidationFailure``
+- ``UnsupportedChatParameter``
+
+These types are designed to give downstream callers stable messages without forcing them to parse localized or framework-specific strings.

--- a/Sources/Core/ApfelCore.docc/GettingStarted.md
+++ b/Sources/Core/ApfelCore.docc/GettingStarted.md
@@ -1,0 +1,53 @@
+# Getting Started
+
+Add apfel as a package dependency and depend on the `ApfelCore` product:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Arthur-Ficial/apfel.git", from: "1.0.5")
+],
+targets: [
+    .executableTarget(
+        name: "MyTool",
+        dependencies: [
+            .product(name: "ApfelCore", package: "apfel")
+        ]
+    )
+]
+```
+
+Then import `ApfelCore` and work with the same request, tool, and validation types apfel uses internally:
+
+```swift
+import ApfelCore
+
+let request = ChatCompletionRequest(
+    model: "apple-foundationmodel",
+    messages: [
+        OpenAIMessage(role: "user", content: .text("Hello"))
+    ],
+    stream: false,
+    stream_options: nil,
+    temperature: 0.2,
+    max_tokens: 64,
+    seed: nil,
+    tools: nil,
+    tool_choice: nil,
+    response_format: nil,
+    logprobs: nil,
+    n: nil,
+    stop: nil,
+    presence_penalty: nil,
+    frequency_penalty: nil,
+    user: nil,
+    x_context_strategy: nil,
+    x_context_max_turns: nil,
+    x_context_output_reserve: nil
+)
+
+if let failure = ChatRequestValidator.validate(request) {
+    print(failure.message)
+}
+```
+
+See the executable examples in [Examples](../../../../Examples) for small runnable entry points.

--- a/Sources/Core/ApfelCore.docc/GettingStarted.md
+++ b/Sources/Core/ApfelCore.docc/GettingStarted.md
@@ -1,10 +1,10 @@
 # Getting Started
 
-Add apfel as a package dependency and depend on the `ApfelCore` product:
+The first tagged release that contains `ApfelCore` is `1.1.0`. Add apfel as a package dependency and depend on the `ApfelCore` product:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Arthur-Ficial/apfel.git", from: "1.0.5")
+    .package(url: "https://github.com/Arthur-Ficial/apfel.git", from: "1.1.0")
 ],
 targets: [
     .executableTarget(

--- a/Sources/Core/ApfelCore.docc/OpenAITypes.md
+++ b/Sources/Core/ApfelCore.docc/OpenAITypes.md
@@ -1,0 +1,14 @@
+# OpenAI Types
+
+`ApfelCore` models the OpenAI-compatible chat-completions payloads apfel accepts and emits.
+
+Key types include:
+
+- ``ChatCompletionRequest``
+- ``OpenAIMessage``
+- ``MessageContent``
+- ``OpenAITool``
+- ``ToolChoice``
+- ``ResponseFormat``
+
+These types are pure Swift values, `Sendable`, and hashable where it is useful for callers building caches, sets, or maps of request metadata.

--- a/Sources/Core/ApfelCore.docc/ToolCalling.md
+++ b/Sources/Core/ApfelCore.docc/ToolCalling.md
@@ -1,0 +1,9 @@
+# Tool Calling
+
+Use `ToolCallHandler` when you need to:
+
+- describe fallback tool schemas in prompt text
+- normalize model-emitted argument strings into valid JSON
+- parse OpenAI-style `tool_calls` payloads out of a model response
+
+`SchemaParser` and `SchemaIR` complement this by parsing raw JSON Schema text into a deterministic intermediate representation you can adapt to another runtime.

--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ApfelError: Error, Equatable, Sendable {
+public enum ApfelError: Error, Equatable, Hashable, Sendable {
     case guardrailViolation
     case contextOverflow
     case rateLimited
@@ -149,6 +149,37 @@ public enum ApfelError: Error, Equatable, Sendable {
             return true
         default:
             return false
+        }
+    }
+}
+
+extension ApfelError: LocalizedError, CustomStringConvertible, CustomDebugStringConvertible {
+    public var errorDescription: String? { openAIMessage }
+
+    public var description: String { openAIMessage }
+
+    public var debugDescription: String {
+        switch self {
+        case .guardrailViolation:
+            return "ApfelError.guardrailViolation"
+        case .contextOverflow:
+            return "ApfelError.contextOverflow"
+        case .rateLimited:
+            return "ApfelError.rateLimited"
+        case .concurrentRequest:
+            return "ApfelError.concurrentRequest"
+        case .assetsUnavailable:
+            return "ApfelError.assetsUnavailable"
+        case .unsupportedGuide:
+            return "ApfelError.unsupportedGuide"
+        case .decodingFailure(let message):
+            return "ApfelError.decodingFailure(\(String(reflecting: message)))"
+        case .unsupportedLanguage(let message):
+            return "ApfelError.unsupportedLanguage(\(String(reflecting: message)))"
+        case .toolExecution(let message):
+            return "ApfelError.toolExecution(\(String(reflecting: message)))"
+        case .unknown(let message):
+            return "ApfelError.unknown(\(String(reflecting: message)))"
         }
     }
 }

--- a/Sources/Core/BufferedLineReader.swift
+++ b/Sources/Core/BufferedLineReader.swift
@@ -4,6 +4,7 @@
 // ============================================================================
 
 import Foundation
+import os
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -13,11 +14,20 @@ import Glibc
 /// Reads newline-delimited lines from a file descriptor using buffered I/O.
 /// Each `readLine()` call returns one complete line (without the trailing newline).
 /// Bytes arriving after the newline are stashed for the next call.
-public final class BufferedLineReader: @unchecked Sendable {
+public final class BufferedLineReader: Sendable {
+    private struct State {
+        var leftover = Data()
+    }
+
     private let fd: Int32
     private let bufferSize: Int
-    private var leftover = Data()
+    private let state = OSAllocatedUnfairLock<State>(initialState: State())
 
+    /// Creates a reader for a newline-delimited byte stream.
+    ///
+    /// - Parameters:
+    ///   - fileDescriptor: The file descriptor to read from.
+    ///   - bufferSize: The chunk size to use for each low-level read.
     public init(fileDescriptor: Int32, bufferSize: Int = 4096) {
         self.fd = fileDescriptor
         self.bufferSize = bufferSize
@@ -30,74 +40,77 @@ public final class BufferedLineReader: @unchecked Sendable {
     /// - Returns: The line content (without trailing newline).
     /// - Throws: `MCPError.timedOut` or `MCPError.processError` on failure.
     public func readLine(timeoutMilliseconds: Int, operationDescription: String) throws -> String {
-        var lineBuffer = Data()
-        let deadline = Date().timeIntervalSinceReferenceDate + (Double(timeoutMilliseconds) / 1000.0)
+        try state.withLock { state in
+            var lineBuffer = Data()
+            let deadline = Date().timeIntervalSinceReferenceDate + (Double(timeoutMilliseconds) / 1000.0)
 
-        // Drain any leftover bytes from a previous read that crossed a message boundary.
-        if let newlineIndex = leftover.firstIndex(of: UInt8(ascii: "\n")) {
-            lineBuffer.append(leftover[leftover.startIndex..<newlineIndex])
-            leftover = Data(leftover[(newlineIndex + 1)...])
-            if let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty {
-                return line
-            }
-        } else if !leftover.isEmpty {
-            lineBuffer.append(leftover)
-            leftover = Data()
-        }
-
-        var chunk = [UInt8](repeating: 0, count: bufferSize)
-
-        while true {
-            let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
-            if remainingMilliseconds <= 0 {
-                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
-            }
-
-            var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
-            let ready = poll(&pollDescriptor, 1, Int32(remainingMilliseconds))
-            if ready == 0 {
-                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
-            }
-            if ready < 0 {
-                if errno == EINTR { continue }
-                throw MCPError.processError("Failed waiting for MCP response: \(String(cString: strerror(errno)))")
-            }
-            if (pollDescriptor.revents & Int16(POLLNVAL)) != 0 {
-                throw MCPError.processError("MCP stdout became invalid")
-            }
-            if (pollDescriptor.revents & Int16(POLLERR)) != 0 {
-                throw MCPError.processError("MCP stdout reported an I/O error")
-            }
-            if (pollDescriptor.revents & Int16(POLLHUP)) != 0 && (pollDescriptor.revents & Int16(POLLIN)) == 0 {
-                throw MCPError.processError("MCP server closed unexpectedly")
-            }
-            if (pollDescriptor.revents & Int16(POLLIN)) == 0 {
-                continue
-            }
-
-            let readCount = Darwin.read(fd, &chunk, chunk.count)
-            if readCount == 0 {
-                throw MCPError.processError("MCP server closed unexpectedly")
-            }
-            if readCount < 0 {
-                if errno == EINTR { continue }
-                throw MCPError.processError("Failed reading MCP response: \(String(cString: strerror(errno)))")
-            }
-
-            let bytes = chunk[..<readCount]
-            if let newlineOffset = bytes.firstIndex(of: UInt8(ascii: "\n")) {
-                lineBuffer.append(contentsOf: bytes[bytes.startIndex..<newlineOffset])
-                let afterNewline = bytes.index(after: newlineOffset)
-                if afterNewline < bytes.endIndex {
-                    leftover = Data(bytes[afterNewline...])
+            // Drain any leftover bytes from a previous read that crossed a message boundary.
+            if let newlineIndex = state.leftover.firstIndex(of: UInt8(ascii: "\n")) {
+                lineBuffer.append(state.leftover[state.leftover.startIndex..<newlineIndex])
+                state.leftover = Data(state.leftover[(newlineIndex + 1)...])
+                if let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty {
+                    return line
                 }
-                break
+            } else if !state.leftover.isEmpty {
+                lineBuffer.append(state.leftover)
+                state.leftover = Data()
             }
-            lineBuffer.append(contentsOf: bytes)
+
+            var chunk = [UInt8](repeating: 0, count: bufferSize)
+
+            while true {
+                let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
+                if remainingMilliseconds <= 0 {
+                    throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
+                }
+
+                var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+                let ready = poll(&pollDescriptor, 1, Int32(remainingMilliseconds))
+                if ready == 0 {
+                    throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
+                }
+                if ready < 0 {
+                    if errno == EINTR { continue }
+                    throw MCPError.processError("Failed waiting for MCP response: \(String(cString: strerror(errno)))")
+                }
+                if (pollDescriptor.revents & Int16(POLLNVAL)) != 0 {
+                    throw MCPError.processError("MCP stdout became invalid")
+                }
+                if (pollDescriptor.revents & Int16(POLLERR)) != 0 {
+                    throw MCPError.processError("MCP stdout reported an I/O error")
+                }
+                if (pollDescriptor.revents & Int16(POLLHUP)) != 0 && (pollDescriptor.revents & Int16(POLLIN)) == 0 {
+                    throw MCPError.processError("MCP server closed unexpectedly")
+                }
+                if (pollDescriptor.revents & Int16(POLLIN)) == 0 {
+                    continue
+                }
+
+                let readCount = read(fd, &chunk, chunk.count)
+                if readCount == 0 {
+                    throw MCPError.processError("MCP server closed unexpectedly")
+                }
+                if readCount < 0 {
+                    if errno == EINTR { continue }
+                    throw MCPError.processError("Failed reading MCP response: \(String(cString: strerror(errno)))")
+                }
+
+                let bytes = chunk[..<readCount]
+                if let newlineOffset = bytes.firstIndex(of: UInt8(ascii: "\n")) {
+                    lineBuffer.append(contentsOf: bytes[bytes.startIndex..<newlineOffset])
+                    let afterNewline = bytes.index(after: newlineOffset)
+                    if afterNewline < bytes.endIndex {
+                        state.leftover = Data(bytes[afterNewline...])
+                    }
+                    break
+                }
+                lineBuffer.append(contentsOf: bytes)
+            }
+
+            guard let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty else {
+                throw MCPError.processError("Empty response from MCP server")
+            }
+            return line
         }
-        guard let line = String(data: lineBuffer, encoding: .utf8), !line.isEmpty else {
-            throw MCPError.processError("Empty response from MCP server")
-        }
-        return line
     }
 }

--- a/Sources/Core/Chat/BodyLimits.swift
+++ b/Sources/Core/Chat/BodyLimits.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum BodyLimits {
+package enum BodyLimits {
     /// Cap on the size of a decoded HTTP request body (1 MiB).
     /// Prevents OOM from a malicious or misconfigured client.
     public static let maxRequestBodyBytes: Int = 1024 * 1024

--- a/Sources/Core/Chat/FinishReasonResolver.swift
+++ b/Sources/Core/Chat/FinishReasonResolver.swift
@@ -4,11 +4,15 @@
 
 import Foundation
 
-public enum FinishReason: Sendable, Equatable {
+public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
+    /// The response completed normally.
     case stop
+    /// The response stopped because it reached the requested token cap.
     case length
+    /// The response ended in a tool-call payload instead of plain text.
     case toolCalls
 
+    /// The OpenAI-compatible wire value for this finish reason.
     public var openAIValue: String {
         switch self {
         case .stop: return "stop"
@@ -16,6 +20,10 @@ public enum FinishReason: Sendable, Equatable {
         case .toolCalls: return "tool_calls"
         }
     }
+
+    public var description: String { openAIValue }
+
+    public var debugDescription: String { "FinishReason.\(openAIValue)" }
 }
 
 public enum FinishReasonResolver {

--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -5,15 +5,23 @@
 
 import Foundation
 
-public enum UnsupportedChatParameter: String, Sendable, Equatable {
+/// Chat-completions request fields that ApfelCore rejects explicitly.
+public enum UnsupportedChatParameter: String, Sendable, Equatable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
+    /// Requests token log probabilities in the response.
     case logprobs
+    /// Requests multiple completions from one prompt.
     case n
+    /// Requests stop-sequence handling that Apple's local model does not expose.
     case stop
+    /// Requests OpenAI presence-penalty tuning.
     case presencePenalty = "presence_penalty"
+    /// Requests OpenAI frequency-penalty tuning.
     case frequencyPenalty = "frequency_penalty"
 
+    /// The JSON field name for the unsupported parameter.
     public var name: String { rawValue }
 
+    /// The stable user-facing explanation for why the parameter is unsupported.
     public var message: String {
         switch self {
         case .logprobs:
@@ -29,6 +37,16 @@ public enum UnsupportedChatParameter: String, Sendable, Equatable {
         }
     }
 
+    public var description: String { name }
+
+    public var debugDescription: String { "UnsupportedChatParameter.\(rawValue)" }
+
+    /// Detects the first unsupported parameter present in a request.
+    ///
+    /// Detection is intentionally ordered so error reporting stays stable.
+    ///
+    /// - Parameter request: The decoded chat-completions request.
+    /// - Returns: The first unsupported parameter found, or `nil`.
     public static func detect(in request: ChatCompletionRequest) -> UnsupportedChatParameter? {
         if request.logprobs == true {
             return .logprobs
@@ -49,14 +67,22 @@ public enum UnsupportedChatParameter: String, Sendable, Equatable {
     }
 }
 
-public enum ChatRequestValidationFailure: Sendable, Equatable {
+/// Stable validation failures for OpenAI-compatible chat-completions requests.
+public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
+    /// The request did not include any messages.
     case emptyMessages
+    /// The request used a parameter ApfelCore does not support.
     case unsupportedParameter(UnsupportedChatParameter)
+    /// The final message role was not `user` or `tool`.
     case invalidLastRole
+    /// The request included image content.
     case imageContent
+    /// A numeric or string parameter had an invalid value.
     case invalidParameterValue(String)
+    /// The request asked for a model name other than `apple-foundationmodel`.
     case invalidModel(String)
 
+    /// The stable HTTP-facing error message for this validation failure.
     public var message: String {
         switch self {
         case .emptyMessages:
@@ -74,6 +100,7 @@ public enum ChatRequestValidationFailure: Sendable, Equatable {
         }
     }
 
+    /// The stable log/debug event string for this validation failure.
     public var event: String {
         switch self {
         case .emptyMessages:
@@ -90,12 +117,20 @@ public enum ChatRequestValidationFailure: Sendable, Equatable {
             return "validation failed: unknown model \(model)"
         }
     }
+
+    public var description: String { message }
+
+    public var debugDescription: String { event }
 }
 
 public enum ChatRequestValidator {
     /// The only model name this server accepts.
     public static let validModel = "apple-foundationmodel"
 
+    /// Validates a decoded chat-completions request.
+    ///
+    /// - Parameter request: The request to validate.
+    /// - Returns: The first validation failure encountered, or `nil`.
     public static func validate(_ request: ChatCompletionRequest) -> ChatRequestValidationFailure? {
         guard !request.messages.isEmpty else {
             return .emptyMessages

--- a/Sources/Core/Concurrency/StreamCleanup.swift
+++ b/Sources/Core/Concurrency/StreamCleanup.swift
@@ -6,11 +6,23 @@
 
 import Foundation
 
+/// Ensures asynchronous cleanup work executes at most once.
+///
+/// The streaming server path can trigger cleanup from multiple places, such as
+/// normal completion and client disconnect handling. `StreamCleanup` provides
+/// a tiny actor that turns those competing signals into one idempotent cleanup
+/// execution.
 public actor StreamCleanup {
     private var didRun = false
 
+    /// Creates a cleanup coordinator in the "not yet run" state.
     public init() {}
 
+    /// Runs the cleanup operation exactly once.
+    ///
+    /// Subsequent callers return immediately without invoking `operation`.
+    ///
+    /// - Parameter operation: The asynchronous cleanup work to perform.
     public func run(_ operation: @Sendable () async -> Void) async {
         if didRun { return }
         didRun = true

--- a/Sources/Core/Concurrency/StreamTaskBox.swift
+++ b/Sources/Core/Concurrency/StreamTaskBox.swift
@@ -13,7 +13,7 @@
 import Foundation
 import os
 
-public final class StreamTaskBox: Sendable {
+package final class StreamTaskBox: Sendable {
     private let storage = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
     public init() {}

--- a/Sources/Core/Concurrency/TraceBuffer.swift
+++ b/Sources/Core/Concurrency/TraceBuffer.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public actor TraceBuffer {
+package actor TraceBuffer {
     private var events: [String]
 
     public init(events: [String]) {

--- a/Sources/Core/ContextStrategy.swift
+++ b/Sources/Core/ContextStrategy.swift
@@ -4,16 +4,20 @@
 // ============================================================================
 
 /// Strategy for trimming conversation history when approaching the context limit.
-public enum ContextStrategy: String, Codable, Sendable, CaseIterable {
+public enum ContextStrategy: String, Codable, Sendable, CaseIterable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
     case newestFirst = "newest-first"
     case oldestFirst = "oldest-first"
     case slidingWindow = "sliding-window"
     case summarize = "summarize"
     case strict = "strict"
+
+    public var description: String { rawValue }
+
+    public var debugDescription: String { "ContextStrategy.\(rawValue)" }
 }
 
 /// Configuration for context window management.
-public struct ContextConfig: Sendable, Equatable {
+public struct ContextConfig: Sendable, Equatable, Hashable {
     public let strategy: ContextStrategy
     public let maxTurns: Int?
     public let outputReserve: Int

--- a/Sources/Core/DebugOutput.swift
+++ b/Sources/Core/DebugOutput.swift
@@ -5,11 +5,11 @@ import os
 /// The value is intentionally synchronous to keep hot logging call-sites cheap,
 /// but the storage is lock-protected so reads and writes remain data-race-safe
 /// under Swift 6 strict concurrency.
-public enum ApfelDebugConfiguration {
+package enum ApfelDebugConfiguration {
     private static let storage = OSAllocatedUnfairLock<Bool>(initialState: false)
 
     /// Enables or disables debug logging.
-    public static var isEnabled: Bool {
+    package static var isEnabled: Bool {
         get { storage.withLock { $0 } }
         set { storage.withLock { $0 = newValue } }
     }

--- a/Sources/Core/DebugOutput.swift
+++ b/Sources/Core/DebugOutput.swift
@@ -1,3 +1,16 @@
-/// Global debug flag. Set by --debug CLI flag.
-/// Checked by debugLog() to suppress output when disabled.
-public nonisolated(unsafe) var apfelDebugEnabled = false
+import os
+
+/// Process-wide debug logging configuration shared by the CLI and server.
+///
+/// The value is intentionally synchronous to keep hot logging call-sites cheap,
+/// but the storage is lock-protected so reads and writes remain data-race-safe
+/// under Swift 6 strict concurrency.
+public enum ApfelDebugConfiguration {
+    private static let storage = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+    /// Enables or disables debug logging.
+    public static var isEnabled: Bool {
+        get { storage.withLock { $0 } }
+        set { storage.withLock { $0 = newValue } }
+    }
+}

--- a/Sources/Core/JSONFenceStripper.swift
+++ b/Sources/Core/JSONFenceStripper.swift
@@ -5,15 +5,17 @@
 
 import Foundation
 
-/// Strips a surrounding Markdown code fence (```json ... ``` or ``` ... ```)
-/// from JSON content. When `response_format: { "type": "json_object" }` is
+/// Strips a surrounding Markdown code fence from JSON content.
+///
+/// Supports both JSON-tagged and untagged fences. When
+/// `response_format: { "type": "json_object" }` is
 /// requested, the OpenAI spec requires the message content to be valid JSON.
 /// Apple's on-device model often emits a fenced block despite explicit
 /// instructions, so we post-process the output to deliver raw JSON.
 ///
 /// - Returns the trimmed inner content when the input is fenced with an
-///   opening ```` ``` ```` (optionally followed by `json`/`JSON`) on its own
-///   line and a closing ```` ``` ```` on its own line.
+///   opening three-backtick fence (optionally followed by `json`/`JSON`) on
+///   its own line and a closing three-backtick fence on its own line.
 /// - Returns the input trimmed of surrounding whitespace otherwise.
 public enum JSONFenceStripper {
     public static func strip(_ content: String) -> String {

--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -9,10 +9,12 @@ import Foundation
 /// No I/O, no subprocesses - just JSON-RPC 2.0 over MCP.
 public enum MCPProtocol {
 
+    /// The MCP protocol version ApfelCore speaks on the wire.
     public static let protocolVersion = "2025-06-18"
 
     // MARK: - Request formatting
 
+    /// Formats the MCP `initialize` JSON-RPC request.
     public static func initializeRequest(id: Int) -> String {
         return jsonRPC(id: id, method: "initialize", params: [
             "protocolVersion": protocolVersion,
@@ -21,14 +23,22 @@ public enum MCPProtocol {
         ])
     }
 
+    /// Formats the MCP `notifications/initialized` JSON-RPC notification.
     public static func initializedNotification() -> String {
         return jsonRPC(method: "notifications/initialized")
     }
 
+    /// Formats the MCP `tools/list` JSON-RPC request.
     public static func toolsListRequest(id: Int) -> String {
         return jsonRPC(id: id, method: "tools/list")
     }
 
+    /// Formats the MCP `tools/call` JSON-RPC request.
+    ///
+    /// - Parameters:
+    ///   - id: The JSON-RPC request identifier.
+    ///   - name: The tool name to invoke.
+    ///   - arguments: JSON text describing the tool-call arguments.
     public static func toolsCallRequest(id: Int, name: String, arguments: String) -> String {
         let argsObj = (try? JSONSerialization.jsonObject(with: Data(arguments.utf8))) ?? [:]
         return jsonRPC(id: id, method: "tools/call", params: [
@@ -39,11 +49,15 @@ public enum MCPProtocol {
 
     // MARK: - Response parsing
 
+    /// MCP server identity returned from the initialize handshake.
     public struct ServerInfo: Sendable {
+        /// The server name.
         public let name: String
+        /// The server version string.
         public let version: String
     }
 
+    /// Parses the result of an MCP `initialize` response.
     public static func parseInitializeResponse(_ json: String) throws -> ServerInfo {
         let obj = try parseJSON(json)
         guard let result = obj["result"] as? [String: Any],
@@ -56,6 +70,7 @@ public enum MCPProtocol {
         )
     }
 
+    /// Parses the result of an MCP `tools/list` response into OpenAI-style tools.
     public static func parseToolsListResponse(_ json: String) throws -> [OpenAITool] {
         let obj = try parseJSON(json)
         guard let result = obj["result"] as? [String: Any],
@@ -85,11 +100,15 @@ public enum MCPProtocol {
         }
     }
 
+    /// Result of an MCP `tools/call` response.
     public struct ToolCallResult: Sendable {
+        /// The text returned by the tool.
         public let text: String
+        /// Whether the MCP server marked the result as an error.
         public let isError: Bool
     }
 
+    /// Parses an MCP `tools/call` response.
     public static func parseToolCallResponse(_ json: String) throws -> ToolCallResult {
         let obj = try parseJSON(json)
 
@@ -134,11 +153,17 @@ public enum MCPProtocol {
     }
 }
 
+/// Stable MCP protocol and transport failures surfaced by ApfelCore.
 public enum MCPError: Error, Sendable, Equatable {
+    /// The server returned malformed or incomplete JSON.
     case invalidResponse(String)
+    /// The remote MCP server returned an application-level error.
     case serverError(String)
+    /// The requested tool does not exist.
     case toolNotFound(String)
+    /// The local subprocess or transport failed.
     case processError(String)
+    /// The request exceeded its timeout budget.
     case timedOut(String)
 }
 

--- a/Sources/Core/ModelAvailability.swift
+++ b/Sources/Core/ModelAvailability.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 /// See:
 /// https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/availability-swift.enum/unavailablereason
-public enum ModelAvailability: Sendable, Equatable {
+public enum ModelAvailability: Sendable, Equatable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
     case available
     case appleIntelligenceNotEnabled
     case deviceNotEligible
@@ -101,6 +101,23 @@ public enum ModelAvailability: Sendable, Equatable {
                   - Filing an issue at
                     https://github.com/Arthur-Ficial/apfel/issues
                 """
+        }
+    }
+
+    public var description: String { shortLabel }
+
+    public var debugDescription: String {
+        switch self {
+        case .available:
+            return "ModelAvailability.available"
+        case .appleIntelligenceNotEnabled:
+            return "ModelAvailability.appleIntelligenceNotEnabled"
+        case .deviceNotEligible:
+            return "ModelAvailability.deviceNotEligible"
+        case .modelNotReady:
+            return "ModelAvailability.modelNotReady"
+        case .unknownUnavailable:
+            return "ModelAvailability.unknownUnavailable"
         }
     }
 }

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -5,40 +5,118 @@
 
 import Foundation
 
-public struct ChatCompletionRequest: Decodable, Sendable {
+/// OpenAI-compatible chat-completions request payload.
+public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
+    /// The requested model name. ApfelCore accepts `apple-foundationmodel`.
     public let model: String
+    /// The conversation transcript sent to the model.
     public let messages: [OpenAIMessage]
+    /// Whether the caller requested streaming chunks.
     public let stream: Bool?
+    /// Streaming-specific configuration.
     public let stream_options: StreamOptions?
+    /// Sampling temperature override.
     public let temperature: Double?
+    /// Maximum completion tokens requested by the client.
     public let max_tokens: Int?
+    /// Optional deterministic seed request.
     public let seed: Int?
+    /// Client-supplied tool definitions.
     public let tools: [OpenAITool]?
+    /// How the client wants tool choice resolved.
     public let tool_choice: ToolChoice?
+    /// Requested response-format contract.
     public let response_format: ResponseFormat?
+    /// OpenAI logprobs request flag.
     public let logprobs: Bool?
+    /// Number of requested completions.
     public let n: Int?
+    /// Raw stop-sequence payload.
     public let stop: RawJSON?
+    /// OpenAI presence-penalty override.
     public let presence_penalty: Double?
+    /// OpenAI frequency-penalty override.
     public let frequency_penalty: Double?
+    /// End-user identifier forwarded by the client.
     public let user: String?
+    /// Requested context-trimming strategy override.
     public let x_context_strategy: String?
+    /// Requested maximum conversation turns after trimming.
     public let x_context_max_turns: Int?
+    /// Requested token reserve for the model's output.
     public let x_context_output_reserve: Int?
+
+    /// Creates a chat-completions request value.
+    public init(
+        model: String,
+        messages: [OpenAIMessage],
+        stream: Bool? = nil,
+        stream_options: StreamOptions? = nil,
+        temperature: Double? = nil,
+        max_tokens: Int? = nil,
+        seed: Int? = nil,
+        tools: [OpenAITool]? = nil,
+        tool_choice: ToolChoice? = nil,
+        response_format: ResponseFormat? = nil,
+        logprobs: Bool? = nil,
+        n: Int? = nil,
+        stop: RawJSON? = nil,
+        presence_penalty: Double? = nil,
+        frequency_penalty: Double? = nil,
+        user: String? = nil,
+        x_context_strategy: String? = nil,
+        x_context_max_turns: Int? = nil,
+        x_context_output_reserve: Int? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.stream = stream
+        self.stream_options = stream_options
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.seed = seed
+        self.tools = tools
+        self.tool_choice = tool_choice
+        self.response_format = response_format
+        self.logprobs = logprobs
+        self.n = n
+        self.stop = stop
+        self.presence_penalty = presence_penalty
+        self.frequency_penalty = frequency_penalty
+        self.user = user
+        self.x_context_strategy = x_context_strategy
+        self.x_context_max_turns = x_context_max_turns
+        self.x_context_output_reserve = x_context_output_reserve
+    }
 }
 
-public struct StreamOptions: Decodable, Sendable, Equatable {
+/// OpenAI `stream_options` payload.
+public struct StreamOptions: Decodable, Sendable, Equatable, Hashable {
+    /// Whether streaming responses should include a usage block.
     public let include_usage: Bool?
+
+    /// Creates streaming options.
+    public init(include_usage: Bool? = nil) {
+        self.include_usage = include_usage
+    }
 }
 
-public struct OpenAIMessage: Codable, Sendable, Equatable {
+/// OpenAI-compatible chat message.
+public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
+    /// The OpenAI role string, such as `system`, `user`, `assistant`, or `tool`.
     public let role: String
+    /// The message body, either as plain text or structured content parts.
     public let content: MessageContent?
+    /// Tool calls requested by an assistant message.
     public let tool_calls: [ToolCall]?
+    /// Tool-call identifier for tool-role messages.
     public let tool_call_id: String?
+    /// Optional sender name.
     public let name: String?
-    public let refusal: String?      // required by OpenAI spec, always null for our model
+    /// OpenAI refusal text. Always encoded as `null` for the local model.
+    public let refusal: String?
 
+    /// Creates an OpenAI-compatible message value.
     public init(
         role: String,
         content: MessageContent?,
@@ -59,6 +137,7 @@ public struct OpenAIMessage: Codable, Sendable, Equatable {
     // assistant-role response messages (as null when absent). Swift's
     // synthesized Encodable omits nil optionals, so we encode manually.
     // Decoding still uses the synthesized init (content/refusal are Optional).
+    /// Encodes the message using OpenAI-compatible null-handling rules.
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(role, forKey: .role)
@@ -102,16 +181,21 @@ public struct OpenAIMessage: Codable, Sendable, Equatable {
         }
     }
 
+    /// Whether the message contains image parts.
     public var containsImageContent: Bool {
         guard case .parts(let parts) = content else { return false }
         return parts.contains(where: { $0.type == "image_url" })
     }
 }
 
-public enum MessageContent: Codable, Sendable, Equatable {
+/// OpenAI-compatible message content.
+public enum MessageContent: Codable, Sendable, Equatable, Hashable {
+    /// Plain text content.
     case text(String)
+    /// Structured content parts.
     case parts([ContentPart])
 
+    /// Decodes either a plain string or an array of structured parts.
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let text = try? container.decode(String.self) {
@@ -121,6 +205,7 @@ public enum MessageContent: Codable, Sendable, Equatable {
         self = .parts(try container.decode([ContentPart].self))
     }
 
+    /// Encodes the content in its wire-compatible representation.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -132,31 +217,44 @@ public enum MessageContent: Codable, Sendable, Equatable {
     }
 }
 
-public struct ContentPart: Codable, Sendable, Equatable {
+/// One structured content part within an OpenAI message.
+public struct ContentPart: Codable, Sendable, Equatable, Hashable {
+    /// The OpenAI part type, such as `text` or `image_url`.
     public let type: String
+    /// The text payload for text parts.
     public let text: String?
 
+    /// Creates a content part.
     public init(type: String, text: String?) {
         self.type = type
         self.text = text
     }
 }
 
-public struct OpenAITool: Decodable, Sendable {
+/// OpenAI-compatible tool definition.
+public struct OpenAITool: Decodable, Sendable, Equatable, Hashable {
+    /// The tool type. OpenAI-compatible tool-calling uses `function`.
     public let type: String
+    /// The function-style tool metadata.
     public let function: OpenAIFunction
 
+    /// Creates a tool definition.
     public init(type: String, function: OpenAIFunction) {
         self.type = type
         self.function = function
     }
 }
 
-public struct OpenAIFunction: Decodable, Sendable {
+/// OpenAI-compatible function definition nested under a tool.
+public struct OpenAIFunction: Decodable, Sendable, Equatable, Hashable {
+    /// The function name.
     public let name: String
+    /// Human-readable tool description.
     public let description: String?
+    /// Raw JSON Schema parameters for the tool.
     public let parameters: RawJSON?
 
+    /// Creates a function definition.
     public init(name: String, description: String?, parameters: RawJSON?) {
         self.name = name
         self.description = description
@@ -165,13 +263,16 @@ public struct OpenAIFunction: Decodable, Sendable {
 }
 
 /// Stores arbitrary JSON as a raw string — used for tool parameter schemas.
-public struct RawJSON: Decodable, Sendable, Equatable {
+public struct RawJSON: Decodable, Sendable, Equatable, Hashable {
+    /// The raw JSON text.
     public let value: String
 
+    /// Creates a raw JSON wrapper from already-serialized JSON text.
     public init(rawValue: String) {
         self.value = rawValue
     }
 
+    /// Decodes arbitrary JSON and stores its canonical serialized form.
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(AnyCodable.self)
@@ -180,11 +281,16 @@ public struct RawJSON: Decodable, Sendable, Equatable {
     }
 }
 
-public struct ToolCall: Codable, Sendable, Equatable {
+/// OpenAI-compatible tool-call payload.
+public struct ToolCall: Codable, Sendable, Equatable, Hashable {
+    /// Stable tool-call identifier.
     public let id: String
+    /// The tool-call type. OpenAI-compatible tool-calling uses `function`.
     public let type: String
+    /// Function invocation details.
     public let function: ToolCallFunction
 
+    /// Creates a tool call.
     public init(id: String, type: String, function: ToolCallFunction) {
         self.id = id
         self.type = type
@@ -192,22 +298,32 @@ public struct ToolCall: Codable, Sendable, Equatable {
     }
 }
 
-public struct ToolCallFunction: Codable, Sendable, Equatable {
+/// OpenAI-compatible function invocation payload.
+public struct ToolCallFunction: Codable, Sendable, Equatable, Hashable {
+    /// The function name to invoke.
     public let name: String
+    /// JSON-encoded argument object as a string.
     public let arguments: String
 
+    /// Creates a function invocation payload.
     public init(name: String, arguments: String) {
         self.name = name
         self.arguments = arguments
     }
 }
 
-public enum ToolChoice: Decodable, Sendable, Equatable {
+/// OpenAI-compatible tool choice request.
+public enum ToolChoice: Decodable, Sendable, Equatable, Hashable {
+    /// Let the model decide whether to call tools.
     case auto
+    /// Do not allow tool calls.
     case none
+    /// Require the model to call a tool.
     case required
+    /// Force a specific tool name.
     case specific(name: String)
 
+    /// Decodes the OpenAI string-or-object tool choice format.
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let string = try? container.decode(String.self) {
@@ -239,8 +355,15 @@ public enum ToolChoice: Decodable, Sendable, Equatable {
     }
 }
 
-public struct ResponseFormat: Decodable, Sendable, Equatable {
+/// OpenAI-compatible response-format request.
+public struct ResponseFormat: Decodable, Sendable, Equatable, Hashable {
+    /// The requested response format type, such as `text` or `json_object`.
     public let type: String
+
+    /// Creates a response-format request.
+    public init(type: String) {
+        self.type = type
+    }
 }
 
 // MARK: - Type-erased Codable for raw JSON schemas

--- a/Sources/Core/SchemaIR.swift
+++ b/Sources/Core/SchemaIR.swift
@@ -11,19 +11,37 @@
 
 import Foundation
 
-public indirect enum SchemaIR: Equatable, Sendable {
+/// Pure intermediate representation for the JSON Schema subset ApfelCore supports.
+public indirect enum SchemaIR: Equatable, Hashable, Sendable {
+    /// An object schema with named child properties.
     case object(name: String, description: String?, properties: [Property])
+    /// A string schema, optionally constrained to an enum of allowed values.
     case string(name: String, description: String?, enumValues: [String]?)
+    /// A numeric schema. Covers both JSON Schema `integer` and `number`.
     case number(name: String, description: String?)   // covers integer + number
+    /// A Boolean schema.
     case bool(name: String, description: String?)
+    /// An array schema whose items are described by another schema node.
     case array(itemName: String, items: SchemaIR)
 
-    public struct Property: Equatable, Sendable {
+    /// A named property within an object schema.
+    public struct Property: Equatable, Hashable, Sendable {
+        /// The JSON property name.
         public let name: String
+        /// Optional human-readable help text for the property.
         public let description: String?
+        /// The property's nested schema.
         public let schema: SchemaIR
+        /// Whether the property may be omitted.
         public let isOptional: Bool
 
+        /// Creates a schema property.
+        ///
+        /// - Parameters:
+        ///   - name: The JSON property name.
+        ///   - description: Optional human-readable help text.
+        ///   - schema: The nested schema for the property.
+        ///   - isOptional: Whether the property may be omitted.
         public init(name: String, description: String?, schema: SchemaIR, isOptional: Bool) {
             self.name = name
             self.description = description

--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -14,7 +14,7 @@ public struct ToolDef: Sendable {
 }
 
 /// Result of executing a prompt through the unified processPrompt() pipeline.
-public struct ProcessPromptResult: Sendable {
+package struct ProcessPromptResult: Sendable {
     public let content: String
     public let toolLog: [ToolLogEntry]
 
@@ -24,7 +24,7 @@ public struct ProcessPromptResult: Sendable {
 }
 
 /// A log entry from executing a tool call.
-public struct ToolLogEntry: Sendable, Equatable {
+package struct ToolLogEntry: Sendable, Equatable {
     public let name: String
     public let args: String
     public let result: String

--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -62,14 +62,14 @@ func printError(_ message: String) {
 
 // MARK: - Debug Output
 
-/// Print a debug message to stderr. Zero-cost when apfelDebugEnabled is false.
+/// Print a debug message to stderr. Zero-cost when debug logging is disabled.
 func debugLog(_ message: @autoclosure () -> String) {
-    guard apfelDebugEnabled else { return }
+    guard ApfelDebugConfiguration.isEnabled else { return }
     printStderr("\(styled("debug:", .dim)) \(message())")
 }
 
-/// Print a categorized debug message to stderr. Zero-cost when apfelDebugEnabled is false.
+/// Print a categorized debug message to stderr. Zero-cost when debug logging is disabled.
 func debugLog(_ category: String, _ message: @autoclosure () -> String) {
-    guard apfelDebugEnabled else { return }
+    guard ApfelDebugConfiguration.isEnabled else { return }
     printStderr("\(styled("debug[\(category)]:", .dim)) \(message())")
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -102,7 +102,7 @@ default:
 if let fmt = parsed.outputFormat { outputFormat = fmt }
 if parsed.quiet { quietMode = true }
 if parsed.noColor { noColorFlag = true }
-if parsed.debug { apfelDebugEnabled = true }
+if parsed.debug { ApfelDebugConfiguration.isEnabled = true }
 
 // Build the prompt: positional args + piped stdin + attached files.
 var prompt = parsed.prompt

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -50,10 +50,14 @@ func runApfelCorePublicAPIUsageTests() {
             let _: String = e.openAIMessage
             let _: Int    = e.httpStatusCode
             let _: Bool   = e.isRetryable
+            let _: String = e.description
+            let _: String = e.debugDescription
+            let _: String? = e.errorDescription
             let _ = requireSendable(e)
         }
         // Equatable is public.
         try assertEqual(ApfelError.rateLimited, ApfelError.rateLimited)
+        let _: Set<ApfelError> = [.rateLimited, .contextOverflow]
         // classify(_:) is public static.
         let classified = ApfelError.classify(MCPError.timedOut("x"))
         if case .toolExecution = classified { } else {
@@ -133,6 +137,7 @@ func runApfelCorePublicAPIUsageTests() {
         // MessageContent cases
         let _: MessageContent = .text("x")
         let _: MessageContent = .parts([ContentPart(type: "text", text: "a")])
+        let _: Set<MessageContent> = [.text("x")]
 
         // ContentPart
         let part = ContentPart(type: "text", text: "x")
@@ -161,6 +166,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: String?          = tool.function.description
         let _: RawJSON?         = tool.function.parameters
         let _ = requireSendable(tool)
+        let _: Set<OpenAITool> = [tool]
 
         // RawJSON
         let raw = RawJSON(rawValue: "{}")
@@ -172,6 +178,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: ToolChoice = .none
         let _: ToolChoice = .required
         let _: ToolChoice = .specific(name: "x")
+        let _: Set<ToolChoice> = [.auto, .required]
 
         // ResponseFormat (Decodable-only, so construct via JSON)
         let fmt = try JSONDecoder().decode(
@@ -179,6 +186,7 @@ func runApfelCorePublicAPIUsageTests() {
         )
         let _: String = fmt.type
         let _ = requireSendable(fmt)
+        let _: Set<ResponseFormat> = [fmt]
 
         // StreamOptions (Decodable-only, construct via JSON)
         let opts = try JSONDecoder().decode(
@@ -212,6 +220,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: Int?                = req.x_context_max_turns
         let _: Int?                = req.x_context_output_reserve
         let _ = requireSendable(req)
+        let _: Set<ChatCompletionRequest> = [req]
     }
 
     // MARK: - ChatRequestValidator surface
@@ -227,8 +236,11 @@ func runApfelCorePublicAPIUsageTests() {
             let _: String = p.name
             let _: String = p.message
             let _: String = p.rawValue  // RawValue: String is public
+            let _: String = p.description
+            let _: String = p.debugDescription
             let _ = requireSendable(p)
         }
+        let _: Set<UnsupportedChatParameter> = [.logprobs, .stop]
 
         // ChatRequestValidationFailure cases
         let failures: [ChatRequestValidationFailure] = [
@@ -242,8 +254,11 @@ func runApfelCorePublicAPIUsageTests() {
         for f in failures {
             let _: String = f.message
             let _: String = f.event
+            let _: String = f.description
+            let _: String = f.debugDescription
             let _ = requireSendable(f)
         }
+        let _: Set<ChatRequestValidationFailure> = [.emptyMessages, .invalidLastRole]
 
         // validate(_:) and detect(in:) are public
         let req = try JSONDecoder().decode(
@@ -254,21 +269,17 @@ func runApfelCorePublicAPIUsageTests() {
         let _: UnsupportedChatParameter?     = UnsupportedChatParameter.detect(in: req)
     }
 
-    // MARK: - BodyLimits
-
-    test("BodyLimits public constants compile") {
-        let _: Int = BodyLimits.maxRequestBodyBytes
-        let _: Int = BodyLimits.defaultOutputReserveTokens
-    }
-
     // MARK: - FinishReason / FinishReasonResolver
 
     test("FinishReason and FinishReasonResolver public surface compiles") {
         let cases: [FinishReason] = [.stop, .length, .toolCalls]
         for c in cases {
             let _: String = c.openAIValue
+            let _: String = c.description
+            let _: String = c.debugDescription
             let _ = requireSendable(c)
         }
+        let _: Set<FinishReason> = [.stop, .toolCalls]
         let r = FinishReasonResolver.resolve(hasToolCalls: false, completionTokens: 0, maxTokens: nil)
         try assertEqual(r, .stop)
     }
@@ -282,25 +293,12 @@ func runApfelCorePublicAPIUsageTests() {
         let _ = requireSendable(resolved)
     }
 
-    // MARK: - Concurrency primitives
+    // MARK: - StreamCleanup
 
-    testAsync("StreamCleanup / StreamTaskBox / TraceBuffer public surface compiles") {
+    testAsync("StreamCleanup public surface compiles") {
         let c = StreamCleanup()
         await c.run { }
         let _ = requireSendable(c)
-
-        let box = StreamTaskBox()
-        let t: Task<Void, Never> = Task { }
-        box.set(t)
-        box.cancel()
-        let _: Int = box.taskCount
-        let _ = requireSendable(box)
-
-        let buf = TraceBuffer(events: [])
-        await buf.append("x")
-        let snap: [String] = await buf.snapshot()
-        try assertEqual(snap, ["x"])
-        let _ = requireSendable(buf)
     }
 
     // MARK: - ContextStrategy / ContextConfig
@@ -312,6 +310,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: ContextStrategy = .summarize
         let _: ContextStrategy = .strict
         let _: [ContextStrategy] = ContextStrategy.allCases
+        let _: Set<ContextStrategy> = [.strict, .summarize]
 
         let cfg = ContextConfig(
             strategy: .slidingWindow,
@@ -326,15 +325,16 @@ func runApfelCorePublicAPIUsageTests() {
         let _ = requireSendable(cfg)
         let _: ContextConfig   = ContextConfig.defaults
         try assertEqual(ContextConfig.defaults.strategy, .newestFirst)
+        let _: Set<ContextConfig> = [cfg, .defaults]
     }
 
-    // MARK: - Global debug flag
+    // MARK: - Debug configuration
 
-    test("apfelDebugEnabled is a public Bool with sync read/write") {
-        let original = apfelDebugEnabled
-        defer { apfelDebugEnabled = original }
-        apfelDebugEnabled = true
-        try assertEqual(apfelDebugEnabled, true)
+    test("ApfelDebugConfiguration.isEnabled is a public Bool with sync read/write") {
+        let original = ApfelDebugConfiguration.isEnabled
+        defer { ApfelDebugConfiguration.isEnabled = original }
+        ApfelDebugConfiguration.isEnabled = true
+        try assertEqual(ApfelDebugConfiguration.isEnabled, true)
     }
 
     // MARK: - JSONFenceStripper
@@ -366,8 +366,11 @@ func runApfelCorePublicAPIUsageTests() {
             let _: Bool   = m.isAvailable
             let _: String = m.shortLabel
             let _: String = m.remediation
+            let _: String = m.description
+            let _: String = m.debugDescription
             let _ = requireSendable(m)
         }
+        let _: Set<ModelAvailability> = [.available, .deviceNotEligible]
         try assertTrue(ModelAvailability.available.isAvailable)
     }
 
@@ -421,6 +424,7 @@ func runApfelCorePublicAPIUsageTests() {
         if case .object = parsed { } else {
             throw TestFailure("expected object IR at root")
         }
+        let _: Set<SchemaIR> = [parsed]
 
         // SchemaParser.Error cases
         let errs: [SchemaParser.Error] = [
@@ -429,7 +433,7 @@ func runApfelCorePublicAPIUsageTests() {
         try assertEqual(errs.count, 3)
     }
 
-    // MARK: - ToolCallHandler (+ helper types)
+    // MARK: - ToolCallHandler
 
     test("ToolCallHandler public surface compiles") {
         let def = ToolDef(name: "f", description: "d", parametersJSON: "{}")
@@ -437,19 +441,6 @@ func runApfelCorePublicAPIUsageTests() {
         let _: String? = def.description
         let _: String? = def.parametersJSON
         let _ = requireSendable(def)
-
-        let log = ToolLogEntry(name: "f", args: "{}", result: "ok", isError: false)
-        let _: String = log.name
-        let _: String = log.args
-        let _: String = log.result
-        let _: Bool   = log.isError
-        try assertEqual(log, log)
-        let _ = requireSendable(log)
-
-        let result = ProcessPromptResult(content: "out", toolLog: [log])
-        let _: String          = result.content
-        let _: [ToolLogEntry]  = result.toolLog
-        let _ = requireSendable(result)
 
         let instructions = ToolCallHandler.buildOutputFormatInstructions(toolNames: ["f"])
         try assertTrue(instructions.contains("Tool Calling Format"))

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -180,25 +180,29 @@ func runApfelCorePublicAPIUsageTests() {
         let _: ToolChoice = .specific(name: "x")
         let _: Set<ToolChoice> = [.auto, .required]
 
-        // ResponseFormat (Decodable-only, so construct via JSON)
-        let fmt = try JSONDecoder().decode(
-            ResponseFormat.self, from: Data(#"{"type":"text"}"#.utf8)
-        )
+        // ResponseFormat
+        let fmt = ResponseFormat(type: "text")
         let _: String = fmt.type
         let _ = requireSendable(fmt)
         let _: Set<ResponseFormat> = [fmt]
-
-        // StreamOptions (Decodable-only, construct via JSON)
-        let opts = try JSONDecoder().decode(
-            StreamOptions.self, from: Data(#"{"include_usage":true}"#.utf8)
+        try assertEqual(
+            try JSONDecoder().decode(ResponseFormat.self, from: Data(#"{"type":"text"}"#.utf8)),
+            fmt
         )
+
+        // StreamOptions
+        let opts = StreamOptions(include_usage: true)
         let _: Bool? = opts.include_usage
         let _ = requireSendable(opts)
+        try assertEqual(
+            try JSONDecoder().decode(StreamOptions.self, from: Data(#"{"include_usage":true}"#.utf8)),
+            opts
+        )
 
-        // ChatCompletionRequest (Decodable-only)
-        let req = try JSONDecoder().decode(
-            ChatCompletionRequest.self,
-            from: Data(#"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}]}"#.utf8)
+        // ChatCompletionRequest
+        let req = ChatCompletionRequest(
+            model: "apple-foundationmodel",
+            messages: [OpenAIMessage(role: "user", content: .text("hi"))]
         )
         let _: String              = req.model
         let _: [OpenAIMessage]     = req.messages
@@ -221,6 +225,13 @@ func runApfelCorePublicAPIUsageTests() {
         let _: Int?                = req.x_context_output_reserve
         let _ = requireSendable(req)
         let _: Set<ChatCompletionRequest> = [req]
+        try assertEqual(
+            try JSONDecoder().decode(
+                ChatCompletionRequest.self,
+                from: Data(#"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}]}"#.utf8)
+            ),
+            req
+        )
     }
 
     // MARK: - ChatRequestValidator surface
@@ -326,15 +337,6 @@ func runApfelCorePublicAPIUsageTests() {
         let _: ContextConfig   = ContextConfig.defaults
         try assertEqual(ContextConfig.defaults.strategy, .newestFirst)
         let _: Set<ContextConfig> = [cfg, .defaults]
-    }
-
-    // MARK: - Debug configuration
-
-    test("ApfelDebugConfiguration.isEnabled is a public Bool with sync read/write") {
-        let original = ApfelDebugConfiguration.isEnabled
-        defer { ApfelDebugConfiguration.isEnabled = original }
-        ApfelDebugConfiguration.isEnabled = true
-        try assertEqual(ApfelDebugConfiguration.isEnabled, true)
     }
 
     // MARK: - JSONFenceStripper

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -142,6 +142,24 @@ func runApfelErrorMessageTests() {
         try assertEqual(MCPError.timedOut("x").errorDescription,         "x")
     }
 
+    test("ApfelError.localizedDescription equals openAIMessage for every case") {
+        let cases: [ApfelError] = [
+            .guardrailViolation,
+            .contextOverflow,
+            .rateLimited,
+            .concurrentRequest,
+            .assetsUnavailable,
+            .unsupportedGuide,
+            .decodingFailure("bad JSON"),
+            .unsupportedLanguage("tlh"),
+            .toolExecution("calculator exploded"),
+            .unknown("mystery"),
+        ]
+        for error in cases {
+            try assertEqual((error as Error).localizedDescription, error.openAIMessage)
+        }
+    }
+
     // MARK: - ChatRequestValidationFailure.message (HTTP 400 body for bad requests)
 
     test("ChatRequestValidationFailure.message for every case") {

--- a/Tests/apfelTests/BufferedLineReaderConcurrencyTests.swift
+++ b/Tests/apfelTests/BufferedLineReaderConcurrencyTests.swift
@@ -9,10 +9,9 @@
 //      call finishes before the next starts) and the leftover buffer remains
 //      consistent.
 //
-// NOT tested here: simultaneous readLine() calls on the same reader. That is
-// the actual race the Mutex refactor targets; today it is a data race and a
-// green test would be meaningless. A TSan-gated test for that belongs in the
-// same commit as the refactor.
+// The key future-safe guarantee added by #105 is that simultaneous readLine()
+// calls on the same reader are serialized safely instead of racing on the
+// leftover buffer.
 // ============================================================================
 
 import Foundation
@@ -141,6 +140,26 @@ func runBufferedLineReaderConcurrencyTests() {
             guard collected[i] == "line-\(i)" else {
                 throw TestFailure("order broken at index \(i): \(collected[i])")
             }
+        }
+    }
+
+    testAsync("simultaneous reads on one reader return distinct complete lines") {
+        let (r, w) = makePipePair()
+        defer { close(r); close(w) }
+
+        writeString(w, "alpha\nbeta\n")
+        let reader = BufferedLineReader(fileDescriptor: r)
+
+        async let first: String = Task.detached {
+            try reader.readLine(timeoutMilliseconds: 2000, operationDescription: "parallel-a")
+        }.value
+        async let second: String = Task.detached {
+            try reader.readLine(timeoutMilliseconds: 2000, operationDescription: "parallel-b")
+        }.value
+
+        let got = try await [first, second].sorted()
+        guard got == ["alpha", "beta"] else {
+            throw TestFailure("simultaneous same-reader reads lost or duplicated lines: \(got)")
         }
     }
 }

--- a/Tests/apfelTests/DebugFlagBaselineTests.swift
+++ b/Tests/apfelTests/DebugFlagBaselineTests.swift
@@ -1,71 +1,57 @@
 // ============================================================================
-// DebugFlagBaselineTests.swift — Baseline for the apfelDebugEnabled refactor
-// promised in #105 ("Replace nonisolated(unsafe) var with Mutex or actor").
+// DebugFlagBaselineTests.swift — Public contract for the future-safe debug
+// configuration introduced by issue #105.
 //
-// What this file locks in:
-//   - Public type of the flag is Bool (not an actor, not a Mutex wrapper).
-//   - Reads and writes are SYNCHRONOUS from both sync and async contexts.
-//   - Default value is false.
-//   - Save/restore pattern (the idiom used across the test suite) works.
-//
-// If the refactor changes this contract (e.g. `await apfelDebugFlag.get()`),
-// these tests stop compiling — which is the deliberate signal that every call
-// site needs updating. That is the point of this baseline.
+// The old `nonisolated(unsafe) var apfelDebugEnabled` was data-race-prone and
+// not library-grade. The replacement must still be easy to use from sync and
+// async contexts, but the public surface should now be a namespaced
+// configuration API instead of a bare global variable.
 // ============================================================================
 
 import Foundation
 import ApfelCore
 
 func runDebugFlagBaselineTests() {
-    test("apfelDebugEnabled is typed as Bool") {
-        // Compile-time assertion. If the variable's type ever changes, the
-        // assignment below stops compiling.
-        let snapshot: Bool = apfelDebugEnabled
-        // Use snapshot so the compiler doesn't warn about unused binding.
+    test("ApfelDebugConfiguration.isEnabled is typed as Bool") {
+        let snapshot: Bool = ApfelDebugConfiguration.isEnabled
         try assertTrue(snapshot == true || snapshot == false)
     }
 
-    test("apfelDebugEnabled has default value false at test-runner startup") {
-        // Only meaningful if nothing earlier in the suite left it true without
-        // restoring. The existing DebugLoggerTests use defer-restore, so this
-        // assertion holds and guards against future leakage.
-        try assertEqual(apfelDebugEnabled, false)
+    test("ApfelDebugConfiguration.isEnabled has default value false at test-runner startup") {
+        try assertEqual(ApfelDebugConfiguration.isEnabled, false)
     }
 
-    test("apfelDebugEnabled supports synchronous write + read") {
-        let original = apfelDebugEnabled
-        defer { apfelDebugEnabled = original }
-        apfelDebugEnabled = true
-        try assertEqual(apfelDebugEnabled, true)
-        apfelDebugEnabled = false
-        try assertEqual(apfelDebugEnabled, false)
+    test("ApfelDebugConfiguration supports synchronous write + read") {
+        let original = ApfelDebugConfiguration.isEnabled
+        defer { ApfelDebugConfiguration.isEnabled = original }
+        ApfelDebugConfiguration.isEnabled = true
+        try assertEqual(ApfelDebugConfiguration.isEnabled, true)
+        ApfelDebugConfiguration.isEnabled = false
+        try assertEqual(ApfelDebugConfiguration.isEnabled, false)
     }
 
     test("nested save/restore idiom restores prior value") {
-        let original = apfelDebugEnabled
-        defer { apfelDebugEnabled = original }
+        let original = ApfelDebugConfiguration.isEnabled
+        defer { ApfelDebugConfiguration.isEnabled = original }
 
-        apfelDebugEnabled = true
+        ApfelDebugConfiguration.isEnabled = true
         do {
-            let inner = apfelDebugEnabled
-            defer { apfelDebugEnabled = inner }
-            apfelDebugEnabled = false
-            try assertEqual(apfelDebugEnabled, false)
+            let inner = ApfelDebugConfiguration.isEnabled
+            defer { ApfelDebugConfiguration.isEnabled = inner }
+            ApfelDebugConfiguration.isEnabled = false
+            try assertEqual(ApfelDebugConfiguration.isEnabled, false)
         }
-        try assertEqual(apfelDebugEnabled, true)
+        try assertEqual(ApfelDebugConfiguration.isEnabled, true)
     }
 
-    testAsync("apfelDebugEnabled reads synchronously from an async context") {
-        // If this variable becomes actor-isolated, the line below would require
-        // `await`, which is a breaking change for every file that reads the
-        // flag from async code today (Session, Handlers, Server streaming path).
-        let _: Bool = apfelDebugEnabled
+    testAsync("ApfelDebugConfiguration reads synchronously from an async context") {
+        let _: Bool = ApfelDebugConfiguration.isEnabled
     }
 
-    testAsync("apfelDebugEnabled writes synchronously from an async context") {
-        let original = apfelDebugEnabled
-        defer { apfelDebugEnabled = original }
-        apfelDebugEnabled = true
-        try assertEqual(apfelDebugEnabled, true)
+    testAsync("ApfelDebugConfiguration writes synchronously from an async context") {
+        let original = ApfelDebugConfiguration.isEnabled
+        defer { ApfelDebugConfiguration.isEnabled = original }
+        ApfelDebugConfiguration.isEnabled = true
+        try assertEqual(ApfelDebugConfiguration.isEnabled, true)
     }
 }

--- a/Tests/apfelTests/DebugFlagBaselineTests.swift
+++ b/Tests/apfelTests/DebugFlagBaselineTests.swift
@@ -1,11 +1,11 @@
 // ============================================================================
-// DebugFlagBaselineTests.swift — Public contract for the future-safe debug
+// DebugFlagBaselineTests.swift — Package-internal contract for the future-safe debug
 // configuration introduced by issue #105.
 //
 // The old `nonisolated(unsafe) var apfelDebugEnabled` was data-race-prone and
 // not library-grade. The replacement must still be easy to use from sync and
-// async contexts, but the public surface should now be a namespaced
-// configuration API instead of a bare global variable.
+// async contexts, but it should remain package-scoped instead of leaking into
+// the public `ApfelCore` semver surface.
 // ============================================================================
 
 import Foundation

--- a/Tests/apfelTests/DebugLoggerTests.swift
+++ b/Tests/apfelTests/DebugLoggerTests.swift
@@ -2,13 +2,13 @@ import Foundation
 import ApfelCore
 
 func runDebugLoggerTests() {
-    test("apfelDebugEnabled defaults to false") {
-        try assertEqual(apfelDebugEnabled, false)
+    test("ApfelDebugConfiguration defaults to false") {
+        try assertEqual(ApfelDebugConfiguration.isEnabled, false)
     }
-    test("apfelDebugEnabled can be toggled") {
-        let original = apfelDebugEnabled
-        defer { apfelDebugEnabled = original }
-        apfelDebugEnabled = true
-        try assertEqual(apfelDebugEnabled, true)
+    test("ApfelDebugConfiguration can be toggled") {
+        let original = ApfelDebugConfiguration.isEnabled
+        defer { ApfelDebugConfiguration.isEnabled = original }
+        ApfelDebugConfiguration.isEnabled = true
+        try assertEqual(ApfelDebugConfiguration.isEnabled, true)
     }
 }

--- a/Tests/integration/fixtures/apfelcore-consumer/Package.resolved
+++ b/Tests/integration/fixtures/apfelcore-consumer/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5c1e90a3f231d9a6f4800088304c56867158fafa976e4750a27d0d4c4121d144",
+  "originHash" : "7f56701cdb206d708e801b881401c547d1b01acbb430421a9ce652e52b120ed3",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "3b57e00556515b126ad74455de1e6fa456856391",
-        "version" : "1.33.0"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "d1ce7bbd2f1b17f22031ca4c0daeb39eff07a92e",
-        "version" : "2.21.1"
+        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
+        "version" : "2.22.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
+        "version" : "1.19.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
+        "revision" : "476538ccb827f2dd18efc5de754cc87d77127a47",
+        "version" : "4.4.0"
       }
     },
     {
@@ -101,30 +101,12 @@
       }
     },
     {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin.git",
-      "state" : {
-        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
-        "version" : "1.4.6"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-http-structured-headers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
-        "version" : "1.6.0"
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
@@ -141,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -150,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "f17c111cec972c2a4922cef38cf64f76f7e87886",
-        "version" : "2.8.0"
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -159,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "bdf004b44f77c56fca752cd1cf243c802f8469c9",
-        "version" : "2.97.0"
+        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
+        "version" : "2.98.0"
       }
     },
     {
@@ -168,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
-        "version" : "1.33.0"
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
       }
     },
     {
@@ -177,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
-        "version" : "1.42.0"
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
       }
     },
     {
@@ -186,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
-        "version" : "2.36.1"
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
       }
     },
     {
@@ -195,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
-        "version" : "1.26.0"
+        "revision" : "9d4e67af1eea85967c7de778ad73e7776e5f1f22",
+        "version" : "1.27.0"
       }
     },
     {
@@ -222,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
-        "version" : "2.10.1"
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Tests/integration/fixtures/apfelcore-consumer/Package.swift
+++ b/Tests/integration/fixtures/apfelcore-consumer/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "ApfelCoreConsumer",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(name: "apfel", path: "../../../../"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "apfelcore-consumer",
+            dependencies: [
+                .product(name: "ApfelCore", package: "apfel"),
+            ]
+        )
+    ]
+)

--- a/Tests/integration/fixtures/apfelcore-consumer/Sources/apfelcore-consumer/main.swift
+++ b/Tests/integration/fixtures/apfelcore-consumer/Sources/apfelcore-consumer/main.swift
@@ -1,0 +1,4 @@
+import ApfelCore
+
+let message = OpenAIMessage(role: "user", content: .text("hello"))
+print("\(message.textContent ?? "nil")|\(ContextStrategy.slidingWindow.rawValue)")

--- a/Tests/integration/test_apfelcore_examples.py
+++ b/Tests/integration/test_apfelcore_examples.py
@@ -1,0 +1,79 @@
+"""Smoke-test the runnable ApfelCore example targets.
+
+These examples back the public Swift package docs. If they stop compiling
+or their basic output changes unexpectedly, we want CI to fail loudly.
+"""
+
+import subprocess
+
+import pytest
+
+
+EXAMPLES = [
+    (
+        "apfelcore-context-strategies-example",
+        [
+            "strategy=sliding-window",
+            "max_turns=8",
+            "output_reserve=512",
+        ],
+    ),
+    (
+        "apfelcore-openai-types-example",
+        [
+            "model=apple-foundationmodel",
+            "messages=2",
+        ],
+    ),
+    (
+        "apfelcore-tool-calling-example",
+        [
+            "## Tool Calling Format",
+            '"name" : "add"',
+        ],
+    ),
+    (
+        "apfelcore-error-handling-example",
+        [
+            "[rate limited]",
+            "[context overflow]",
+            "[unsupported language]",
+        ],
+    ),
+    (
+        "apfelcore-mcp-protocol-example",
+        [
+            '"method":"initialize"',
+            '"method":"tools\\/list"',
+        ],
+    ),
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_server_11434():
+    yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_server_11435():
+    yield
+
+
+@pytest.mark.parametrize(("target", "expected_fragments"), EXAMPLES)
+def test_apfelcore_examples_build_and_run(target, expected_fragments):
+    result = subprocess.run(
+        ["swift", "run", target],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"{target} failed to build or run\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    for fragment in expected_fragments:
+        assert fragment in result.stdout, (
+            f"{target} output missing expected fragment: {fragment!r}\n"
+            f"stdout:\n{result.stdout}"
+        )

--- a/Tests/integration/test_apfelcore_package.py
+++ b/Tests/integration/test_apfelcore_package.py
@@ -1,0 +1,40 @@
+"""
+Smoke-test `ApfelCore` as a downstream SwiftPM product.
+
+This fixture package depends on the repo by local path and imports
+`ApfelCore` as an external product. The test should fail until
+`Package.swift` exposes `.library(name: "ApfelCore", targets: ["ApfelCore"])`.
+"""
+
+import pathlib
+import subprocess
+
+import pytest
+
+
+FIXTURE = pathlib.Path(__file__).resolve().parent / "fixtures" / "apfelcore-consumer"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_server_11434():
+    yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_server_11435():
+    yield
+
+
+def test_apfelcore_can_be_imported_by_a_downstream_package():
+    result = subprocess.run(
+        ["swift", "run", "apfelcore-consumer"],
+        cwd=FIXTURE,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "downstream SwiftPM consumer failed to build or run\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert result.stdout.strip() == "hello|sliding-window"

--- a/docs/release.md
+++ b/docs/release.md
@@ -48,6 +48,12 @@ The preflight script checks:
 
 Do not release if preflight fails.
 
+Before cutting a release, review whether the branch changes the public `ApfelCore` Swift Package API.
+
+- Additive `ApfelCore` API changes belong in [../CHANGELOG.md](../CHANGELOG.md) and require at least a minor bump.
+- Deprecated or removed `ApfelCore` API changes belong in [../CHANGELOG.md](../CHANGELOG.md) and require the deprecation policy from [../STABILITY.md](../STABILITY.md) to be followed.
+- Any removal or incompatible signature change to public `ApfelCore` API is a major release.
+
 ## Release commands
 
 ```bash
@@ -119,8 +125,8 @@ All three channels are "owned" in the sense that we file PRs against them and re
 apfel follows semver. See [STABILITY.md](../STABILITY.md) for the full stability policy.
 
 - **PATCH** (1.0.x): bug fixes, documentation, CI improvements
-- **MINOR** (1.x.0): new flags, new endpoints, backward-compatible features
-- **MAJOR** (x.0.0): removed flags, changed exit codes, breaking API changes
+- **MINOR** (1.x.0): new flags, new endpoints, backward-compatible features, additive public `ApfelCore` API
+- **MAJOR** (x.0.0): removed flags, changed exit codes, breaking API changes, removed or incompatible public `ApfelCore` API
 
 Model output changes from macOS updates are NOT version bumps.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-apfel uses semantic versioning. Releases are fully automated through GitHub Actions. Local builds (`make build`, `make install`) never change the version number.
+apfel uses semantic versioning. Releases are fully automated through the local `make release` workflow. Local builds (`make build`, `make install`) never change the version number.
 
 ## The release flow
 
@@ -10,16 +10,16 @@ apfel uses semantic versioning. Releases are fully automated through GitHub Acti
 make preflight              local qualification (git, build, tests, policy files)
        |
        v pass
-make release [TYPE=]        dispatch GitHub Actions
+make release [TYPE=]        run local release workflow
        |
-       v workflow runs on macos-26
+       v on-device release machine
   bump .version
        |
   build release binary
        |
-  unit tests (335+)
+  unit tests
        |
-  integration tests (7 suites)
+  integration tests
        |
   commit + tag + push
        |
@@ -41,8 +41,8 @@ The preflight script checks:
 - Git working tree is clean
 - On main branch, up to date with origin
 - Release build succeeds
-- Unit tests pass (335+)
-- Integration tests pass (7 suites: cli_e2e, performance, openai_client, openapi_spec, security, mcp_server, openapi_conformance)
+- Unit tests pass
+- Integration tests pass
 - SECURITY.md, STABILITY.md, LICENSE exist
 - Binary version matches .version
 
@@ -69,8 +69,8 @@ This runs locally via `scripts/publish-release.sh` (not on GitHub Actions - GitH
 1. Preflight checks (clean tree, on main, up to date with origin)
 2. Bumps `.version` via `make release-patch` / `release-minor` / `release-major`
 3. Builds the release binary
-4. Runs ALL 362 unit tests
-5. Runs ALL 7 integration test suites (157 tests, 0 skipped) with real Apple Intelligence
+4. Runs all unit tests via `swift run apfel-tests`
+5. Runs all integration tests discovered under `Tests/integration/` with real Apple Intelligence
 6. Commits `.version`, `README.md`, `Sources/BuildInfo.swift`, tags, and pushes to main
 7. Packages `apfel-<version>-arm64-macos.tar.gz`
 8. Publishes GitHub Release with changelog and tarball
@@ -103,10 +103,10 @@ The release workflow also updates the custom tap (`Arthur-Ficial/homebrew-tap`) 
 ## GitHub CI vs local testing
 
 GitHub CI (`ci.yml`) runs on every push/PR as a safety net, but it is a **subset**:
-- 362 unit tests (no model needed)
-- 21 model-free CLI integration tests (flags, help, version, file handling)
+- Unit tests that do not need Apple Intelligence
+- Model-free integration checks such as flags, help, version, file handling, man-page drift, and ApfelCore packaging smoke tests
 
-GitHub CI **cannot** run the full integration suite because GitHub-hosted `macos-26` runners are Intel Macs without Apple Intelligence. The full 519-test qualification (362 unit + 157 integration across 7 suites) runs locally on a Mac with Apple Intelligence via `make preflight` and `make release`. This local run is the real gate - no release ships without it.
+GitHub CI **cannot** run the full integration suite because GitHub-hosted `macos-26` runners are Intel Macs without Apple Intelligence. Full qualification runs locally on a Mac with Apple Intelligence via `make preflight` and `make release`. This local run is the real gate - no release ships without it.
 
 ## Distribution channels
 


### PR DESCRIPTION
## Summary

This PR exposes `ApfelCore` as a public Swift Package library product and hardens the package for downstream use.

It includes:
- a public `.library(name: "ApfelCore", targets: ["ApfelCore"])` product in `Package.swift`
- DocC catalog pages, example targets, `.spi.yml`, and `CHANGELOG.md`
- a dedicated `apfelcore-public-api` CI job for build, strict concurrency, DocC, API-diff, downstream-consumer, and examples smoke coverage
- public-surface cleanup via `package` access for internal-only symbols
- future-safety fixes for the old unsafe debug flag and `BufferedLineReader` sendability
- additive API polish for public types (`Hashable`, `LocalizedError`, `CustomStringConvertible`, `CustomDebugStringConvertible`, and convenience initializers where useful)

## Why

`ApfelCore` was already the cleanest pure-Swift seam in the repo. Making it a real package product is useful only if it is treated like library surface rather than an internal target.

This PR makes that boundary explicit and safer to depend on by:
- shrinking accidental semver commitments before release
- documenting the package and giving downstream consumers runnable examples
- adding CI and downstream-consumer checks so the package contract does not silently drift

## Notes

This PR intentionally does **not** claim the following are fully implemented:
- exhaustive doc comments for every public symbol
- a numeric 100% public-surface coverage gate
- `ApfelCoreTestHelpers`
- a larger redesign of public error associated values
- public `AnyCodable`
- the manual Swift Package Index submission itself

Those items were explicitly called out on #105 as not implemented rather than left ambiguous.

Closes #105.

## Validation

- `swift run apfel-tests`
- `python3 -m pytest Tests/integration/test_apfelcore_package.py Tests/integration/test_apfelcore_examples.py -v --tb=short`
- `swift package --allow-writing-to-directory /tmp/apfelcore-docs generate-documentation --target ApfelCore --disable-indexing --warnings-as-errors --output-path /tmp/apfelcore-docs`
- `make test`
