### PR TITLE
fix(server): return 200 OK with content_filter for model refusals (#118)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum ApfelError: Error, Equatable, Hashable, Sendable {
     case guardrailViolation
+    case refusal(String)
     case contextOverflow
     case rateLimited
     case concurrentRequest
@@ -72,6 +73,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var cliLabel: String {
         switch self {
         case .guardrailViolation:  return "[guardrail]"
+        case .refusal:             return "[refusal]"
         case .contextOverflow:     return "[context overflow]"
         case .rateLimited:         return "[rate limited]"
         case .concurrentRequest:   return "[busy]"
@@ -87,6 +89,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var openAIType: String {
         switch self {
         case .guardrailViolation:  return "content_policy_violation"
+        case .refusal:             return "content_policy_violation"
         case .contextOverflow:     return "context_length_exceeded"
         case .rateLimited:         return "rate_limit_error"
         case .concurrentRequest:   return "rate_limit_error"
@@ -103,6 +106,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var httpStatusCode: Int {
         switch self {
         case .guardrailViolation:  return 400
+        case .refusal:             return 200
         case .contextOverflow:     return 400
         case .rateLimited:         return 429
         case .concurrentRequest:   return 429
@@ -119,6 +123,8 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         switch self {
         case .guardrailViolation:
             return "The request was blocked by Apple's safety guardrails. Try rephrasing."
+        case .refusal(let explanation):
+            return explanation
         case .contextOverflow:
             return "Input exceeds the 4096-token context window. Shorten the conversation history."
         case .rateLimited:
@@ -146,7 +152,8 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         switch self {
         case .rateLimited, .concurrentRequest, .assetsUnavailable:
             return true
-        default:
+        case .guardrailViolation, .refusal, .contextOverflow, .unsupportedGuide,
+             .decodingFailure, .unsupportedLanguage, .toolExecution, .unknown:
             return false
         }
     }
@@ -169,8 +176,10 @@ private enum FoundationModelsGenerationErrorCase: String, CaseIterable {
 
     func apfelError(localizedDescription: String) -> ApfelError {
         switch self {
-        case .guardrailViolation, .refusal:
+        case .guardrailViolation:
             return .guardrailViolation
+        case .refusal:
+            return .refusal(localizedDescription)
         case .exceededContextWindowSize:
             return .contextOverflow
         case .rateLimited:
@@ -204,6 +213,8 @@ extension ApfelError: LocalizedError, CustomStringConvertible, CustomDebugString
         switch self {
         case .guardrailViolation:
             return "ApfelError.guardrailViolation"
+        case .refusal(let message):
+            return "ApfelError.refusal(\(String(reflecting: message)))"
         case .contextOverflow:
             return "ApfelError.contextOverflow"
         case .rateLimited:

--- a/Sources/Core/Chat/FinishReasonResolver.swift
+++ b/Sources/Core/Chat/FinishReasonResolver.swift
@@ -11,6 +11,8 @@ public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible
     case length
     /// The response ended in a tool-call payload instead of plain text.
     case toolCalls
+    /// The response was blocked by the model's content filter (refusal).
+    case contentFilter
 
     /// The OpenAI-compatible wire value for this finish reason.
     public var openAIValue: String {
@@ -18,6 +20,7 @@ public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible
         case .stop: return "stop"
         case .length: return "length"
         case .toolCalls: return "tool_calls"
+        case .contentFilter: return "content_filter"
         }
     }
 

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -151,8 +151,12 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
         try c.encodeIfPresent(tool_calls, forKey: .tool_calls)
         try c.encodeIfPresent(tool_call_id, forKey: .tool_call_id)
         try c.encodeIfPresent(name, forKey: .name)
-        // refusal: always present in responses (null when absent)
-        try c.encodeNil(forKey: .refusal)
+        // refusal: always present in responses (null when absent, string when set)
+        if let refusal = refusal {
+            try c.encode(refusal, forKey: .refusal)
+        } else {
+            try c.encodeNil(forKey: .refusal)
+        }
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -188,6 +188,19 @@ private func mcpAutoExecuteResponse(
         }
     } catch {
         let classified = ApfelError.classify(error)
+        if case .refusal(let explanation) = classified {
+            if streaming {
+                return refusalStreamingResponse(
+                    explanation: explanation, id: id, created: created,
+                    promptTokens: promptTokens, includeUsage: includeUsage,
+                    requestBody: requestBody, events: events
+                )
+            }
+            return refusalResponse(
+                explanation: explanation, id: id, created: created,
+                promptTokens: promptTokens, requestBody: requestBody, events: events
+            )
+        }
         let msg = classified.openAIMessage
         return chatFailure(
             status: .init(code: classified.httpStatusCode),
@@ -244,7 +257,7 @@ private func mcpAutoExecuteResponse(
             sseDataLine(sseContentChunk(id: id, created: created, content: deliveredContent)),
             sseDataLine(ChatCompletionChunk(
                 id: id, object: "chat.completion.chunk", created: created, model: modelName,
-                choices: [.init(index: 0, delta: .init(role: nil, content: nil, tool_calls: nil), finish_reason: finishReason, logprobs: nil)],
+                choices: [.init(index: 0, delta: .init(role: nil, content: nil, refusal: nil, tool_calls: nil), finish_reason: finishReason, logprobs: nil)],
                 usage: nil
             )),
         ]
@@ -322,6 +335,12 @@ private func nonStreamingResponse(
         }
     } catch {
         let classified = ApfelError.classify(error)
+        if case .refusal(let explanation) = classified {
+            return refusalResponse(
+                explanation: explanation, id: id, created: created,
+                promptTokens: promptTokens, requestBody: requestBody, events: events
+            )
+        }
         let msg = classified.openAIMessage
         return chatFailure(
             status: .init(code: classified.httpStatusCode),
@@ -475,7 +494,7 @@ private func streamingResponse(
                         id: id, object: "chat.completion.chunk", created: created, model: modelName,
                         choices: [.init(
                             index: 0,
-                            delta: .init(role: nil, content: nil, tool_calls: chunkToolCalls),
+                            delta: .init(role: nil, content: nil, refusal: nil, tool_calls: chunkToolCalls),
                             finish_reason: finishReason,
                             logprobs: nil
                         )],
@@ -488,7 +507,7 @@ private func streamingResponse(
                 } else {
                     let stopChunk = ChatCompletionChunk(
                         id: id, object: "chat.completion.chunk", created: created, model: modelName,
-                        choices: [.init(index: 0, delta: .init(role: nil, content: nil, tool_calls: nil), finish_reason: finishReason, logprobs: nil)],
+                        choices: [.init(index: 0, delta: .init(role: nil, content: nil, refusal: nil, tool_calls: nil), finish_reason: finishReason, logprobs: nil)],
                         usage: nil
                     )
                     let stopLine = sseDataLine(stopChunk)
@@ -514,15 +533,32 @@ private func streamingResponse(
                 await eventBox.append("stream cancelled by client")
             } catch {
                 let classified = ApfelError.classify(error)
-                let errPayload = OpenAIErrorResponse(error: .init(
-                    message: classified.openAIMessage, type: classified.openAIType, param: nil, code: nil))
-                let errJSON = jsonString(errPayload, pretty: false)
-                let errMsg = "data: \(errJSON)\n\n"
-                responseLines?.append(errMsg.trimmingCharacters(in: .whitespacesAndNewlines))
-                continuation.yield(ByteBuffer(string: errMsg))
-                continuation.yield(ByteBuffer(string: sseDone))
-                streamError = classified.openAIMessage
-                await eventBox.append("stream error: \(classified.cliLabel) \(classified.openAIMessage)")
+                if case .refusal(let explanation) = classified {
+                    let refusalLine = sseDataLine(sseRefusalChunk(id: id, created: created, refusal: explanation))
+                    responseLines?.append(refusalLine.trimmingCharacters(in: .whitespacesAndNewlines))
+                    continuation.yield(ByteBuffer(string: refusalLine))
+                    let finishLine = sseDataLine(sseFinishChunk(id: id, created: created, finishReason: FinishReason.contentFilter.openAIValue))
+                    responseLines?.append(finishLine.trimmingCharacters(in: .whitespacesAndNewlines))
+                    continuation.yield(ByteBuffer(string: finishLine))
+                    if includeUsage {
+                        let usageLine = sseDataLine(sseUsageChunk(id: id, created: created, promptTokens: promptTokens, completionTokens: 0))
+                        responseLines?.append(usageLine.trimmingCharacters(in: .whitespacesAndNewlines))
+                        continuation.yield(ByteBuffer(string: usageLine))
+                    }
+                    continuation.yield(ByteBuffer(string: sseDone))
+                    responseLines?.append("data: [DONE]")
+                    await eventBox.append("refusal: \(explanation) finish_reason=content_filter")
+                } else {
+                    let errPayload = OpenAIErrorResponse(error: .init(
+                        message: classified.openAIMessage, type: classified.openAIType, param: nil, code: nil))
+                    let errJSON = jsonString(errPayload, pretty: false)
+                    let errMsg = "data: \(errJSON)\n\n"
+                    responseLines?.append(errMsg.trimmingCharacters(in: .whitespacesAndNewlines))
+                    continuation.yield(ByteBuffer(string: errMsg))
+                    continuation.yield(ByteBuffer(string: sseDone))
+                    streamError = classified.openAIMessage
+                    await eventBox.append("stream error: \(classified.cliLabel) \(classified.openAIMessage)")
+                }
             }
 
             let completionLog = RequestLog(
@@ -587,6 +623,83 @@ private func chatFailure(
             requestBody: requestBody,
             responseBody: captureTruncatedLogBody(message, enabled: serverState.config.debug),
             events: events + [event]
+        )
+    )
+}
+
+// MARK: - Refusal Response (200 OK with content_filter)
+
+private func refusalResponse(
+    explanation: String,
+    id: String,
+    created: Int,
+    promptTokens: Int,
+    requestBody: String?,
+    events: [String]
+) -> (response: Response, trace: ChatRequestTrace) {
+    let responseMessage = OpenAIMessage(role: "assistant", content: nil, refusal: explanation)
+    let finishReason = FinishReason.contentFilter.openAIValue
+    let payload = ChatCompletionResponse(
+        id: id,
+        object: "chat.completion",
+        created: created,
+        model: modelName,
+        choices: [.init(index: 0, message: responseMessage, finish_reason: finishReason, logprobs: nil)],
+        usage: .init(prompt_tokens: promptTokens, completion_tokens: 0, total_tokens: promptTokens)
+    )
+    let body = jsonString(payload)
+    var headers = HTTPFields()
+    headers[.contentType] = "application/json"
+    let response = Response(status: .ok, headers: headers,
+                             body: .init(byteBuffer: ByteBuffer(string: body)))
+    return (
+        response,
+        ChatRequestTrace(
+            stream: false,
+            estimatedTokens: promptTokens,
+            error: nil,
+            requestBody: requestBody,
+            responseBody: captureTruncatedLogBody(body, enabled: serverState.config.debug),
+            events: events + ["refusal: \(explanation)", "finish_reason=\(finishReason)"]
+        )
+    )
+}
+
+private func refusalStreamingResponse(
+    explanation: String,
+    id: String,
+    created: Int,
+    promptTokens: Int,
+    includeUsage: Bool,
+    requestBody: String?,
+    events: [String]
+) -> (response: Response, trace: ChatRequestTrace) {
+    let finishReason = FinishReason.contentFilter.openAIValue
+    var chunks: [String] = [
+        sseDataLine(sseRoleChunk(id: id, created: created)),
+        sseDataLine(sseRefusalChunk(id: id, created: created, refusal: explanation)),
+        sseDataLine(sseFinishChunk(id: id, created: created, finishReason: finishReason)),
+    ]
+    if includeUsage {
+        chunks.append(sseDataLine(sseUsageChunk(id: id, created: created, promptTokens: promptTokens, completionTokens: 0)))
+    }
+    chunks.append(sseDone)
+    let body = chunks.joined()
+    var headers = HTTPFields()
+    headers[.contentType] = "text/event-stream"
+    headers[.cacheControl] = "no-cache"
+    headers[.init("Connection")!] = "keep-alive"
+    let response = Response(status: .ok, headers: headers,
+                             body: .init(byteBuffer: ByteBuffer(string: body)))
+    return (
+        response,
+        ChatRequestTrace(
+            stream: true,
+            estimatedTokens: promptTokens,
+            error: nil,
+            requestBody: requestBody,
+            responseBody: captureTruncatedLogBody(body, enabled: serverState.config.debug),
+            events: events + ["refusal: \(explanation)", "finish_reason=\(finishReason)"]
         )
     )
 }

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -90,6 +90,7 @@ struct ChatCompletionChunk: Encodable, Sendable {
     struct Delta: Encodable, Sendable {
         let role: String?
         let content: String?
+        let refusal: String?
         let tool_calls: [ToolCallDelta]?
     }
     struct ToolCallDelta: Encodable, Sendable {

--- a/Sources/SSE.swift
+++ b/Sources/SSE.swift
@@ -24,7 +24,7 @@ func sseRoleChunk(id: String, created: Int) -> ChatCompletionChunk {
         model: modelName,
         choices: [.init(
             index: 0,
-            delta: .init(role: "assistant", content: nil, tool_calls: nil),
+            delta: .init(role: "assistant", content: nil, refusal: nil, tool_calls: nil),
             finish_reason: nil,
             logprobs: nil
         )],
@@ -41,8 +41,42 @@ func sseContentChunk(id: String, created: Int, content: String) -> ChatCompletio
         model: modelName,
         choices: [.init(
             index: 0,
-            delta: .init(role: nil, content: content, tool_calls: nil),
+            delta: .init(role: nil, content: content, refusal: nil, tool_calls: nil),
             finish_reason: nil,
+            logprobs: nil
+        )],
+        usage: nil
+    )
+}
+
+/// Create a refusal delta SSE chunk.
+func sseRefusalChunk(id: String, created: Int, refusal: String) -> ChatCompletionChunk {
+    ChatCompletionChunk(
+        id: id,
+        object: "chat.completion.chunk",
+        created: created,
+        model: modelName,
+        choices: [.init(
+            index: 0,
+            delta: .init(role: nil, content: nil, refusal: refusal, tool_calls: nil),
+            finish_reason: nil,
+            logprobs: nil
+        )],
+        usage: nil
+    )
+}
+
+/// Create a finish chunk with a specific finish reason and no delta content.
+func sseFinishChunk(id: String, created: Int, finishReason: String) -> ChatCompletionChunk {
+    ChatCompletionChunk(
+        id: id,
+        object: "chat.completion.chunk",
+        created: created,
+        model: modelName,
+        choices: [.init(
+            index: 0,
+            delta: .init(role: nil, content: nil, refusal: nil, tool_calls: nil),
+            finish_reason: finishReason,
             logprobs: nil
         )],
         usage: nil

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -29,6 +29,7 @@ let exitRateLimited: Int32 = 6
 func exitCode(for error: ApfelError) -> Int32 {
     switch error {
     case .guardrailViolation:  return exitGuardrail
+    case .refusal:             return exitGuardrail
     case .contextOverflow:     return exitContextOverflow
     case .rateLimited:         return exitRateLimited
     case .concurrentRequest:   return exitRateLimited

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -34,6 +34,7 @@ func runApfelCorePublicAPIUsageTests() {
     test("ApfelError cases, accessors, and classify(_:) are public") {
         let cases: [ApfelError] = [
             .guardrailViolation,
+            .refusal("r"),
             .contextOverflow,
             .rateLimited,
             .concurrentRequest,
@@ -283,7 +284,7 @@ func runApfelCorePublicAPIUsageTests() {
     // MARK: - FinishReason / FinishReasonResolver
 
     test("FinishReason and FinishReasonResolver public surface compiles") {
-        let cases: [FinishReason] = [.stop, .length, .toolCalls]
+        let cases: [FinishReason] = [.stop, .length, .toolCalls, .contentFilter]
         for c in cases {
             let _: String = c.openAIValue
             let _: String = c.description

--- a/Tests/apfelTests/ApfelErrorTests.swift
+++ b/Tests/apfelTests/ApfelErrorTests.swift
@@ -50,6 +50,7 @@ func runApfelErrorTests() {
     }
     test("CLI labels") {
         try assertEqual(ApfelError.guardrailViolation.cliLabel, "[guardrail]")
+        try assertEqual(ApfelError.refusal("x").cliLabel, "[refusal]")
         try assertEqual(ApfelError.contextOverflow.cliLabel, "[context overflow]")
         try assertEqual(ApfelError.rateLimited.cliLabel, "[rate limited]")
         try assertEqual(ApfelError.concurrentRequest.cliLabel, "[busy]")
@@ -58,6 +59,7 @@ func runApfelErrorTests() {
     }
     test("OpenAI error types") {
         try assertEqual(ApfelError.guardrailViolation.openAIType, "content_policy_violation")
+        try assertEqual(ApfelError.refusal("x").openAIType, "content_policy_violation")
         try assertEqual(ApfelError.contextOverflow.openAIType, "context_length_exceeded")
         try assertEqual(ApfelError.rateLimited.openAIType, "rate_limit_error")
         try assertEqual(ApfelError.concurrentRequest.openAIType, "rate_limit_error")
@@ -65,6 +67,7 @@ func runApfelErrorTests() {
     }
     test("HTTP status codes") {
         try assertEqual(ApfelError.guardrailViolation.httpStatusCode, 400)
+        try assertEqual(ApfelError.refusal("x").httpStatusCode, 200)
         try assertEqual(ApfelError.contextOverflow.httpStatusCode, 400)
         try assertEqual(ApfelError.rateLimited.httpStatusCode, 429)
         try assertEqual(ApfelError.concurrentRequest.httpStatusCode, 429)
@@ -74,6 +77,7 @@ func runApfelErrorTests() {
     test("classify passes through existing ApfelError unchanged") {
         try assertEqual(ApfelError.classify(ApfelError.contextOverflow), .contextOverflow)
         try assertEqual(ApfelError.classify(ApfelError.guardrailViolation), .guardrailViolation)
+        try assertEqual(ApfelError.classify(ApfelError.refusal("nope")), .refusal("nope"))
         try assertEqual(ApfelError.classify(ApfelError.rateLimited), .rateLimited)
         try assertEqual(ApfelError.classify(ApfelError.concurrentRequest), .concurrentRequest)
         try assertEqual(ApfelError.classify(ApfelError.assetsUnavailable), .assetsUnavailable)
@@ -90,7 +94,7 @@ func runApfelErrorTests() {
             ("decodingFailure", .decodingFailure(localized)),
             ("rateLimited", .rateLimited),
             ("concurrentRequests", .concurrentRequest),
-            ("refusal", .guardrailViolation),
+            ("refusal", .refusal(localized)),
         ]
 
         for item in cases {
@@ -99,7 +103,8 @@ func runApfelErrorTests() {
         }
     }
     test("openAIMessage is non-empty for all cases") {
-        let cases: [ApfelError] = [.guardrailViolation, .contextOverflow, .rateLimited,
+        let cases: [ApfelError] = [.guardrailViolation, .refusal("refused"),
+                                    .contextOverflow, .rateLimited,
                                     .concurrentRequest, .assetsUnavailable,
                                     .toolExecution("tool failed"), .unknown("oops"),
                                     .unsupportedGuide, .decodingFailure("decode failed"),
@@ -196,5 +201,35 @@ func runApfelErrorTests() {
         if case .decodingFailure = ApfelError.classify(ApfelError.decodingFailure("x")) { } else {
             throw TestFailure("expected .decodingFailure passthrough")
         }
+    }
+
+    // --- refusal (#118) ---
+
+    test("refusal error properties") {
+        let err = ApfelError.refusal("I can't help with that.")
+        try assertEqual(err.cliLabel, "[refusal]")
+        try assertEqual(err.openAIType, "content_policy_violation")
+        try assertEqual(err.httpStatusCode, 200)
+        try assertEqual(err.openAIMessage, "I can't help with that.")
+        try assertTrue(!err.isRetryable)
+    }
+    test("classify detects GenerationError.refusal separately from guardrailViolation") {
+        let err = FoundationModelsGenerationErrorStub(
+            caseName: "refusal",
+            localizedMsg: "The model declined this request."
+        )
+        let classified = ApfelError.classify(err)
+        if case .refusal(let msg) = classified {
+            try assertTrue(msg.contains("declined"))
+        } else {
+            throw TestFailure("expected .refusal, got \(classified)")
+        }
+    }
+    test("classify passthrough for refusal") {
+        let original = ApfelError.refusal("nope")
+        try assertEqual(ApfelError.classify(original), .refusal("nope"))
+    }
+    test("refusal is not retryable") {
+        try assertTrue(!isRetryableError(ApfelError.refusal("no")))
     }
 }

--- a/Tests/apfelTests/FinishReasonResolverTests.swift
+++ b/Tests/apfelTests/FinishReasonResolverTests.swift
@@ -47,6 +47,7 @@ func runFinishReasonResolverTests() {
         try assertEqual(FinishReason.stop.openAIValue, "stop")
         try assertEqual(FinishReason.length.openAIValue, "length")
         try assertEqual(FinishReason.toolCalls.openAIValue, "tool_calls")
+        try assertEqual(FinishReason.contentFilter.openAIValue, "content_filter")
     }
 
     test("zero completion tokens with max set -> stop (not length)") {

--- a/Tests/apfelTests/OpenAIWireFormatTests.swift
+++ b/Tests/apfelTests/OpenAIWireFormatTests.swift
@@ -56,11 +56,17 @@ func runOpenAIWireFormatTests() {
         )
     }
 
-    test("OpenAIMessage refusal is always serialized as null, even when set") {
-        // Our model never refuses, so the encoder hard-codes refusal=null.
-        // Third-party tooling relies on this: a non-null refusal means a
-        // different model/server.
-        let msg = OpenAIMessage(role: "assistant", content: .text("ok"), refusal: "this should be ignored")
+    test("OpenAIMessage refusal is serialized as string when set") {
+        let msg = OpenAIMessage(role: "assistant", content: nil, refusal: "I can't help with that.")
+        let json = try sortedEncode(msg)
+        try assertEqual(
+            json,
+            #"{"content":null,"refusal":"I can't help with that.","role":"assistant"}"#
+        )
+    }
+
+    test("OpenAIMessage refusal is serialized as null when nil") {
+        let msg = OpenAIMessage(role: "assistant", content: .text("ok"))
         let json = try sortedEncode(msg)
         try assertEqual(
             json,
@@ -294,9 +300,10 @@ func runOpenAIWireFormatTests() {
     // MARK: - FinishReason wire values
 
     test("FinishReason.openAIValue for every case") {
-        try assertEqual(FinishReason.stop.openAIValue,      "stop")
-        try assertEqual(FinishReason.length.openAIValue,    "length")
-        try assertEqual(FinishReason.toolCalls.openAIValue, "tool_calls")
+        try assertEqual(FinishReason.stop.openAIValue,          "stop")
+        try assertEqual(FinishReason.length.openAIValue,        "length")
+        try assertEqual(FinishReason.toolCalls.openAIValue,     "tool_calls")
+        try assertEqual(FinishReason.contentFilter.openAIValue, "content_filter")
     }
 
     // MARK: - StreamOptions equality (public Equatable conformance)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #118.

## Root cause

When Apple's on-device model refuses a request, apfel classified it as `ApfelError.guardrailViolation` (collapsing `GenerationError.refusal` and `GenerationError.guardrailViolation` into one case) and returned HTTP 400 with `error.type: "content_policy_violation"`. The `OpenAIMessage` encoder also hard-coded `refusal: null` on line 155 of `OpenAIModels.swift`, so even if the refusal text was available in-memory, it could never reach the wire. OpenAI's actual wire format for refusals is 200 OK with `finish_reason: "content_filter"` and a populated `refusal` field on the assistant message.

## The fix

Six coordinated changes, all tightly coupled:

1. **`ApfelError.refusal(String)`** - New error case that preserves the model's explanation text, separate from `.guardrailViolation`. Returns `httpStatusCode: 200` (not 400), `openAIType: "content_policy_violation"`, `cliLabel: "[refusal]"`. The classifier now maps `GenerationError.refusal` to this case instead of collapsing it into `.guardrailViolation`.

2. **`OpenAIMessage.encode(to:)`** - The encoder now emits the actual `refusal` value when set (`"refusal": "explanation..."`) and `null` when nil. Previously it unconditionally emitted `null`.

3. **`FinishReason.contentFilter`** - New case with wire value `"content_filter"`, matching the OpenAI spec.

4. **Handler refusal interception** - All three response paths (non-streaming, streaming, MCP auto-execute) now catch `.refusal` errors and return 200 OK responses with the refusal populated on the assistant message and `finish_reason: "content_filter"`, instead of routing through the error path. Streaming emits a `delta.refusal` chunk followed by a `content_filter` finish chunk.

5. **SSE helpers** - `sseRefusalChunk` and `sseFinishChunk` for the streaming refusal path.

6. **CLI preserved** - `exitCode(for: .refusal)` still returns `exitGuardrail` (code 3). CLI semantics and HTTP semantics are separate contracts per the issue spec.

## Test coverage

- Added `ApfelErrorTests.swift`: `refusal error properties`, `classify detects GenerationError.refusal separately from guardrailViolation`, `classify passthrough for refusal`, `refusal is not retryable`
- Updated `ApfelErrorTests.swift`: existing tests for CLI labels, OpenAI types, HTTP status codes, classify passthrough, and GenerationError classification now include `.refusal`
- Updated `OpenAIWireFormatTests.swift`: replaced the "refusal is always null" test with two tests - "refusal is serialized as string when set" and "refusal is serialized as null when nil"
- Updated `FinishReasonResolverTests.swift`: `contentFilter` wire value test
- Updated `ApfelCorePublicAPIUsageTests.swift`: compile-time surface lockdown includes `.refusal` and `.contentFilter`

## What I verified (static only)

- All switch statements on `ApfelError` are exhaustive with the new `.refusal` case
- All `Delta` constructor call sites updated with the new `refusal` parameter
- No forbidden files touched (no `.version`, `BuildInfo.swift`, CI workflows, release scripts, `Package.swift`)
- Swift 6 concurrency: no data races introduced - all new types are value types or use existing Sendable patterns
- Diff limited to source files needed for this fix plus their corresponding tests

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- Integration tests for real FoundationModels refusals (requires Apple Intelligence)
- Whether the streaming `delta.refusal` field is correctly omitted by Swift's synthesized `Encodable` when nil (it should be, since `Delta` uses synthesized encoding and `refusal` is `String?`)

## Anything that seemed suspicious

Nothing - straightforward enhancement filed by the project's own account with detailed specifications. No external input was copied into the implementation.

## Open question for Franz

The issue's "Green (creativity)" section proposes a feature flag (`--openai-refusal-200` or `APFEL_OPENAI_REFUSAL_200=1`) to gate the 200-vs-400 behavior for one release cycle, letting existing integrations migrate. This PR implements the change without a flag (always 200 for refusals). If you want a flag-gated rollout, I can add that in a follow-up - let me know.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01StdsRVUyjndmUpewTYJAed)_