### PR TITLE
test(errors): TDD coverage for ApfelError.refusal + testable exitCode mapping

### DIFF
--- a/Sources/CLI/ExitCodes.swift
+++ b/Sources/CLI/ExitCodes.swift
@@ -1,0 +1,40 @@
+// ============================================================================
+// ExitCodes.swift - CLI exit-code constants and ApfelError -> exit-code mapping.
+// Part of ApfelCLI so the mapping is unit-testable; main.swift delegates here.
+//
+// Exit codes are a stable CLI contract documented in the man page. Changes
+// here must stay in sync with `apfel.1` and with the bidirectional-coverage
+// integration test (`Tests/integration/test_man_page.py`).
+// ============================================================================
+
+import Foundation
+import ApfelCore
+
+/// Stable CLI exit codes and the `ApfelError` -> exit-code mapping.
+/// Documented in the man page; regression-locked by `ExitCodeMapTests`.
+public enum ApfelExitCodes {
+    public static let success: Int32 = 0
+    public static let runtimeError: Int32 = 1
+    public static let usageError: Int32 = 2
+    public static let guardrail: Int32 = 3
+    public static let contextOverflow: Int32 = 4
+    public static let modelUnavailable: Int32 = 5
+    public static let rateLimited: Int32 = 6
+
+    /// Map a classified `ApfelError` to its documented CLI exit code.
+    public static func code(for error: ApfelError) -> Int32 {
+        switch error {
+        case .guardrailViolation:  return guardrail
+        case .refusal:             return guardrail
+        case .contextOverflow:     return contextOverflow
+        case .rateLimited:         return rateLimited
+        case .concurrentRequest:   return rateLimited
+        case .assetsUnavailable:   return runtimeError
+        case .unsupportedGuide:    return runtimeError
+        case .decodingFailure:     return runtimeError
+        case .unsupportedLanguage: return runtimeError
+        case .toolExecution:       return runtimeError
+        case .unknown:             return runtimeError
+        }
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -16,30 +16,24 @@ let appName = "apfel"
 let modelName = "apple-foundationmodel"
 
 // MARK: - Exit Codes
+// Declared as `let` here (not the ApfelExitCodes struct) so the
+// man-page bidirectional-coverage test (test_bidirectional_exit_code_coverage)
+// can still scrape them via its `let\s+exit\w+` regex. Values are delegated
+// to ApfelCLI.ApfelExitCodes to keep the mapping unit-testable.
 
-let exitSuccess: Int32 = 0
-let exitRuntimeError: Int32 = 1
-let exitUsageError: Int32 = 2
-let exitGuardrail: Int32 = 3
-let exitContextOverflow: Int32 = 4
-let exitModelUnavailable: Int32 = 5
-let exitRateLimited: Int32 = 6
+let exitSuccess: Int32 = ApfelExitCodes.success
+let exitRuntimeError: Int32 = ApfelExitCodes.runtimeError
+let exitUsageError: Int32 = ApfelExitCodes.usageError
+let exitGuardrail: Int32 = ApfelExitCodes.guardrail
+let exitContextOverflow: Int32 = ApfelExitCodes.contextOverflow
+let exitModelUnavailable: Int32 = ApfelExitCodes.modelUnavailable
+let exitRateLimited: Int32 = ApfelExitCodes.rateLimited
 
 /// Map an ApfelError to the appropriate exit code.
+/// Thin wrapper around ApfelExitCodes.code(for:) (see Sources/CLI/ExitCodes.swift)
+/// so the mapping is unit-testable.
 func exitCode(for error: ApfelError) -> Int32 {
-    switch error {
-    case .guardrailViolation:  return exitGuardrail
-    case .refusal:             return exitGuardrail
-    case .contextOverflow:     return exitContextOverflow
-    case .rateLimited:         return exitRateLimited
-    case .concurrentRequest:   return exitRateLimited
-    case .assetsUnavailable:   return exitRuntimeError
-    case .unsupportedGuide:    return exitRuntimeError
-    case .decodingFailure:     return exitRuntimeError
-    case .unsupportedLanguage: return exitRuntimeError
-    case .toolExecution:       return exitRuntimeError
-    case .unknown:             return exitRuntimeError
-    }
+    ApfelExitCodes.code(for: error)
 }
 
 // MARK: - Signal Handling

--- a/Tests/apfelTests/ApfelErrorTests.swift
+++ b/Tests/apfelTests/ApfelErrorTests.swift
@@ -139,6 +139,71 @@ func runApfelErrorTests() {
         try assertTrue(err.openAIMessage.contains("Model says no"))
         try assertTrue(!err.isRetryable)
     }
+    test("refusal Equatable: same text equal, different text unequal, distinct from guardrailViolation") {
+        try assertEqual(ApfelError.refusal("a"), ApfelError.refusal("a"))
+        try assertTrue(ApfelError.refusal("a") != ApfelError.refusal("b"))
+        try assertTrue(ApfelError.refusal("") != ApfelError.guardrailViolation)
+        try assertTrue(ApfelError.refusal("text") != ApfelError.unknown("text"))
+    }
+    test("refusal Hashable: round-trips through Set with associated text") {
+        let set: Set<ApfelError> = [
+            .refusal("one"),
+            .refusal("two"),
+            .refusal("one"),            // dupe of the first
+            .guardrailViolation,
+        ]
+        try assertEqual(set.count, 3, "duplicate refusal('one') must collapse, guardrailViolation stays distinct")
+        try assertTrue(set.contains(.refusal("one")))
+        try assertTrue(set.contains(.refusal("two")))
+        try assertTrue(set.contains(.guardrailViolation))
+        try assertTrue(!set.contains(.refusal("three")))
+    }
+    test("refusal debugDescription is a stable, reflective format") {
+        try assertEqual(
+            ApfelError.refusal("I cannot help with that.").debugDescription,
+            #"ApfelError.refusal("I cannot help with that.")"#
+        )
+        // Internal quotes in the explanation must be escaped by String(reflecting:).
+        try assertEqual(
+            ApfelError.refusal(#"he said "no""#).debugDescription,
+            #"ApfelError.refusal("he said \"no\"")"#
+        )
+    }
+    test("refusal with empty explanation still produces a non-empty openAIMessage") {
+        let empty = ApfelError.refusal("")
+        try assertTrue(!empty.openAIMessage.isEmpty, "empty refusal must not produce empty message")
+        try assertEqual(empty.openAIMessage, "The on-device model refused the request: ")
+        try assertEqual(empty.cliLabel, "[refusal]")
+    }
+    test("refusal localizedDescription equals openAIMessage for non-trivial text") {
+        let err = ApfelError.refusal("multi-sentence reason. Another clause.")
+        try assertEqual((err as Error).localizedDescription, err.openAIMessage)
+    }
+    // Locale-independence of the typed refusal classification path.
+    // The mirror string contains "refusal" regardless of the user's locale;
+    // localizedMsg is rendered by Apple in whatever language the system is set to.
+    // Each case must still classify as .refusal with the localized text preserved.
+    let refusalLocaleFixtures: [(lang: String, localizedMsg: String)] = [
+        ("en", "The model refused to answer."),
+        ("de", "Das Modell hat die Antwort verweigert."),
+        ("fr", "Le modele a refuse de repondre."),
+        ("ja", "モデルは回答を拒否しました。"),
+        ("zh", "模型拒绝回答。"),
+    ]
+    for fixture in refusalLocaleFixtures {
+        test("refusal is detected and explanation preserved on \(fixture.lang) locale") {
+            let err = FoundationModelsGenerationErrorStub(
+                caseName: "refusal",
+                localizedMsg: fixture.localizedMsg
+            )
+            let classified = ApfelError.classify(err)
+            if case .refusal(let text) = classified {
+                try assertEqual(text, fixture.localizedMsg, "locale=\(fixture.lang)")
+            } else {
+                throw TestFailure("expected .refusal on \(fixture.lang), got \(classified)")
+            }
+        }
+    }
     test("openAIMessage is non-empty for all cases") {
         let cases: [ApfelError] = [.guardrailViolation, .refusal("text"), .contextOverflow,
                                     .rateLimited, .concurrentRequest, .assetsUnavailable,

--- a/Tests/apfelTests/ExitCodeMapTests.swift
+++ b/Tests/apfelTests/ExitCodeMapTests.swift
@@ -1,0 +1,54 @@
+// ============================================================================
+// ExitCodeMapTests.swift — Lockdown for ApfelError -> CLI exit-code mapping.
+//
+// Exit codes are a stable CLI contract (documented in the man page). Every
+// `ApfelError` case must map to the correct exit code, and changing that
+// mapping must be a deliberate, visible diff.
+// ============================================================================
+
+import Foundation
+import ApfelCore
+import ApfelCLI
+
+func runExitCodeMapTests() {
+    test("ApfelExitCodes: guardrailViolation -> exitGuardrail (3)") {
+        try assertEqual(ApfelExitCodes.code(for: .guardrailViolation), 3)
+    }
+    test("ApfelExitCodes: refusal -> exitGuardrail (3) — same as guardrail for script compat") {
+        try assertEqual(ApfelExitCodes.code(for: .refusal("any explanation")), 3)
+    }
+    test("ApfelExitCodes: refusal exit code is independent of associated text") {
+        try assertEqual(ApfelExitCodes.code(for: .refusal("")), 3)
+        try assertEqual(ApfelExitCodes.code(for: .refusal("short")), 3)
+        try assertEqual(ApfelExitCodes.code(for: .refusal(String(repeating: "x", count: 10_000))), 3)
+    }
+    test("ApfelExitCodes: contextOverflow -> 4") {
+        try assertEqual(ApfelExitCodes.code(for: .contextOverflow), 4)
+    }
+    test("ApfelExitCodes: rateLimited and concurrentRequest -> 6") {
+        try assertEqual(ApfelExitCodes.code(for: .rateLimited), 6)
+        try assertEqual(ApfelExitCodes.code(for: .concurrentRequest), 6)
+    }
+    test("ApfelExitCodes: assetsUnavailable -> runtime error (1), not modelUnavailable") {
+        // Rationale: exitModelUnavailable (5) is for the availability *precheck*
+        // (Apple Intelligence disabled, device ineligible). assetsUnavailable is a
+        // transient loading state that the model itself surfaces during inference.
+        try assertEqual(ApfelExitCodes.code(for: .assetsUnavailable), 1)
+    }
+    test("ApfelExitCodes: all remaining cases -> runtime error (1)") {
+        try assertEqual(ApfelExitCodes.code(for: .unsupportedGuide), 1)
+        try assertEqual(ApfelExitCodes.code(for: .decodingFailure("x")), 1)
+        try assertEqual(ApfelExitCodes.code(for: .unsupportedLanguage("x")), 1)
+        try assertEqual(ApfelExitCodes.code(for: .toolExecution("x")), 1)
+        try assertEqual(ApfelExitCodes.code(for: .unknown("x")), 1)
+    }
+    test("ApfelExitCodes: constants match documented values") {
+        try assertEqual(ApfelExitCodes.success, 0)
+        try assertEqual(ApfelExitCodes.runtimeError, 1)
+        try assertEqual(ApfelExitCodes.usageError, 2)
+        try assertEqual(ApfelExitCodes.guardrail, 3)
+        try assertEqual(ApfelExitCodes.contextOverflow, 4)
+        try assertEqual(ApfelExitCodes.modelUnavailable, 5)
+        try assertEqual(ApfelExitCodes.rateLimited, 6)
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -73,6 +73,7 @@ func suite(_ name: String, _ block: () -> Void) {
 // MARK: - Run all test suites
 
 suite("ApfelErrorTests") { runApfelErrorTests() }
+suite("ExitCodeMapTests") { runExitCodeMapTests() }
 suite("ToolCallHandlerTests") { runToolCallHandlerTests() }
 suite("ContextStrategyTests") { runContextStrategyTests() }
 suite("OpenAIModelsTests") { runOpenAIModelsTests() }

--- a/Tests/integration/test_man_page.py
+++ b/Tests/integration/test_man_page.py
@@ -24,6 +24,7 @@ MAN_PAGE = ROOT / ".build" / "release" / "apfel.1"
 MAN_SOURCE = ROOT / "man" / "apfel.1.in"
 VERSION_FILE = ROOT / ".version"
 MAIN_SWIFT = ROOT / "Sources" / "main.swift"
+EXIT_CODES_SWIFT = ROOT / "Sources" / "CLI" / "ExitCodes.swift"
 
 FLAG_RE = re.compile(r"(--[a-z][a-z0-9-]+)")
 SHORT_FLAG_RE = re.compile(r"(?<![\w-])(-[a-z])(?=[ ,])")
@@ -179,14 +180,17 @@ def test_bidirectional_env_var_coverage():
 
 
 def test_bidirectional_exit_code_coverage():
-    """Every exit code declared in main.swift must appear in the man page."""
-    main_src = MAIN_SWIFT.read_text()
-    # e.g. `let exitGuardrail: Int32 = 3`
-    declared = set(re.findall(r"let\s+exit\w+\s*:\s*Int32\s*=\s*(\d+)", main_src))
-    assert declared, "No exit codes found in Sources/main.swift - pattern changed?"
+    """Every exit code declared in ApfelCLI must appear in the man page."""
+    # Constants live in Sources/CLI/ExitCodes.swift (testable); main.swift
+    # re-exposes them via `let exit...: Int32 = ApfelExitCodes.xxx` for local
+    # readability. Scrape the literal values from ExitCodes.swift.
+    src = EXIT_CODES_SWIFT.read_text()
+    # e.g. `public static let guardrail: Int32 = 3`
+    declared = set(re.findall(r"public\s+static\s+let\s+\w+\s*:\s*Int32\s*=\s*(\d+)", src))
+    assert declared, "No exit codes found in Sources/CLI/ExitCodes.swift - pattern changed?"
 
     man_text = _man_page_text()
     for code in sorted(declared, key=int):
         assert f".B {code}\n" in man_text, (
-            f"Exit code {code} declared in main.swift but not documented in man page"
+            f"Exit code {code} declared in ApfelExitCodes but not documented in man page"
         )


### PR DESCRIPTION
## Summary

TDD gap-fill for the `.refusal(String)` case landed in `1.2.0`. No behavior change. +18 unit tests, one minor structural change to make the exit-code mapping unit-testable.

## The gap

`1.2.0` added `ApfelError.refusal(String)` with the obvious lockdown tests (label, openAIType, status code, openAIMessage, isRetryable). Audit after shipping found these additional axes were either uncovered for **any** case or specifically uncovered for refusal:

| Axis | Before | Now |
|---|---|---|
| `exitCode(for:)` mapping | Untestable — lived in `Sources/main.swift`, not importable. Only an integration-level regex smoke test. | Extracted to public `ApfelExitCodes.code(for:)` in ApfelCLI. Per-case unit lockdown. |
| `.refusal` Equatable with associated value | Not tested | `.refusal("a") == .refusal("a")`, `!= .refusal("b")`, `!= .guardrailViolation`, `!= .unknown("text")` |
| `.refusal` Hashable | Not tested | `Set<ApfelError>` round-trip including dedup of same-text |
| `.refusal` `debugDescription` exact format | Existence checked, format not locked | Exact string, including `String(reflecting:)` quote escaping |
| `.refusal("")` edge case | Not tested | Still produces non-empty `openAIMessage` and `[refusal]` label |
| `.refusal` typed-path locale independence | Not tested (other cases have this) | en/de/fr/ja/zh fixtures verify classify preserves explanation text |

## Structural change: `exitCode` moves to ApfelCLI

- New file: `Sources/CLI/ExitCodes.swift` — `public enum ApfelExitCodes` with named constants (`.success`, `.guardrail`, etc.) and `code(for: ApfelError) -> Int32`.
- `Sources/main.swift` keeps `let exitSuccess: Int32 = ApfelExitCodes.success` shadow constants (so `exit(exitSuccess)` call sites stay untouched) and delegates `exitCode(for:)` to `ApfelExitCodes.code(for:)`.
- `Tests/integration/test_man_page.py::test_bidirectional_exit_code_coverage` now scrapes the literal `Int32` values from `Sources/CLI/ExitCodes.swift` — the new source of truth.
- ApfelCLI is an **internal target** (only `ApfelCore` and the `apfel` executable are public Swift Package products). `ApfelExitCodes` is not on the versioned public library surface. `apfelcore-public-api` CI check is unaffected; this is a patch bump (`1.2.1`).

## Tests

- **567 unit tests passing** on `swift run apfel-tests` (was 549).
- **250 integration tests passing** on `make test` (was 250 — one updated to point at the new exit-codes file).
- **817 total, 0 skipped.**

## Test plan

- [x] `swift build` clean on Swift 6.3.1 / SDK 26.4+
- [x] 567 unit tests pass (+18 new)
- [x] 250 integration tests pass with both servers up (ports 11434 + 11435)
- [x] `test_bidirectional_exit_code_coverage` still catches a missing man-page entry if an exit code is added
- [x] Every new `.refusal` test runs and passes
- [ ] CI: `build-and-test` green
- [ ] CI: `apfelcore-public-api` green (no change to ApfelCore public surface this time)

## Post-merge

`make release TYPE=patch` → `1.2.1`. Test-only + internal refactor, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
