### PR TITLE
fix(server): return 200 OK with content_filter for model refusals (#118)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -109,7 +109,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
     public var httpStatusCode: Int {
         switch self {
         case .guardrailViolation:  return 400
-        case .refusal:             return 400
+        case .refusal:             return 200
         case .contextOverflow:     return 400
         case .rateLimited:         return 429
         case .concurrentRequest:   return 429

--- a/Sources/Core/Chat/FinishReasonResolver.swift
+++ b/Sources/Core/Chat/FinishReasonResolver.swift
@@ -11,6 +11,8 @@ public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible
     case length
     /// The response ended in a tool-call payload instead of plain text.
     case toolCalls
+    /// The response was blocked by the model's content filter (refusal).
+    case contentFilter
 
     /// The OpenAI-compatible wire value for this finish reason.
     public var openAIValue: String {
@@ -18,6 +20,7 @@ public enum FinishReason: Sendable, Equatable, Hashable, CustomStringConvertible
         case .stop: return "stop"
         case .length: return "length"
         case .toolCalls: return "tool_calls"
+        case .contentFilter: return "content_filter"
         }
     }
 

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -113,7 +113,7 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
     public let tool_call_id: String?
     /// Optional sender name.
     public let name: String?
-    /// OpenAI refusal text. Always encoded as `null` for the local model.
+    /// OpenAI refusal text. Populated when the model refuses a request.
     public let refusal: String?
 
     /// Creates an OpenAI-compatible message value.
@@ -151,8 +151,12 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
         try c.encodeIfPresent(tool_calls, forKey: .tool_calls)
         try c.encodeIfPresent(tool_call_id, forKey: .tool_call_id)
         try c.encodeIfPresent(name, forKey: .name)
-        // refusal: always present in responses (null when absent)
-        try c.encodeNil(forKey: .refusal)
+        // refusal: always present in responses (null when absent, string when set)
+        if let refusal = refusal {
+            try c.encode(refusal, forKey: .refusal)
+        } else {
+            try c.encodeNil(forKey: .refusal)
+        }
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -188,6 +188,12 @@ private func mcpAutoExecuteResponse(
         }
     } catch {
         let classified = ApfelError.classify(error)
+        if case .refusal(let explanation) = classified {
+            return refusalResponse(
+                explanation: explanation, id: id, created: created,
+                promptTokens: promptTokens, requestBody: requestBody, events: events
+            )
+        }
         let msg = classified.openAIMessage
         return chatFailure(
             status: .init(code: classified.httpStatusCode),
@@ -322,6 +328,12 @@ private func nonStreamingResponse(
         }
     } catch {
         let classified = ApfelError.classify(error)
+        if case .refusal(let explanation) = classified {
+            return refusalResponse(
+                explanation: explanation, id: id, created: created,
+                promptTokens: promptTokens, requestBody: requestBody, events: events
+            )
+        }
         let msg = classified.openAIMessage
         return chatFailure(
             status: .init(code: classified.httpStatusCode),
@@ -514,15 +526,32 @@ private func streamingResponse(
                 await eventBox.append("stream cancelled by client")
             } catch {
                 let classified = ApfelError.classify(error)
-                let errPayload = OpenAIErrorResponse(error: .init(
-                    message: classified.openAIMessage, type: classified.openAIType, param: nil, code: nil))
-                let errJSON = jsonString(errPayload, pretty: false)
-                let errMsg = "data: \(errJSON)\n\n"
-                responseLines?.append(errMsg.trimmingCharacters(in: .whitespacesAndNewlines))
-                continuation.yield(ByteBuffer(string: errMsg))
-                continuation.yield(ByteBuffer(string: sseDone))
-                streamError = classified.openAIMessage
-                await eventBox.append("stream error: \(classified.cliLabel) \(classified.openAIMessage)")
+                if case .refusal(let explanation) = classified {
+                    let refusalLine = sseDataLine(sseRefusalChunk(id: id, created: created, refusal: explanation))
+                    responseLines?.append(refusalLine.trimmingCharacters(in: .whitespacesAndNewlines))
+                    continuation.yield(ByteBuffer(string: refusalLine))
+                    let finishLine = sseDataLine(sseFinishChunk(id: id, created: created, finishReason: FinishReason.contentFilter.openAIValue))
+                    responseLines?.append(finishLine.trimmingCharacters(in: .whitespacesAndNewlines))
+                    continuation.yield(ByteBuffer(string: finishLine))
+                    if includeUsage {
+                        let usageLine = sseDataLine(sseUsageChunk(id: id, created: created, promptTokens: promptTokens, completionTokens: 0))
+                        responseLines?.append(usageLine.trimmingCharacters(in: .whitespacesAndNewlines))
+                        continuation.yield(ByteBuffer(string: usageLine))
+                    }
+                    continuation.yield(ByteBuffer(string: sseDone))
+                    responseLines?.append("data: [DONE]")
+                    await eventBox.append("refusal: finish_reason=content_filter")
+                } else {
+                    let errPayload = OpenAIErrorResponse(error: .init(
+                        message: classified.openAIMessage, type: classified.openAIType, param: nil, code: nil))
+                    let errJSON = jsonString(errPayload, pretty: false)
+                    let errMsg = "data: \(errJSON)\n\n"
+                    responseLines?.append(errMsg.trimmingCharacters(in: .whitespacesAndNewlines))
+                    continuation.yield(ByteBuffer(string: errMsg))
+                    continuation.yield(ByteBuffer(string: sseDone))
+                    streamError = classified.openAIMessage
+                    await eventBox.append("stream error: \(classified.cliLabel) \(classified.openAIMessage)")
+                }
             }
 
             let completionLog = RequestLog(
@@ -587,6 +616,38 @@ private func chatFailure(
             requestBody: requestBody,
             responseBody: captureTruncatedLogBody(message, enabled: serverState.config.debug),
             events: events + [event]
+        )
+    )
+}
+
+// MARK: - Refusal Response (200 OK with content_filter)
+
+private func refusalResponse(
+    explanation: String,
+    id: String,
+    created: Int,
+    promptTokens: Int,
+    requestBody: String?,
+    events: [String]
+) -> (response: Response, trace: ChatRequestTrace) {
+    let responseMessage = OpenAIMessage(role: "assistant", content: nil, refusal: explanation)
+    let finishReason = FinishReason.contentFilter.openAIValue
+    let payload = ChatCompletionResponse(
+        id: id, object: "chat.completion", created: created, model: modelName,
+        choices: [.init(index: 0, message: responseMessage, finish_reason: finishReason, logprobs: nil)],
+        usage: .init(prompt_tokens: promptTokens, completion_tokens: 0, total_tokens: promptTokens)
+    )
+    let body = jsonString(payload)
+    var headers = HTTPFields()
+    headers[.contentType] = "application/json"
+    let response = Response(status: .ok, headers: headers, body: .init(byteBuffer: ByteBuffer(string: body)))
+    return (
+        response,
+        ChatRequestTrace(
+            stream: false, estimatedTokens: promptTokens, error: nil,
+            requestBody: requestBody,
+            responseBody: captureTruncatedLogBody(body, enabled: serverState.config.debug),
+            events: events + ["refusal: finish_reason=\(finishReason)"]
         )
     )
 }

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -91,6 +91,13 @@ struct ChatCompletionChunk: Encodable, Sendable {
         let role: String?
         let content: String?
         let tool_calls: [ToolCallDelta]?
+        let refusal: String?
+        init(role: String?, content: String?, tool_calls: [ToolCallDelta]?, refusal: String? = nil) {
+            self.role = role
+            self.content = content
+            self.tool_calls = tool_calls
+            self.refusal = refusal
+        }
     }
     struct ToolCallDelta: Encodable, Sendable {
         let index: Int

--- a/Sources/SSE.swift
+++ b/Sources/SSE.swift
@@ -49,6 +49,40 @@ func sseContentChunk(id: String, created: Int, content: String) -> ChatCompletio
     )
 }
 
+/// Create a refusal delta SSE chunk.
+func sseRefusalChunk(id: String, created: Int, refusal: String) -> ChatCompletionChunk {
+    ChatCompletionChunk(
+        id: id,
+        object: "chat.completion.chunk",
+        created: created,
+        model: modelName,
+        choices: [.init(
+            index: 0,
+            delta: .init(role: nil, content: nil, tool_calls: nil, refusal: refusal),
+            finish_reason: nil,
+            logprobs: nil
+        )],
+        usage: nil
+    )
+}
+
+/// Create a finish-reason-only SSE chunk (no content delta).
+func sseFinishChunk(id: String, created: Int, finishReason: String) -> ChatCompletionChunk {
+    ChatCompletionChunk(
+        id: id,
+        object: "chat.completion.chunk",
+        created: created,
+        model: modelName,
+        choices: [.init(
+            index: 0,
+            delta: .init(role: nil, content: nil, tool_calls: nil),
+            finish_reason: finishReason,
+            logprobs: nil
+        )],
+        usage: nil
+    )
+}
+
 /// Create a usage-only SSE chunk (empty choices, usage stats).
 func sseUsageChunk(id: String, created: Int, promptTokens: Int, completionTokens: Int) -> ChatCompletionChunk {
     ChatCompletionChunk(

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -283,7 +283,7 @@ func runApfelCorePublicAPIUsageTests() {
     // MARK: - FinishReason / FinishReasonResolver
 
     test("FinishReason and FinishReasonResolver public surface compiles") {
-        let cases: [FinishReason] = [.stop, .length, .toolCalls]
+        let cases: [FinishReason] = [.stop, .length, .toolCalls, .contentFilter]
         for c in cases {
             let _: String = c.openAIValue
             let _: String = c.description

--- a/Tests/apfelTests/ApfelErrorTests.swift
+++ b/Tests/apfelTests/ApfelErrorTests.swift
@@ -135,7 +135,7 @@ func runApfelErrorTests() {
         let err = ApfelError.refusal("Model says no")
         try assertEqual(err.cliLabel, "[refusal]")
         try assertEqual(err.openAIType, "content_policy_violation")
-        try assertEqual(err.httpStatusCode, 400)
+        try assertEqual(err.httpStatusCode, 200)
         try assertTrue(err.openAIMessage.contains("Model says no"))
         try assertTrue(!err.isRetryable)
     }

--- a/Tests/apfelTests/FinishReasonResolverTests.swift
+++ b/Tests/apfelTests/FinishReasonResolverTests.swift
@@ -47,6 +47,7 @@ func runFinishReasonResolverTests() {
         try assertEqual(FinishReason.stop.openAIValue, "stop")
         try assertEqual(FinishReason.length.openAIValue, "length")
         try assertEqual(FinishReason.toolCalls.openAIValue, "tool_calls")
+        try assertEqual(FinishReason.contentFilter.openAIValue, "content_filter")
     }
 
     test("zero completion tokens with max set -> stop (not length)") {

--- a/Tests/apfelTests/OpenAIWireFormatTests.swift
+++ b/Tests/apfelTests/OpenAIWireFormatTests.swift
@@ -7,7 +7,8 @@
 //
 // What's covered:
 //   - OpenAIMessage.encode (custom encoder): content always present (null when
-//     nil), refusal always encoded as null, optional fields omitted when nil
+//     nil), refusal present (null when nil, string when set), optional fields
+//     omitted when nil
 //   - MessageContent encodes as string for .text and array for .parts
 //   - ContentPart default synthesized encoding (nil text omitted)
 //   - ToolCall / ToolCallFunction default encoding
@@ -56,11 +57,17 @@ func runOpenAIWireFormatTests() {
         )
     }
 
-    test("OpenAIMessage refusal is always serialized as null, even when set") {
-        // Our model never refuses, so the encoder hard-codes refusal=null.
-        // Third-party tooling relies on this: a non-null refusal means a
-        // different model/server.
-        let msg = OpenAIMessage(role: "assistant", content: .text("ok"), refusal: "this should be ignored")
+    test("OpenAIMessage refusal is serialized as string when set") {
+        let msg = OpenAIMessage(role: "assistant", content: nil, refusal: "I cannot help with that.")
+        let json = try sortedEncode(msg)
+        try assertEqual(
+            json,
+            #"{"content":null,"refusal":"I cannot help with that.","role":"assistant"}"#
+        )
+    }
+
+    test("OpenAIMessage refusal is serialized as null when not set") {
+        let msg = OpenAIMessage(role: "assistant", content: .text("ok"))
         let json = try sortedEncode(msg)
         try assertEqual(
             json,
@@ -294,9 +301,10 @@ func runOpenAIWireFormatTests() {
     // MARK: - FinishReason wire values
 
     test("FinishReason.openAIValue for every case") {
-        try assertEqual(FinishReason.stop.openAIValue,      "stop")
-        try assertEqual(FinishReason.length.openAIValue,    "length")
-        try assertEqual(FinishReason.toolCalls.openAIValue, "tool_calls")
+        try assertEqual(FinishReason.stop.openAIValue,          "stop")
+        try assertEqual(FinishReason.length.openAIValue,        "length")
+        try assertEqual(FinishReason.toolCalls.openAIValue,     "tool_calls")
+        try assertEqual(FinishReason.contentFilter.openAIValue, "content_filter")
     }
 
     // MARK: - StreamOptions equality (public Equatable conformance)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #118.

## Root cause

When Apple's on-device model refuses a request, apfel classified it as `ApfelError.refusal(String)` but returned it through the HTTP error path: HTTP 400 with an `OpenAIErrorResponse` payload and `error.type: "content_policy_violation"`. The `OpenAIMessage` encoder also unconditionally hard-coded `refusal: null` (line 155 of `OpenAIModels.swift`), so the refusal explanation text - already preserved in memory by the `.refusal(String)` case - could never reach the wire. OpenAI's actual wire format for refusals is 200 OK with `finish_reason: "content_filter"` and a populated `refusal` field on the assistant message.

## The fix

Six coordinated changes across the data layer, handler layer, and streaming layer:

1. **`OpenAIMessage.encode(to:)`** - The encoder now emits the actual `refusal` value when set and `null` when nil, instead of unconditionally encoding `null`.

2. **`FinishReason.contentFilter`** - New enum case with wire value `"content_filter"`, completing the OpenAI finish_reason taxonomy.

3. **`ApfelError.httpStatusCode`** - `.refusal` now returns 200, not 400. Refusals are successful completions with a content filter, not request errors.

4. **Non-streaming refusal interception** - Both the direct and MCP auto-execute response paths now catch `.refusal` errors and build a proper 200 OK `ChatCompletionResponse` with `finish_reason: "content_filter"`, `message.refusal` populated, and `message.content: null`, instead of routing through the error path.

5. **Streaming refusal interception** - The streaming catch block now emits a `delta.refusal` chunk followed by a `content_filter` finish chunk (plus usage if opted in), instead of an SSE error event.

6. **CLI preserved** - `ApfelExitCodes.code(for: .refusal)` still returns `guardrail` (exit code 3). CLI semantics and HTTP semantics are separate contracts.

No feature flags per Franz's direction - this is a straight bug fix for OpenAI spec compliance.

## Test coverage

- Replaced `OpenAIWireFormatTests` "refusal is always serialized as null, even when set" with two tests: "refusal is serialized as string when set" and "refusal is serialized as null when not set". The old test locked in the broken behavior; the new tests lock in the correct behavior.
- Updated `ApfelErrorTests` "refusal error properties" to expect `httpStatusCode: 200`.
- Added `FinishReason.contentFilter` wire value assertions to `OpenAIWireFormatTests`, `FinishReasonResolverTests`, and `ApfelCorePublicAPIUsageTests`.
- Existing `ExitCodeMapTests` "refusal -> exitGuardrail (3)" is unchanged and continues to lock in CLI behavior.

## What I verified (static only)

- Encoder logic follows the existing `content` encoding pattern (conditional nil-check).
- `FinishReason.openAIValue` is an exhaustive switch - adding the new case is compile-safe.
- `Delta` struct gains a `refusal: String?` field with default `nil` in an explicit init, so all existing call sites compile without changes.
- All three handler catch blocks (non-streaming, streaming, MCP auto-execute) intercept `.refusal` before falling through to the error path.
- SSE helpers (`sseRefusalChunk`, `sseFinishChunk`) follow the existing helper pattern.
- No forbidden files touched (no `.version`, `BuildInfo.swift`, CI workflows, release scripts, `Package.swift`).
- Swift 6 concurrency: no data races introduced - all types remain value types.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or the Swift compiler. If the fix does not compile or tests fail, that is on me to refine - ping me in a review comment.
- Integration tests for real FoundationModels refusals (requires Apple Intelligence).
- Whether the synthesized `Encodable` on `Delta` correctly omits `refusal` when nil in streaming chunks (it should, since synthesized encoding omits nil optionals).

## Anything that seemed suspicious

Nothing - straightforward bug fix. The issue was filed by the project's own account and references prior audits (#115, #116). Franz explicitly directed "no flags and fix this as a bug - KISS and TDD!" in the issue comments.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_017YwE1NGCP6eh8XvM9cATsf)_