### PR TITLE
fix(parity): CLI/server same 1024 max_tokens default + x_permissive (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,11 @@ alias apfel=apfel-run                 # optional, every apfel flag still works
 | `GET /v1/logs`, `/v1/logs/stats` | Debug only | Requires `--debug` |
 | Tool calling | Supported | Native `ToolDefinition` + JSON detection. See [docs/tool-calling-guide.md](docs/tool-calling-guide.md) |
 | `response_format: json_object` | Supported | System-prompt injection; markdown fences stripped from output |
-| `temperature`, `max_tokens`, `seed` | Supported | Mapped to `GenerationOptions`. **`max_tokens` defaults to 512 when omitted** - see [Default response cap](#default-response-cap-max_tokens) |
+| `temperature`, `max_tokens`, `seed` | Supported | Mapped to `GenerationOptions`. **`max_tokens` defaults to 1024 when omitted** - see [Default response cap](#default-response-cap-max_tokens) |
 | `stream: true` | Supported | SSE; final usage chunk only when `stream_options: {"include_usage": true}` (per OpenAI spec) |
 | `finish_reason` | Supported | `stop`, `tool_calls`, `length` |
 | Context strategies | Supported | `x_context_strategy`, `x_context_max_turns`, `x_context_output_reserve` extension fields |
+| Permissive guardrails | Supported | `x_permissive: true` in request body. Equivalent to `--permissive` on the CLI |
 | CORS | Supported | Enable with `--cors` |
 | `POST /v1/completions` | 501 | Legacy text completions not supported |
 | `POST /v1/embeddings` | 501 | Embeddings not available on-device |
@@ -248,26 +249,26 @@ Full API spec: [openai/openai-openapi](https://github.com/openai/openai-openapi)
 
 ## Default response cap (`max_tokens`)
 
-When a `/v1/chat/completions` request **omits `max_tokens`**, the server applies a default cap of **512 tokens**. Best practice: **always set `max_tokens` explicitly** to a value that matches your use case.
+When `max_tokens` is **omitted**, both the CLI and the server apply a default cap of **1024 tokens**. Best practice: **always set `max_tokens` explicitly** to a value that matches your use case.
 
 ### Why a default exists
 
-The on-device model has a **4096-token context window** that holds input *and* output combined. With no cap, generation runs until that window overflows, which produces an unrecoverable `[context overflow]` error after ~50 seconds of wasted generation - the client gets nothing usable. The 512-token default matches the output budget the context trimmer already reserves, so a typical short prompt gets a usable reply in ~1 second instead of hanging.
+The on-device model has a **4096-token context window** that holds input *and* output combined. With no cap, generation runs until that window overflows, which produces an unrecoverable `[context overflow]` error after ~50 seconds of wasted generation - the client gets nothing usable. The 1024-token default covers typical structured JSON and short-to-medium replies while still leaving 3072 tokens for input.
 
 ### When the cap is hit
 
-The response sets `finish_reason: "length"` (per the OpenAI spec) so the client can detect a truncated reply. If 512 tokens is too short for your prompt, raise it explicitly - up to whatever leaves room for your input inside the 4096-token window.
+The response sets `finish_reason: "length"` (per the OpenAI spec) so the client can detect a truncated reply. If 1024 tokens is too short for your prompt, raise it explicitly - up to whatever leaves room for your input inside the 4096-token window.
 
 ### Examples
 
-Without `max_tokens` (default 512 applied, fast and bounded):
+Without `max_tokens` (default 1024 applied, fast and bounded):
 
 ```bash
 curl -sS http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"apple-foundationmodel",
        "messages":[{"role":"user","content":"Reply SKIP, MOVE, or RENAME."}]}'
-# ~1s, returns a short reply, finish_reason: "stop" or "length"
+# returns a short reply, finish_reason: "stop" or "length"
 ```
 
 With explicit `max_tokens` (recommended - sized to your need):
@@ -275,7 +276,7 @@ With explicit `max_tokens` (recommended - sized to your need):
 ```bash
 curl -sS http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"apple-foundationmodel","max_tokens":1024,
+  -d '{"model":"apple-foundationmodel","max_tokens":2048,
        "messages":[{"role":"user","content":"Summarise this paragraph: ..."}]}'
 ```
 
@@ -293,7 +294,7 @@ Keep `input_tokens + max_tokens` comfortably below 4096. The context trimmer dro
 
 ### CLI parity
 
-The CLI (`apfel "prompt"`) does **not** apply this default - it streams to stdout with no server in front of it, so a runaway response is visible in real time and you can `Ctrl-C`. Use `--max-tokens N` if you want a hard cap.
+The CLI and the server apply the **same** 1024-token default when `max_tokens` / `--max-tokens` is omitted. Override with `--max-tokens N` on the CLI or `"max_tokens": N` in the request body.
 
 ## Limitations
 

--- a/Sources/Core/Chat/BodyLimits.swift
+++ b/Sources/Core/Chat/BodyLimits.swift
@@ -13,7 +13,8 @@ package enum BodyLimits {
     /// into the 4096-token context window.
     public static let defaultOutputReserveTokens: Int = 512
 
-    /// Server-side cap applied when a client omits max_tokens.
-    /// Matches the output reserve to stay within the 4096-token context window.
-    public static let defaultMaxResponseTokens: Int = 512
+    /// Default cap applied when a client (server or CLI) omits max_tokens.
+    /// 1024 covers typical structured JSON and short-to-medium replies while
+    /// leaving 3072 tokens for input inside the 4096-token window.
+    public static let defaultMaxResponseTokens: Int = 1024
 }

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -45,6 +45,8 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
     public let x_context_max_turns: Int?
     /// Requested token reserve for the model's output.
     public let x_context_output_reserve: Int?
+    /// Per-request opt-in for permissive guardrails on the server.
+    public let x_permissive: Bool?
 
     /// Creates a chat-completions request value.
     public init(
@@ -66,7 +68,8 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         user: String? = nil,
         x_context_strategy: String? = nil,
         x_context_max_turns: Int? = nil,
-        x_context_output_reserve: Int? = nil
+        x_context_output_reserve: Int? = nil,
+        x_permissive: Bool? = nil
     ) {
         self.model = model
         self.messages = messages
@@ -87,6 +90,7 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         self.x_context_strategy = x_context_strategy
         self.x_context_max_turns = x_context_max_turns
         self.x_context_output_reserve = x_context_output_reserve
+        self.x_permissive = x_permissive
     }
 }
 

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -68,10 +68,12 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     events.append("decoded messages=\(chatRequest.messages.count) stream=\(isStreaming) model=\(chatRequest.model)")
 
     // Build context config from request extensions (optional, defaults to newest-first)
+    let permissive = chatRequest.x_permissive == true
     let contextConfig = ContextConfig(
         strategy: chatRequest.x_context_strategy.flatMap { ContextStrategy(rawValue: $0) } ?? .newestFirst,
         maxTurns: chatRequest.x_context_max_turns,
-        outputReserve: chatRequest.x_context_output_reserve ?? BodyLimits.defaultOutputReserveTokens
+        outputReserve: chatRequest.x_context_output_reserve ?? BodyLimits.defaultOutputReserveTokens,
+        permissive: permissive
     )
 
     // Build session options from request (retry config comes from server config)
@@ -79,7 +81,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         temperature: chatRequest.temperature,
         maxTokens: chatRequest.max_tokens ?? BodyLimits.defaultMaxResponseTokens,
         seed: chatRequest.seed.map { UInt64($0) },
-        permissive: false,
+        permissive: permissive,
         contextConfig: contextConfig,
         retryEnabled: serverState.config.retryEnabled,
         retryCount: serverState.config.retryCount

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -134,13 +134,13 @@ if !fileContents.isEmpty {
 let contextConfig = ContextConfig(
     strategy: parsed.contextStrategy ?? .newestFirst,
     maxTurns: parsed.contextMaxTurns,
-    outputReserve: parsed.contextOutputReserve ?? 512,
+    outputReserve: parsed.contextOutputReserve ?? BodyLimits.defaultOutputReserveTokens,
     permissive: parsed.permissive
 )
 
 let sessionOpts = SessionOptions(
     temperature: parsed.temperature,
-    maxTokens: parsed.maxTokens,
+    maxTokens: parsed.maxTokens ?? BodyLimits.defaultMaxResponseTokens,
     seed: parsed.seed,
     permissive: parsed.permissive,
     contextConfig: contextConfig,

--- a/Tests/apfelTests/BodyLimitsTests.swift
+++ b/Tests/apfelTests/BodyLimitsTests.swift
@@ -14,12 +14,13 @@ func runBodyLimitsTests() {
         try assertEqual(BodyLimits.defaultOutputReserveTokens, 512)
     }
 
-    test("defaultMaxResponseTokens is 512") {
-        try assertEqual(BodyLimits.defaultMaxResponseTokens, 512)
+    test("defaultMaxResponseTokens is 1024") {
+        try assertEqual(BodyLimits.defaultMaxResponseTokens, 1024)
     }
 
-    test("defaultMaxResponseTokens matches defaultOutputReserveTokens") {
-        try assertEqual(BodyLimits.defaultMaxResponseTokens, BodyLimits.defaultOutputReserveTokens)
+    test("defaultMaxResponseTokens fits within 4096-token context window") {
+        try assertTrue(BodyLimits.defaultMaxResponseTokens <= 4096)
+        try assertTrue(4096 - BodyLimits.defaultMaxResponseTokens >= 64)
     }
 
     test("constants are positive") {

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -337,6 +337,31 @@ func runChatRequestValidatorTests() {
             .invalidParameterValue("'x_context_max_turns' must be a positive integer, got 0")
         )
     }
+
+    test("x_permissive decodes true when present") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"x_permissive":true}"#
+        )
+        try assertEqual(request.x_permissive, true)
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("x_permissive decodes false when present") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"x_permissive":false}"#
+        )
+        try assertEqual(request.x_permissive, false)
+    }
+
+    test("x_permissive defaults to nil when omitted") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}]}"#
+        )
+        try assertNil(request.x_permissive)
+    }
 }
 
 private func unwrap<T>(_ value: T?, _ message: String) throws -> T {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #130.

## Root cause

The CLI and server constructed `SessionOptions` independently with different defaults. Three divergences:

1. **`max_tokens`**: Server applied `BodyLimits.defaultMaxResponseTokens` (512) as fallback; CLI passed `nil` (no cap). Piped, scripted, JSON-output, and launchd CLI invocations had no Ctrl-C escape hatch - same overflow risk the server fix addressed.
2. **`permissive`**: Server hard-coded `false` at `Handlers.swift:82`; CLI read `--permissive`. Server clients had no way to enable permissive guardrails.
3. **`ContextConfig.permissive`**: Server never passed `permissive` to `ContextConfig`, so the summarize strategy always used default guardrails.

## The fix

Per the KISS directive in the issue thread:

- **`defaultMaxResponseTokens` raised from 512 to 1024.** Covers typical structured JSON and short-to-medium replies, leaves 3072 tokens for input. Both CLI (`main.swift:143`) and server (`Handlers.swift:82`) now reference the same `BodyLimits.defaultMaxResponseTokens` constant - parity is compiler-enforced.
- **`x_permissive` request extension added.** `ChatCompletionRequest` gains an `x_permissive: Bool?` field. When `true`, the server uses `.permissiveContentTransformations` - same guardrail mode as `--permissive` on the CLI. The hard-coded `false` is gone.
- **`ContextConfig.permissive` propagated.** Server now passes `permissive` through to `ContextConfig` so the summarize strategy respects it.
- **`outputReserve` magic number replaced.** CLI's `outputReserve: 512` replaced with `BodyLimits.defaultOutputReserveTokens` for consistency.
- **README updated.** "Default response cap" section rewritten to reflect 1024 and actual CLI/server parity. `x_permissive` documented in the API table.

## Test coverage

- Updated `BodyLimitsTests: "defaultMaxResponseTokens is 1024"` to match the new value.
- Replaced the coupling assertion (`defaultMaxResponseTokens == defaultOutputReserveTokens`) with a range invariant: `"defaultMaxResponseTokens fits within 4096-token context window"`.
- Added `ChatRequestValidatorTests: "x_permissive decodes true when present"` - verifies the field round-trips and passes validation.
- Added `ChatRequestValidatorTests: "x_permissive decodes false when present"` - verifies explicit false.
- Added `ChatRequestValidatorTests: "x_permissive defaults to nil when omitted"` - verifies omission doesn't break existing requests.

## What I verified (static only)

- Both `main.swift` and `Handlers.swift` reference `BodyLimits.defaultMaxResponseTokens` - shared default is compiler-enforced.
- Both `main.swift` and `Handlers.swift` reference `BodyLimits.defaultOutputReserveTokens` for output reserve.
- `permissive` flows through `ContextConfig` and `SessionOptions` on both surfaces.
- Diff is 7 files, 54 insertions, 20 deletions. No touches to release infrastructure, guardrails, CI, dependencies, or `.version`.
- Swift 6 concurrency: no new concurrency surfaces introduced.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward parity bug filed by the repo owner with accurate code references and a clear KISS directive.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBwrpGFyjSnMSiXeT2uJZ)_