### PR TITLE
fix(server): cache static model metadata at startup to avoid /health cold-start timeout and mid-flight SDK crash (apfel-gui#4)

### DIFF
--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -49,26 +49,38 @@ nonisolated(unsafe) var serverState: ServerState!
 /// Start the OpenAI-compatible HTTP server.
 func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async throws {
     serverState = ServerState(config: config, mcpManager: mcpManager)
+
+    // Pre-fetch static model properties BEFORE binding so:
+    // (a) the first /health or /v1/models request does not pay the cold-start
+    //     SDK cost (12-second GUI health-probe timeouts observed in apfel-gui#4),
+    // (b) any SDK-level crash inside SystemLanguageModel.supportedLanguages
+    //     fails visibly during startup instead of SIGSEGV on a routine health
+    //     probe (also apfel-gui#4).
+    // Availability stays a per-request read because it can flip at runtime
+    // (user toggles Apple Intelligence, assets re-download, etc.).
+    let tc = TokenCounter.shared
+    let cachedContextSize = await tc.contextSize
+    let cachedLangs = await tc.supportedLanguages
+
     let router = Router()
 
     // Security middleware: origin check, token auth, CORS headers
     router.add(middleware: SecurityMiddleware<BasicRequestContext>(config: config))
 
-    // Health - includes model availability from SDK
+    // Health - includes model availability from SDK.
+    // contextSize and supportedLanguages captured from startup to avoid
+    // per-request SDK calls (cold-start safety, apfel-gui#4).
     router.get("/health") { _, _ -> Response in
         let active = await serverState.logStore.activeRequests
-        let tc = TokenCounter.shared
-        let available = await tc.isAvailable
-        let contextSize = await tc.contextSize
-        let langs = await tc.supportedLanguages
+        let available = await TokenCounter.shared.isAvailable
         let health: [String: Any] = [
             "status": available ? "ok" : "model_unavailable",
             "model": modelName,
             "version": version,
             "active_requests": active,
-            "context_window": contextSize,
+            "context_window": cachedContextSize,
             "model_available": available,
-            "supported_languages": langs
+            "supported_languages": cachedLangs
         ]
         if let data = try? JSONSerialization.data(withJSONObject: health, options: [.sortedKeys]),
            let json = String(data: data, encoding: .utf8) {
@@ -77,19 +89,17 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
         return jsonResponse("{\"status\":\"ok\"}")
     }
 
-    // Models — includes context_window and supported_languages from SDK
+    // Models — includes context_window and supported_languages from SDK.
+    // Uses the same startup-cached values as /health.
     router.get("/v1/models") { _, _ -> Response in
-        let tc = TokenCounter.shared
-        let contextSize = await tc.contextSize
-        let langs = await tc.supportedLanguages
         return jsonResponse(jsonString(ModelsListResponse(
             object: "list",
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
-                context_window: contextSize,
+                context_window: cachedContextSize,
                 supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
-                notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(langs.joined(separator: ", "))"
+                notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(cachedLangs.joined(separator: ", "))"
             )]
         )))
     }

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -67,8 +67,18 @@ actor TokenCounter {
     }
 
     /// Supported languages as locale identifier strings.
+    /// Callers should fetch this ONCE at startup (see Server.swift) - it touches
+    /// the FoundationModels SDK, and a crash observed in apfel-gui#4 suggests
+    /// repeated mid-flight access on Hummingbird's dispatch queue can destabilize
+    /// the process in some macOS 26.4 environments.
     var supportedLanguages: [String] {
-        model.supportedLanguages.compactMap { $0.languageCode?.identifier }
+        var ids: [String] = []
+        for language in model.supportedLanguages {
+            if let id = language.languageCode?.identifier {
+                ids.append(id)
+            }
+        }
+        return ids
     }
 
     /// Count tokens for transcript entries using the real API.

--- a/Tests/integration/openai_client_test.py
+++ b/Tests/integration/openai_client_test.py
@@ -29,6 +29,50 @@ def test_apple_intelligence_enabled():
         "Apple Intelligence is NOT enabled. Go to System Settings → Apple Intelligence & Siri → Turn on."
 
 
+def test_health_returns_fast_without_cold_start():
+    """Repeated /health requests must be fast because contextSize and
+    supportedLanguages are cached at server startup.
+
+    Regression guard for apfel-gui#4: the GUI polls /health every 500ms
+    with a 12-second deadline. If /health synchronously hit the
+    FoundationModels SDK on every request, the GUI would time out on
+    cold starts. Budget: 20 consecutive requests should complete in
+    well under 2 seconds total.
+    """
+    import time
+    url = f"{BASE_URL.replace('/v1', '')}/health"
+    start = time.monotonic()
+    for _ in range(20):
+        resp = httpx.get(url, timeout=2)
+        assert resp.status_code == 200
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0, (
+        f"20 /health requests took {elapsed:.2f}s, expected < 2s. "
+        f"This means /health is hitting the SDK on every request -- "
+        f"regressing apfel-gui#4 (GUI cold-start timeout)."
+    )
+
+
+def test_health_supported_languages_populated():
+    """Startup cache must include a non-empty supported_languages list.
+
+    Regression guard for apfel-gui#4: pre-caching
+    SystemLanguageModel.supportedLanguages at startup must actually
+    produce a non-empty list on a machine with Apple Intelligence
+    enabled. If the SDK starts returning an empty Set we want to
+    notice immediately rather than silently shipping an empty list.
+    """
+    resp = httpx.get(f"{BASE_URL.replace('/v1', '')}/health")
+    data = resp.json()
+    langs = data.get("supported_languages", [])
+    assert isinstance(langs, list)
+    assert len(langs) > 0, (
+        "supported_languages is empty. Either Apple Intelligence is "
+        "disabled or SystemLanguageModel.supportedLanguages changed."
+    )
+    assert "en" in langs, f"expected 'en' in supported_languages, got {langs}"
+
+
 # MARK: - Basic Completions
 
 def test_basic_completion():


### PR DESCRIPTION
## Summary

Fixes two symptoms reported in [Arthur-Ficial/apfel-gui#4](https://github.com/Arthur-Ficial/apfel-gui/issues/4):

1. **GUI /health cold-start timeout** — apfel-gui polls `/health` with a 12-second deadline and times out because the first request synchronously touches FoundationModels, which can block while language packs warm up.
2. **SIGSEGV in `TokenCounter.supportedLanguages.getter` during a /health hit** (macOS 26.4 build 25E5207k, user crash report attached to the issue).

Pre-fetch `contextSize` and `supportedLanguages` exactly once in `startServer()` before binding. Capture as `Sendable` locals and reuse inside the `/health` and `/v1/models` closures. Per-request `isAvailable` reads stay because that value can flip at runtime (user toggles Apple Intelligence).

## Why this is the right scope

- **Cold-start timeout**: the 12-second budget is the GUI's, but the real cause was apfel doing SDK work on every health probe. Fixed at the source. GUI does not need a change.
- **SIGSEGV**: I cannot reliably reproduce the crash (my machine is macOS 26.3.1, user is on 26.4). What I *can* do is move the potential crash site from mid-flight `/health` to server startup:
  - If the SDK call still crashes on the user's system, `apfel --serve` will terminate visibly during startup with a stack trace — actionable.
  - If the crash was specifically triggered by repeated access from Hummingbird's dispatch queue context, pre-fetching on the main actor before binding avoids it entirely.
- **`TokenCounter.supportedLanguages` rewritten** from `compactMap` to an explicit for-loop for simpler codegen and defensive handling of `languageCode?.identifier`. Low probability of helping, zero probability of hurting.

## Tests

Two new integration tests in `Tests/integration/openai_client_test.py`:

- `test_health_returns_fast_without_cold_start` — 20 consecutive `/health` requests must complete in < 2s total. Regression guard against the per-request SDK-hop pattern that caused the GUI timeout.
- `test_health_supported_languages_populated` — non-empty `supported_languages` list with `"en"` present. Regression guard against silently shipping an empty startup cache.

No unit-test changes needed — the cached-at-startup pattern is orchestration, not pure logic, and is best exercised by a running server.

## Results

- `swift build`: clean
- `swift run apfel-tests`: **567 / 567 unit** (unchanged, refactor-only on TokenCounter)
- `make test`: **252 / 252 integration** (+2 new)
- **Total: 819 / 819 passing, 0 skipped.**

## What this does NOT attempt

- Reproduce the exact SIGSEGV. I don't have macOS 26.4 locally. The fix is defensive: change the call pattern, change the codegen, move failure mode to visible startup. @HarryW00 is on standby to retest on `1.2.2`.
- Touch apfel-gui. The GUI's health-polling logic is unchanged; fixing the server side should be sufficient.
- Extend the `SystemLanguageModel.supportedLanguages` crash to a root-cause investigation. If the prefetch still crashes on startup for @HarryW00, that's the signal to file upstream with Apple and fall back to a static language list in apfel.

## Test plan

- [x] `swift build` clean
- [x] 567 unit tests pass
- [x] 252 integration tests pass (including the two new /health regression guards)
- [ ] CI: `build-and-test` green
- [ ] CI: `apfelcore-public-api` green (no ApfelCore change)
- [ ] @HarryW00 retests `apfel --serve --port 11438` directly and via apfel-gui on macOS 26.4

## Post-merge

`make release TYPE=patch` → `1.2.2`. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
