### PR TITLE
fix(chat): use text-only tool instructions to prevent native interception (#144)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -94,23 +94,23 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
     let model = makeModel(permissive: options.permissive)
     var session: LanguageModelSession
     if hasMCPTools {
-        // Build session directly with tool definitions in Instructions.
-        // Can't use ContextManager.makeSession() here because it requires a user message,
-        // and chat has no user message at init time (user hasn't typed anything yet).
-        let converted = await SchemaConverter.convert(tools: mcpTools)
+        // Build session with ALL tool schemas as text instructions and NO native
+        // toolDefinitions. Native defs cause the FoundationModels framework to
+        // intercept tool calls instead of surfacing them as text in the stream.
+        // apfel uses out-of-band text detection (ToolCallHandler.detectToolCall),
+        // so native interception breaks tool execution in chat mode (#144).
         var instrParts: [String] = []
         if let sys = systemPrompt { instrParts.append(sys) }
         let toolNames = mcpTools.map { $0.function.name }
         instrParts.append(ToolCallHandler.buildOutputFormatInstructions(toolNames: toolNames))
         instrParts.append("IMPORTANT: You may ONLY call the functions listed above (\(toolNames.joined(separator: ", "))). Do NOT invent function names. If the user's request cannot be handled by these specific functions, respond with plain text.")
-        if !converted.fallback.isEmpty {
-            instrParts.append(ToolCallHandler.buildFallbackPrompt(tools: converted.fallback))
-        }
+        let allToolDefs = mcpTools.map { ToolDef(name: $0.function.name, description: $0.function.description, parametersJSON: $0.function.parameters?.value) }
+        instrParts.append(ToolCallHandler.buildFallbackPrompt(tools: allToolDefs))
         let instrText = instrParts.joined(separator: "\n\n")
         let segments: [Transcript.Segment] = [.text(Transcript.TextSegment(content: instrText))]
-        let instr = Transcript.Instructions(segments: segments, toolDefinitions: converted.native)
+        let instr = Transcript.Instructions(segments: segments, toolDefinitions: [])
         session = makeTranscriptSession(model: model, entries: [.instructions(instr)])
-        debugLog("chat", "session created with \(converted.native.count) native + \(converted.fallback.count) fallback tools")
+        debugLog("chat", "session created with \(mcpTools.count) text-injected tools")
     } else {
         session = makeSession(systemPrompt: systemPrompt, options: options)
     }
@@ -185,29 +185,10 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
             if tokenCount > budget {
                 do {
                     let truncated = try await truncateTranscript(transcript, budget: budget, config: options.contextConfig)
-                    if hasMCPTools {
-                        // Re-inject MCP tool definitions into the truncated transcript.
-                        // Without this, tools silently stop working after context rotation.
-                        let truncEntries = transcriptEntries(truncated)
-                        var rebuilt: [Transcript.Entry] = []
-                        let converted = await SchemaConverter.convert(tools: mcpTools)
-                        if let first = truncEntries.first, case .instructions(let instr) = first {
-                            let updated = Transcript.Instructions(
-                                segments: instr.segments, toolDefinitions: converted.native)
-                            rebuilt.append(.instructions(updated))
-                            rebuilt.append(contentsOf: truncEntries.dropFirst())
-                        } else {
-                            let toolInstr = Transcript.Instructions(
-                                segments: [], toolDefinitions: converted.native)
-                            rebuilt.append(.instructions(toolInstr))
-                            rebuilt.append(contentsOf: truncEntries)
-                        }
-                        session = makeTranscriptSession(model: model, entries: rebuilt)
-                        debugLog("context", "rotated with MCP tools re-injected (\(converted.native.count) native)")
-                    } else {
-                        session = LanguageModelSession(model: model, transcript: truncated)
-                        debugLog("context", "rotated (no MCP tools)")
-                    }
+                    // Tool schemas live in the Instructions text segments (not native
+                    // toolDefinitions), so they survive truncation without re-injection.
+                    session = LanguageModelSession(model: model, transcript: truncated)
+                    debugLog("context", "rotated\(hasMCPTools ? " (tool text preserved)" : "")")
                     if !quietMode && outputFormat == .plain {
                         print(styled("  [context rotated — \(options.contextConfig.strategy.rawValue)]", .dim))
                     }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -266,4 +266,48 @@ func runMCPClientTests() {
         try assertTrue(instructions.contains("add"), "combined prompt must contain first tool")
         try assertTrue(instructions.contains("multiply"), "combined prompt must contain second tool")
     }
+
+    // MARK: - Chat mode text-only tool instructions (#144)
+    // Native toolDefinitions can cause the framework to intercept tool calls,
+    // preventing text-based detection. Chat mode must use text-only instructions.
+
+    test("Chat text-only instructions include all schemas even when native conversion would succeed") {
+        // Reproduces the #144 scenario: tools that convert to native format just fine
+        // must STILL have their schemas available as text, because chat mode cannot
+        // rely on native toolDefinitions (the framework may intercept instead of
+        // producing text output that detectToolCall can parse).
+        let toolsJSON = """
+        {"jsonrpc":"2.0","id":2,"result":{"tools":[
+            {"name":"read","description":"Read a file","inputSchema":{"type":"object","properties":{"file":{"type":"string","description":"File path"}}}},
+            {"name":"edit","description":"Edit a file","inputSchema":{"type":"object","properties":{"file":{"type":"string"},"content":{"type":"string"}}}}
+        ]}}
+        """
+        let tools = try MCPProtocol.parseToolsListResponse(toolsJSON)
+        try assertEqual(tools.count, 2)
+
+        // Build text-only instructions (ALL tools as text, no native defs)
+        let allToolDefs = tools.map { ToolDef(name: $0.function.name, description: $0.function.description, parametersJSON: $0.function.parameters?.value) }
+        let fallbackPrompt = ToolCallHandler.buildFallbackPrompt(tools: allToolDefs)
+        let formatInstructions = ToolCallHandler.buildOutputFormatInstructions(toolNames: tools.map { $0.function.name })
+
+        // ALL tool schemas must be in the text
+        try assertTrue(fallbackPrompt.contains("read"), "text must contain 'read' tool schema")
+        try assertTrue(fallbackPrompt.contains("edit"), "text must contain 'edit' tool schema")
+        try assertTrue(fallbackPrompt.contains("file"), "text must contain parameter names")
+        try assertTrue(formatInstructions.contains("read"), "format must list 'read'")
+        try assertTrue(formatInstructions.contains("edit"), "format must list 'edit'")
+        try assertTrue(formatInstructions.contains("tool_calls"), "format must contain call format")
+    }
+
+    test("Tool call detection works on object-argument format from #144 report") {
+        // The #144 reporter showed the model producing arguments as a JSON object
+        // (not an escaped string). Detection must handle both forms.
+        let modelOutput = #"{"tool_calls": [{"id": "call_001", "type": "function", "function": {"name": "read", "arguments": {"file": "CLAUDE.md"}}}]}"#
+        let calls = ToolCallHandler.detectToolCall(in: modelOutput)
+        try assertNotNil(calls, "tool calls must be detected with object arguments")
+        try assertEqual(calls!.count, 1)
+        try assertEqual(calls!.first?.name, "read")
+        try assertEqual(calls!.first?.id, "call_001")
+        try assertTrue(calls!.first!.argumentsString.contains("CLAUDE.md"), "arguments must contain the file path")
+    }
 }

--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -342,7 +342,7 @@ def test_chat_mcp_shows_tool_list_on_startup():
 
 
 def test_chat_mcp_can_execute_tool():
-    """Chat+MCP must attempt a tool call (model may generate tool_calls JSON)."""
+    """Chat+MCP must execute tool calls, not leak raw JSON (#144)."""
     require_model()
     returncode, output = run_chat_tty(
         ["--chat", "--mcp", str(MCP_SERVER)],
@@ -356,10 +356,13 @@ def test_chat_mcp_can_execute_tool():
     )
     clean = strip_ansi(output)
     assert "Last message has no text content" not in clean, "Chat+MCP crashed"
-    # Model should either execute the tool (showing "4" or "tool:") or at least
-    # attempt a tool call (showing "tool_calls" JSON)
-    assert "4" in clean or "tool_calls" in clean or "tool:" in clean.lower(), \
-        f"No tool activity in response: {clean[:500]}"
+    # Tool must be executed (tool: log) or model answers correctly
+    assert "4" in clean or "tool:" in clean.lower(), \
+        f"Tool not executed or answer not found: {clean[:500]}"
+    # Raw tool_calls JSON in the AI response is the #144 bug
+    ai_lines = [l for l in clean.split('\n') if 'ai' in l.lower() and '"tool_calls"' in l]
+    assert not ai_lines, \
+        f"Raw tool_calls JSON leaked to chat output (#144): {ai_lines[0][:300] if ai_lines else ''}"
 
 
 def test_chat_mcp_tool_log_on_stderr():
@@ -376,9 +379,13 @@ def test_chat_mcp_tool_log_on_stderr():
     )
     clean = strip_ansi(output)
     assert "Last message has no text content" not in clean, "Chat+MCP crashed"
-    # Model should attempt tool use or answer - any sign of MCP activity
-    assert "tool:" in clean.lower() or "8" in clean or "eight" in clean.lower() or "tool_calls" in clean, \
-        f"No tool activity or answer visible: {clean[:500]}"
+    # Tool must be executed or model answers correctly
+    assert "tool:" in clean.lower() or "8" in clean or "eight" in clean.lower(), \
+        f"No tool execution or answer visible: {clean[:500]}"
+    # Raw tool_calls JSON leak is the #144 bug
+    ai_lines = [l for l in clean.split('\n') if 'ai' in l.lower() and '"tool_calls"' in l]
+    assert not ai_lines, \
+        f"Raw tool_calls JSON leaked to chat output (#144): {ai_lines[0][:300] if ai_lines else ''}"
 
 
 def test_chat_mcp_with_system_prompt():


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #144.

## Root cause

In `--chat` mode, MCP tool schemas were registered as both native `toolDefinitions` in the session's `Transcript.Instructions` AND as text-based format instructions. When the FoundationModels framework sees native tool definitions, it can intercept the model's tool-call output instead of surfacing it as text in the stream. Since apfel uses out-of-band text detection (`ToolCallHandler.detectToolCall` - per #119's design), the intercepted tool call was never detected. The raw JSON leaked to the user as the AI response.

One-shot mode works because `ContextManager.makeSession` threads the user message into the transcript alongside tool definitions before streaming, which causes the model to produce text-based tool calls that pass through `collectStream` as parseable text content.

## The fix

Remove native `toolDefinitions` from chat sessions entirely. Instead, include ALL tool schemas as text instructions via `buildFallbackPrompt`. This forces the model to produce tool calls as text (the `{"tool_calls": [...]}` JSON format), which `detectToolCall` can parse and execute via MCP. This aligns with apfel's out-of-band tool-calling design.

As a bonus, this simplifies context rotation - the tool schemas live in the Instructions text segments and survive truncation without the previous re-injection dance (`SchemaConverter.convert` + transcript rebuilding is gone from the rotation path).

## Test coverage

- Added `MCPClientTests.swift`: "Chat text-only instructions include all schemas even when native conversion would succeed" - verifies the text-only instruction path includes all tool schemas.
- Added `MCPClientTests.swift`: "Tool call detection works on object-argument format from #144 report" - verifies detection handles the exact JSON format the reporter showed.
- Tightened `test_chat.py`: `test_chat_mcp_can_execute_tool` and `test_chat_mcp_tool_log_on_stderr` no longer accept raw `"tool_calls"` JSON in the AI response as a passing condition (they were masking this bug).

## What I verified (static only)

- Diff limited to `Sources/CLI.swift`, `Tests/apfelTests/MCPClientTests.swift`, `Tests/integration/test_chat.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- No new imports or dependencies added.
- `processPrompt` (shared by one-shot and chat) is unchanged - the fix is only in chat session construction.
- Context rotation simplified: `truncateTranscript` preserves Instructions entries (including text segments), so text-based tool schemas survive without re-injection.
- Swift 6 concurrency: no data races introduced (removed an `await SchemaConverter.convert` call from the rotation path, which is strictly simpler).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a clear reproducer from the reporter. The integration tests were explicitly accepting the buggy behaviour (`"tool_calls" in clean`) as a passing condition, which masked the issue.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q81g9BCwAEg5nMaCxK537C)_