### PR TITLE
docs(code): note ToolCallError is unreachable (#119)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -19,6 +19,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         if let mcpError = error as? MCPError {
             return .toolExecution(mcpError.description)
         }
+        // FoundationModels ToolCallError is unreachable - apfel runs tools out-of-band; see #119
 
         let typeName = String(describing: type(of: error))
         let mirror = String(reflecting: error)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #119 (acceptance criteria 1 of 3 - the source comment).

## Root cause

Not a bug - this is a parked enhancement. Issue #119 documents why `FoundationModels.ToolCallError` classification is intentionally absent from `ApfelError.classify(_:)`. apfel runs tools out-of-band (MCP client / apfel-side loop), so the SDK never owns tool execution and never throws `ToolCallError`. The acceptance criteria ask for a one-line architectural comment documenting this.

## The fix

Added a single comment on line 22 of `Sources/Core/ApfelError.swift`, right after the `MCPError` classifier branch:

```swift
// FoundationModels ToolCallError is unreachable - apfel runs tools out-of-band; see #119
```

This satisfies acceptance criterion 1. Criterion 2 (docs note) is optional per the issue - the tracker comment suffices. Criterion 3 (keep issue open with `parked` label) is a label change, not a code change.

## Test coverage

- No new tests needed - this is a comment-only change with zero behavioral impact.
- Existing `ApfelErrorTests` continue to cover all reachable classifier paths.

## What I verified (static only)

- Diff is exactly one line: a comment. No logic changes.
- No touches to release infrastructure, guardrails, CI, dependencies, `.version`, or `BuildInfo.swift`.
- Swift 6 concurrency: no impact (comment only).
- Comment text written fresh - not copied from the issue body.

## What I did NOT verify

- **Functional correctness not verified - needs `make test` on a Mac with Apple Intelligence.** Though this is a comment-only change, the build should still be confirmed clean.

## Anything that seemed suspicious

Nothing - straightforward parked enhancement with clear acceptance criteria, filed by Arthur-Ficial.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUXR87DZGmPb55y7W5L2Ci)_