### PR TITLE
feat(errors): preserve refusal explanation via ApfelError.refusal(String)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum ApfelError: Error, Equatable, Hashable, Sendable {
     case guardrailViolation
+    case refusal(String)
     case contextOverflow
     case rateLimited
     case concurrentRequest
@@ -51,6 +52,9 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
 
     private static func classifyLocalizedDescription(_ description: String) -> ApfelError {
         let desc = description.lowercased()
+        if desc.contains(anyOf: ["refused", "refusal", "declined"]) {
+            return .refusal(description)
+        }
         if desc.contains(anyOf: ["guardrail", "content policy", "unsafe"]) {
             return .guardrailViolation
         }
@@ -72,6 +76,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var cliLabel: String {
         switch self {
         case .guardrailViolation:  return "[guardrail]"
+        case .refusal:             return "[refusal]"
         case .contextOverflow:     return "[context overflow]"
         case .rateLimited:         return "[rate limited]"
         case .concurrentRequest:   return "[busy]"
@@ -87,6 +92,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var openAIType: String {
         switch self {
         case .guardrailViolation:  return "content_policy_violation"
+        case .refusal:             return "content_policy_violation"
         case .contextOverflow:     return "context_length_exceeded"
         case .rateLimited:         return "rate_limit_error"
         case .concurrentRequest:   return "rate_limit_error"
@@ -103,6 +109,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var httpStatusCode: Int {
         switch self {
         case .guardrailViolation:  return 400
+        case .refusal:             return 400
         case .contextOverflow:     return 400
         case .rateLimited:         return 429
         case .concurrentRequest:   return 429
@@ -119,6 +126,8 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         switch self {
         case .guardrailViolation:
             return "The request was blocked by Apple's safety guardrails. Try rephrasing."
+        case .refusal(let explanation):
+            return "The on-device model refused the request: \(explanation)"
         case .contextOverflow:
             return "Input exceeds the 4096-token context window. Shorten the conversation history."
         case .rateLimited:
@@ -169,8 +178,10 @@ private enum FoundationModelsGenerationErrorCase: String, CaseIterable {
 
     func apfelError(localizedDescription: String) -> ApfelError {
         switch self {
-        case .guardrailViolation, .refusal:
+        case .guardrailViolation:
             return .guardrailViolation
+        case .refusal:
+            return .refusal(localizedDescription)
         case .exceededContextWindowSize:
             return .contextOverflow
         case .rateLimited:
@@ -204,6 +215,8 @@ extension ApfelError: LocalizedError, CustomStringConvertible, CustomDebugString
         switch self {
         case .guardrailViolation:
             return "ApfelError.guardrailViolation"
+        case .refusal(let message):
+            return "ApfelError.refusal(\(String(reflecting: message)))"
         case .contextOverflow:
             return "ApfelError.contextOverflow"
         case .rateLimited:

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -29,6 +29,7 @@ let exitRateLimited: Int32 = 6
 func exitCode(for error: ApfelError) -> Int32 {
     switch error {
     case .guardrailViolation:  return exitGuardrail
+    case .refusal:             return exitGuardrail
     case .contextOverflow:     return exitContextOverflow
     case .rateLimited:         return exitRateLimited
     case .concurrentRequest:   return exitRateLimited

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -5,7 +5,7 @@
 // change must be deliberate and visible in this test's diff).
 //
 // Covers:
-//   - ApfelError.openAIMessage (all 10 cases)
+//   - ApfelError.openAIMessage (all 11 cases)
 //   - ApfelError.cliLabel, .openAIType, .httpStatusCode (stable enumerations)
 //   - MCPError.description / errorDescription (all 5 cases)
 //   - ChatRequestValidationFailure.message and .event (all 6 cases)
@@ -22,6 +22,12 @@ func runApfelErrorMessageTests() {
         try assertEqual(
             ApfelError.guardrailViolation.openAIMessage,
             "The request was blocked by Apple's safety guardrails. Try rephrasing."
+        )
+    }
+    test("ApfelError.refusal.openAIMessage embeds the explanation") {
+        try assertEqual(
+            ApfelError.refusal("I cannot answer that question.").openAIMessage,
+            "The on-device model refused the request: I cannot answer that question."
         )
     }
     test("ApfelError.contextOverflow.openAIMessage") {
@@ -83,6 +89,7 @@ func runApfelErrorMessageTests() {
 
     test("ApfelError cliLabel lockdown for every case") {
         try assertEqual(ApfelError.guardrailViolation.cliLabel,  "[guardrail]")
+        try assertEqual(ApfelError.refusal("x").cliLabel,        "[refusal]")
         try assertEqual(ApfelError.contextOverflow.cliLabel,     "[context overflow]")
         try assertEqual(ApfelError.rateLimited.cliLabel,         "[rate limited]")
         try assertEqual(ApfelError.concurrentRequest.cliLabel,   "[busy]")
@@ -98,6 +105,7 @@ func runApfelErrorMessageTests() {
 
     test("ApfelError openAIType lockdown for every case") {
         try assertEqual(ApfelError.guardrailViolation.openAIType,  "content_policy_violation")
+        try assertEqual(ApfelError.refusal("x").openAIType,        "content_policy_violation")
         try assertEqual(ApfelError.contextOverflow.openAIType,     "context_length_exceeded")
         try assertEqual(ApfelError.rateLimited.openAIType,         "rate_limit_error")
         try assertEqual(ApfelError.concurrentRequest.openAIType,   "rate_limit_error")
@@ -113,6 +121,7 @@ func runApfelErrorMessageTests() {
 
     test("ApfelError httpStatusCode lockdown for every case") {
         try assertEqual(ApfelError.guardrailViolation.httpStatusCode,  400)
+        try assertEqual(ApfelError.refusal("x").httpStatusCode,        400)
         try assertEqual(ApfelError.contextOverflow.httpStatusCode,     400)
         try assertEqual(ApfelError.rateLimited.httpStatusCode,         429)
         try assertEqual(ApfelError.concurrentRequest.httpStatusCode,   429)
@@ -145,6 +154,7 @@ func runApfelErrorMessageTests() {
     test("ApfelError.localizedDescription equals openAIMessage for every case") {
         let cases: [ApfelError] = [
             .guardrailViolation,
+            .refusal("model said no"),
             .contextOverflow,
             .rateLimited,
             .concurrentRequest,
@@ -257,6 +267,7 @@ func runApfelErrorMessageTests() {
 
     test("ApfelError.isRetryable lockdown for every case") {
         try assertEqual(ApfelError.guardrailViolation.isRetryable,  false)
+        try assertEqual(ApfelError.refusal("x").isRetryable,        false)
         try assertEqual(ApfelError.contextOverflow.isRetryable,     false)
         try assertEqual(ApfelError.rateLimited.isRetryable,         true)
         try assertEqual(ApfelError.concurrentRequest.isRetryable,   true)
@@ -274,5 +285,6 @@ func runApfelErrorMessageTests() {
         try assertEqual(isRetryableError(ApfelError.assetsUnavailable),  true)
         try assertEqual(isRetryableError(ApfelError.contextOverflow),    false)
         try assertEqual(isRetryableError(ApfelError.guardrailViolation), false)
+        try assertEqual(isRetryableError(ApfelError.refusal("x")),       false)
     }
 }

--- a/Tests/apfelTests/ApfelErrorTests.swift
+++ b/Tests/apfelTests/ApfelErrorTests.swift
@@ -77,6 +77,7 @@ func runApfelErrorTests() {
         try assertEqual(ApfelError.classify(ApfelError.rateLimited), .rateLimited)
         try assertEqual(ApfelError.classify(ApfelError.concurrentRequest), .concurrentRequest)
         try assertEqual(ApfelError.classify(ApfelError.assetsUnavailable), .assetsUnavailable)
+        try assertEqual(ApfelError.classify(ApfelError.refusal("r")), .refusal("r"))
         try assertEqual(ApfelError.classify(ApfelError.toolExecution("x")), .toolExecution("x"))
     }
     test("classify maps every known FoundationModels GenerationError case") {
@@ -90,7 +91,7 @@ func runApfelErrorTests() {
             ("decodingFailure", .decodingFailure(localized)),
             ("rateLimited", .rateLimited),
             ("concurrentRequests", .concurrentRequest),
-            ("refusal", .guardrailViolation),
+            ("refusal", .refusal(localized)),
         ]
 
         for item in cases {
@@ -98,9 +99,49 @@ func runApfelErrorTests() {
             try assertEqual(ApfelError.classify(err), item.expected, "case=\(item.caseName)")
         }
     }
+    test("classify preserves refusal explanation text, distinct from guardrailViolation") {
+        let refusal = FoundationModelsGenerationErrorStub(
+            caseName: "refusal",
+            localizedMsg: "I cannot provide that information."
+        )
+        let classified = ApfelError.classify(refusal)
+        if case .refusal(let text) = classified {
+            try assertEqual(text, "I cannot provide that information.")
+        } else {
+            throw TestFailure("expected .refusal, got \(classified)")
+        }
+        // And guardrailViolation stays distinct
+        let guardrail = FoundationModelsGenerationErrorStub(
+            caseName: "guardrailViolation",
+            localizedMsg: "Blocked by safety policy"
+        )
+        try assertEqual(ApfelError.classify(guardrail), .guardrailViolation)
+    }
+    test("classify string fallback detects refusal keywords") {
+        for keyword in ["refused", "refusal", "declined"] {
+            let err = NSError(domain: "FM", code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "The model \(keyword) to respond"])
+            if case .refusal = ApfelError.classify(err) {
+                continue
+            }
+            throw TestFailure("expected .refusal for keyword '\(keyword)'")
+        }
+    }
+    test("classify passthrough for refusal") {
+        let original = ApfelError.refusal("preserve me")
+        try assertEqual(ApfelError.classify(original), .refusal("preserve me"))
+    }
+    test("refusal error properties") {
+        let err = ApfelError.refusal("Model says no")
+        try assertEqual(err.cliLabel, "[refusal]")
+        try assertEqual(err.openAIType, "content_policy_violation")
+        try assertEqual(err.httpStatusCode, 400)
+        try assertTrue(err.openAIMessage.contains("Model says no"))
+        try assertTrue(!err.isRetryable)
+    }
     test("openAIMessage is non-empty for all cases") {
-        let cases: [ApfelError] = [.guardrailViolation, .contextOverflow, .rateLimited,
-                                    .concurrentRequest, .assetsUnavailable,
+        let cases: [ApfelError] = [.guardrailViolation, .refusal("text"), .contextOverflow,
+                                    .rateLimited, .concurrentRequest, .assetsUnavailable,
                                     .toolExecution("tool failed"), .unknown("oops"),
                                     .unsupportedGuide, .decodingFailure("decode failed"),
                                     .unsupportedLanguage("Klingon")]


### PR DESCRIPTION
## Summary

Preserves the on-device model's actual refusal explanation instead of replacing it with a generic guardrail message.

Today `GenerationError.refusal` collapses into `ApfelError.guardrailViolation`, which has no associated value, so the model's reason is replaced with `"The request was blocked by Apple's safety guardrails. Try rephrasing."` before it ever reaches the CLI or the HTTP error body. This PR threads the explanation through via a new `case refusal(String)`.

### Change

- `ApfelCore`: new `case refusal(String)` on `ApfelError`. Every supporting switch updated (`cliLabel`, `openAIType`, `httpStatusCode`, `openAIMessage`, `debugDescription`, `isRetryable`, `main.swift:exitCode(for:)`).
- `FoundationModelsGenerationErrorCase.refusal` maps to `.refusal(localizedDescription)` instead of `.guardrailViolation`.
- `classifyLocalizedDescription` adds a `refused`/`refusal`/`declined` keyword branch above the guardrail keyword branch.
- Retention semantics: same HTTP 400, same `openAIType: content_policy_violation`, same `isRetryable: false`, same exit code 3 as `guardrailViolation` — script compat preserved. Distinct `[refusal]` CLI label and a message of the form `"The on-device model refused the request: \(explanation)"`.

### Deliberately out of scope (not half-finished)

- **Async `Refusal.explanation` extraction.** `error.localizedDescription` is Apple's locale-rendered surface and carries the explanation in the sync context we already have. No plumbing required.
- **OpenAI wire-format flip from HTTP 400 to 200-with-`message.refusal`.** That's a separate error-vs-success semantic decision; conflating it here would be the half-finished trap. This PR keeps the current error-response shape and only improves the body text.
- **`LanguageModelSession.ToolCallError`.** Confirmed unreachable in apfel's flow: we pass `Transcript.ToolDefinition` (schema-only) to `LanguageModelSession`, never live `Tool` implementations. `ToolCallError` has no throw site.

### API break (by design, semver-minor)

Adding a public enum case to `ApfelError` is detected by `swift package diagnose-api-breaking-changes` and the `apfelcore-public-api` CI check will correctly fail on this PR. Per `STABILITY.md`, additive enum cases are a **minor** bump, not a major. The red check here is the signal to release as `1.2.0`, not a reason to revert. Existing downstream consumers need to add a `.refusal` arm to any exhaustive switch on `ApfelError` — that's the `1.2.0 = new-minor-work` contract.

### Tests

- 5 new refusal-specific tests in `ApfelErrorTests.swift`: classify preserves explanation, distinct from guardrail; string fallback keyword detection; passthrough; error properties.
- Every lockdown switch in `ApfelErrorMessageTests.swift` updated for the new case.
- Local: `swift run apfel-tests` → **549 / 549 unit passing**. `make test` → **250 / 250 integration passing** with both servers up (ports 11434 plain + 11435 MCP). Total **799 / 799, 0 skipped**.

### Test plan

- [x] `swift build` clean on Swift 6.3.1 / SDK 26.4+
- [x] 549 unit tests pass
- [x] 250 integration tests pass (real Apple Intelligence, 2 servers)
- [x] All `ApfelError` lockdown switches include `.refusal`
- [ ] CI: `build-and-test` green
- [ ] CI: `apfelcore-public-api` **expected red** (API-break on minor bump — see above)

### Post-merge

`make release TYPE=minor` → `1.2.0`. Refactor in #117 already structured the surface cleanly for this follow-up, so the diff stays small.

Supersedes the closed #116 / #115 after a harder vet of user value vs. API cost: the explanation-preservation win is real today; the async extraction and wire-format flip correctly stay deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
