### PR TITLE
fix(wire-format): encode refusal field when set, add contentFilter finish reason (#118)

### DIFF
--- a/Sources/Core/Chat/FinishReasonResolver.swift
+++ b/Sources/Core/Chat/FinishReasonResolver.swift
@@ -11,6 +11,8 @@ public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible
     case length
     /// The response ended in a tool-call payload instead of plain text.
     case toolCalls
+    /// The response was blocked by a content filter (refusal).
+    case contentFilter
 
     /// The OpenAI-compatible wire value for this finish reason.
     public var openAIValue: String {
@@ -18,6 +20,7 @@ public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible
         case .stop: return "stop"
         case .length: return "length"
         case .toolCalls: return "tool_calls"
+        case .contentFilter: return "content_filter"
         }
     }
 

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -113,7 +113,7 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
     public let tool_call_id: String?
     /// Optional sender name.
     public let name: String?
-    /// OpenAI refusal text. Always encoded as `null` for the local model.
+    /// OpenAI refusal text. Encoded as null when absent, populated on content-filter refusals.
     public let refusal: String?
 
     /// Creates an OpenAI-compatible message value.
@@ -151,8 +151,11 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
         try c.encodeIfPresent(tool_calls, forKey: .tool_calls)
         try c.encodeIfPresent(tool_call_id, forKey: .tool_call_id)
         try c.encodeIfPresent(name, forKey: .name)
-        // refusal: always present in responses (null when absent)
-        try c.encodeNil(forKey: .refusal)
+        if let refusal = refusal {
+            try c.encode(refusal, forKey: .refusal)
+        } else {
+            try c.encodeNil(forKey: .refusal)
+        }
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Tests/apfelTests/FinishReasonResolverTests.swift
+++ b/Tests/apfelTests/FinishReasonResolverTests.swift
@@ -47,6 +47,7 @@ func runFinishReasonResolverTests() {
         try assertEqual(FinishReason.stop.openAIValue, "stop")
         try assertEqual(FinishReason.length.openAIValue, "length")
         try assertEqual(FinishReason.toolCalls.openAIValue, "tool_calls")
+        try assertEqual(FinishReason.contentFilter.openAIValue, "content_filter")
     }
 
     test("zero completion tokens with max set -> stop (not length)") {

--- a/Tests/apfelTests/OpenAIWireFormatTests.swift
+++ b/Tests/apfelTests/OpenAIWireFormatTests.swift
@@ -7,7 +7,7 @@
 //
 // What's covered:
 //   - OpenAIMessage.encode (custom encoder): content always present (null when
-//     nil), refusal always encoded as null, optional fields omitted when nil
+//     nil), refusal null when absent / populated when set, optional fields omitted when nil
 //   - MessageContent encodes as string for .text and array for .parts
 //   - ContentPart default synthesized encoding (nil text omitted)
 //   - ToolCall / ToolCallFunction default encoding
@@ -56,11 +56,17 @@ func runOpenAIWireFormatTests() {
         )
     }
 
-    test("OpenAIMessage refusal is always serialized as null, even when set") {
-        // Our model never refuses, so the encoder hard-codes refusal=null.
-        // Third-party tooling relies on this: a non-null refusal means a
-        // different model/server.
-        let msg = OpenAIMessage(role: "assistant", content: .text("ok"), refusal: "this should be ignored")
+    test("OpenAIMessage refusal is serialized when set") {
+        let msg = OpenAIMessage(role: "assistant", content: nil, refusal: "I can't help with that.")
+        let json = try sortedEncode(msg)
+        try assertEqual(
+            json,
+            #"{"content":null,"refusal":"I can't help with that.","role":"assistant"}"#
+        )
+    }
+
+    test("OpenAIMessage refusal is null when not set") {
+        let msg = OpenAIMessage(role: "assistant", content: .text("ok"))
         let json = try sortedEncode(msg)
         try assertEqual(
             json,
@@ -294,9 +300,10 @@ func runOpenAIWireFormatTests() {
     // MARK: - FinishReason wire values
 
     test("FinishReason.openAIValue for every case") {
-        try assertEqual(FinishReason.stop.openAIValue,      "stop")
-        try assertEqual(FinishReason.length.openAIValue,    "length")
-        try assertEqual(FinishReason.toolCalls.openAIValue, "tool_calls")
+        try assertEqual(FinishReason.stop.openAIValue,          "stop")
+        try assertEqual(FinishReason.length.openAIValue,        "length")
+        try assertEqual(FinishReason.toolCalls.openAIValue,     "tool_calls")
+        try assertEqual(FinishReason.contentFilter.openAIValue, "content_filter")
     }
 
     // MARK: - StreamOptions equality (public Equatable conformance)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #118 (data-layer prerequisites only - handler-level 200-OK path is a follow-up).

## Root cause

`OpenAIMessage.encode(to:)` unconditionally called `try c.encodeNil(forKey: .refusal)` on line 155, ignoring the actual value of the `refusal` property. This meant even when a caller constructed an `OpenAIMessage` with a non-nil refusal string, the wire output always contained `"refusal": null`. Separately, `FinishReason` had no `contentFilter` case, so there was no way to emit `"finish_reason": "content_filter"` on refusal responses.

## The fix

The custom encoder now checks `refusal`: if non-nil, it encodes the string; if nil, it encodes null. This preserves the existing wire format for normal messages (refusal remains null) while enabling refusal text to reach the wire when set. `FinishReason` gains a `.contentFilter` case with wire value `"content_filter"`, completing the data-layer prerequisites for the handler-level changes described in #118.

## Test coverage

- Replaced `OpenAIWireFormatTests` "refusal is always serialized as null, even when set" with two tests: "refusal is serialized when set" and "refusal is null when not set". The old test locked in the broken behavior; the new tests lock in the correct behavior.
- Added `FinishReason.contentFilter.openAIValue` assertion to both `OpenAIWireFormatTests` and `FinishReasonResolverTests`.

## What I verified (static only)

- Encoder logic is straightforward conditional nil-check - matches the existing `content` encoding pattern on lines 145-149 of the same file.
- `FinishReason.openAIValue` is an exhaustive switch - adding the new case is compile-safe.
- `FinishReasonResolver.resolve()` constructs values directly (not a switch), so it doesn't need changes for the new case.
- `description` and `debugDescription` delegate to `openAIValue` - no additional changes needed.
- Swift 6 concurrency: no data races introduced (all types remain value types).
- Diff limited to `Sources/Core/OpenAIModels.swift`, `Sources/Core/Chat/FinishReasonResolver.swift`, `Tests/apfelTests/OpenAIWireFormatTests.swift`, `Tests/apfelTests/FinishReasonResolverTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or the Swift compiler. If the fix does not compile or tests fail, that is on me to refine - ping me in a review comment.

## Scope note

This PR covers acceptance criteria 3 from #118 (encoder fix + test update) and adds the `contentFilter` finish reason as a prerequisite for criteria 1 and 2. The handler-level changes (converting guardrail violations from HTTP 400 to HTTP 200, streaming path, feature flag) are a separate scope that also depends on the `.refusal(String)` case on `ApfelError` from the `quality/refusal-preserve-explanation` branch. Those are follow-up work.

## Anything that seemed suspicious

Nothing - straightforward data-layer fix. The issue was filed by Arthur-Ficial and references prior audits (#115, #116).

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaEgAuZ1AsUpHysruTUY9q)_