### PR TITLE
docs(readme): add apfel-for-raycast to Community Projects (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Built something on top of apfel? Open an issue and it can be added here.
 | **fruit-chat** by [@bhaskarvilles](https://github.com/bhaskarvilles) | Browser-based chat UI that talks to `apfel --serve` over the OpenAI-compatible API | [github](https://github.com/bhaskarvilles/fruit-chat) |
 | **local-claude** by [@lucaspwo](https://github.com/lucaspwo) | Claude Code wrapper that swaps in apfel as a local backend via a small Anthropic-OpenAI proxy | [github](https://github.com/lucaspwo/local-claude) |
 | **apfeller** by [@hasit](https://github.com/hasit) | App manager for local shell apps built around apfel | [github](https://github.com/hasit/apfeller) - [site](https://hasit.github.io/apfeller/) - [catalog](https://hasit.github.io/apfeller/catalog/) |
-| **apfel-for-raycast** by [@eggsydev](https://github.com/eggsydev) | Raycast command bar extension: ask, translate, explain files and directories, conversation history, custom system prompts. On-device via apfel CLI. | [store](https://www.raycast.com/eggsy/apfel) - [github](https://github.com/raycast/extensions/tree/main/extensions/apfel) |
+| **apfel-for-raycast** by [@eggsy](https://github.com/eggsy) | Raycast command bar extension: ask, translate, explain files and directories, conversation history, custom system prompts. On-device via apfel CLI. | [store](https://www.raycast.com/eggsy/apfel) - [github](https://github.com/raycast/extensions/tree/main/extensions/apfel) |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Built something on top of apfel? Open an issue and it can be added here.
 | **fruit-chat** by [@bhaskarvilles](https://github.com/bhaskarvilles) | Browser-based chat UI that talks to `apfel --serve` over the OpenAI-compatible API | [github](https://github.com/bhaskarvilles/fruit-chat) |
 | **local-claude** by [@lucaspwo](https://github.com/lucaspwo) | Claude Code wrapper that swaps in apfel as a local backend via a small Anthropic-OpenAI proxy | [github](https://github.com/lucaspwo/local-claude) |
 | **apfeller** by [@hasit](https://github.com/hasit) | App manager for local shell apps built around apfel | [github](https://github.com/hasit/apfeller) - [site](https://hasit.github.io/apfeller/) - [catalog](https://hasit.github.io/apfeller/catalog/) |
+| **apfel-for-raycast** by [@eggsydev](https://github.com/eggsydev) | Raycast command bar extension: ask, translate, explain files and directories, conversation history, custom system prompts. On-device via apfel CLI. | [store](https://www.raycast.com/eggsy/apfel) - [github](https://github.com/raycast/extensions/tree/main/extensions/apfel) |
 
 ## Contributing
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review before merging.**

Closes #64.

## What changed

Added EGGSY's [apfel-for-raycast](https://www.raycast.com/eggsy/apfel) extension to the Community Projects table in README.md. The extension is now live on the Raycast Store - confirmed by the author in [#64 (comment)](https://github.com/Arthur-Ficial/apfel/issues/64#issuecomment-4429845560).

## The entry

| Project | What it does | Links |
|---------|-------------|-------|
| **apfel-for-raycast** by [@eggsydev](https://github.com/eggsydev) | Raycast command bar extension: ask, translate, explain files and directories, conversation history, custom system prompts. On-device via apfel CLI. | [store](https://www.raycast.com/eggsy/apfel) - [github](https://github.com/raycast/extensions/tree/main/extensions/apfel) |

## What I verified

- Docs-only change, single file (`README.md`), one line added.
- Entry matches the existing table format and column structure.
- Content adapted from the pre-approved text in issue #64.
- No touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- Could not confirm the store URL is live (Raycast returned 403 to automated fetch). The extension author confirmed it in the issue comment.

---

cc @franzenzenhofer - draft stays draft until you review.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGNpxjD8sVrNcdGCiHy11e)_