### PR TITLE
fix(server): add non-prefixed route aliases for client compatibility (#134)

### DIFF
--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -92,7 +92,8 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
 
     // Models — includes context_window and supported_languages from SDK.
     // Uses the same startup-cached values as /health.
-    router.get("/v1/models") { _, _ -> Response in
+    // Registered at both /v1/models and /models for client compatibility (#134).
+    let modelsHandler: @Sendable (Request, BasicRequestContext) async throws -> Response = { _, _ in
         return jsonResponse(jsonString(ModelsListResponse(
             object: "list",
             data: [.init(
@@ -104,9 +105,12 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
             )]
         )))
     }
+    router.get("/v1/models") { req, ctx in try await modelsHandler(req, ctx) }
+    router.get("/models") { req, ctx in try await modelsHandler(req, ctx) }
 
     // Chat completions (with logging, retry, concurrency)
-    router.post("/v1/chat/completions") { request, context -> Response in
+    // Registered at both /v1/chat/completions and /chat/completions for client compatibility (#134).
+    let chatCompletionsHandler: @Sendable (Request, BasicRequestContext) async throws -> Response = { request, context in
         let start = Date()
         let requestId = "chatcmpl-\(UUID().uuidString.prefix(12).lowercased())"
 
@@ -160,6 +164,8 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
 
         return result.response
     }
+    router.post("/v1/chat/completions") { req, ctx in try await chatCompletionsHandler(req, ctx) }
+    router.post("/chat/completions") { req, ctx in try await chatCompletionsHandler(req, ctx) }
 
     // Logs query
     router.get("/v1/logs") { request, _ -> Response in
@@ -202,10 +208,17 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     }
 
     // Stub endpoints - honest about unsupported features
+    // Non-prefixed aliases included for client compatibility (#134).
     router.post("/v1/completions") { _, _ -> Response in
         openAIError(status: .init(code: 501), message: "Text completions not supported. Use /v1/chat/completions.", type: "invalid_request_error")
     }
+    router.post("/completions") { _, _ -> Response in
+        openAIError(status: .init(code: 501), message: "Text completions not supported. Use /v1/chat/completions.", type: "invalid_request_error")
+    }
     router.post("/v1/embeddings") { _, _ -> Response in
+        openAIError(status: .init(code: 501), message: "Embeddings not supported by Apple's on-device model.", type: "invalid_request_error")
+    }
+    router.post("/embeddings") { _, _ -> Response in
         openAIError(status: .init(code: 501), message: "Embeddings not supported by Apple's on-device model.", type: "invalid_request_error")
     }
 

--- a/Tests/integration/openai_client_test.py
+++ b/Tests/integration/openai_client_test.py
@@ -435,3 +435,46 @@ def test_health_endpoint():
     assert "model" in data
     assert "context_window" in data
     assert "model_available" in data
+
+
+# MARK: - Non-Prefixed Route Aliases (#134)
+
+def test_chat_completions_without_v1_prefix():
+    """POST /chat/completions (no /v1/ prefix) works for clients like Zed."""
+    resp = httpx.post(
+        f"{BASE_URL.replace('/v1', '')}/chat/completions",
+        json={"model": MODEL, "messages": [{"role": "user", "content": "Say hi."}], "max_tokens": 10},
+        timeout=60,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["object"] == "chat.completion"
+    assert len(data["choices"]) > 0
+
+
+def test_models_without_v1_prefix():
+    """GET /models (no /v1/ prefix) works for clients like Zed."""
+    resp = httpx.get(f"{BASE_URL.replace('/v1', '')}/models")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["object"] == "list"
+    assert len(data["data"]) > 0
+    assert data["data"][0]["id"] == MODEL
+
+
+def test_completions_stub_without_v1_prefix():
+    """POST /completions (no /v1/ prefix) returns 501."""
+    resp = httpx.post(
+        f"{BASE_URL.replace('/v1', '')}/completions",
+        json={"model": MODEL, "prompt": "hi"},
+    )
+    assert resp.status_code == 501
+
+
+def test_embeddings_stub_without_v1_prefix():
+    """POST /embeddings (no /v1/ prefix) returns 501."""
+    resp = httpx.post(
+        f"{BASE_URL.replace('/v1', '')}/embeddings",
+        json={"model": MODEL, "input": "hi"},
+    )
+    assert resp.status_code == 501


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #134.

## Root cause

apfel's HTTP server only registers routes with the `/v1/` prefix (`/v1/chat/completions`, `/v1/models`, etc.). Clients like Zed set `api_url` to the server root (e.g. `http://127.0.0.1:11434/`) and append `/chat/completions` without the `/v1/` prefix. The request hits an unregistered path and gets a 404 from Hummingbird's router.

## The fix

Register non-prefixed aliases (`/chat/completions`, `/models`, `/completions`, `/embeddings`) that share the same handler as their `/v1/` counterparts. The models and chat completions handlers are extracted into local closure variables so both routes use the identical handler without code duplication. The stub endpoints (`/completions`, `/embeddings`) are one-liners so they're simply duplicated.

This is a common pattern in OpenAI-compatible servers (LM Studio, Ollama, etc.) and makes apfel work out of the box with clients that don't include `/v1/` in their request paths.

## Test coverage

- Added `openai_client_test.py:test_chat_completions_without_v1_prefix` - verifies POST `/chat/completions` returns 200 with a valid completion.
- Added `openai_client_test.py:test_models_without_v1_prefix` - verifies GET `/models` returns the model list.
- Added `openai_client_test.py:test_completions_stub_without_v1_prefix` - verifies POST `/completions` returns 501.
- Added `openai_client_test.py:test_embeddings_stub_without_v1_prefix` - verifies POST `/embeddings` returns 501.
- Existing `/v1/` prefixed tests still cover the canonical paths.

## What I verified (static only)

- Route registrations use the same handler instances - no behavioral divergence between prefixed and non-prefixed paths.
- SecurityMiddleware applies to all routes (registered on the router, not per-path) - non-prefixed routes get the same origin check, token auth, and CORS handling.
- The `/health` endpoint path check in SecurityMiddleware (`request.uri.path == "/health"`) is unaffected since `/health` was already non-prefixed.
- Swift 6 concurrency: no data races introduced. Closure variables capture only `Sendable` values (`cachedContextSize` is `Int`, `cachedLangs` is `[String]`, `config` is `Sendable`).
- Diff limited to `Sources/Server.swift` and `Tests/integration/openai_client_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward compatibility bug. The reporter's issue body is a clean bug report with environment details and reproduction steps.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ11Np1kGfMkpfW1ua5kbZ)_