### PR TITLE
docs(claude): bake #119 reviewer checkpoint into architecture review (AC#2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ Priority-rank findings:
 - Does it respect the non-negotiable principles (100% on-device, honest limits, clean code, Swift 6 strict concurrency, usable security)?
 - Does it introduce cross-target dependencies that violate the `ApfelCore` (pure) / `ApfelCLI` (CLI types) / `apfel` (FoundationModels + Hummingbird) layering?
 - Are the existing patterns followed (test harness, error types, context strategy, retry)?
+- **Tool-calling boundary (parked architectural ticket #119):** apfel's tool execution is out-of-band - the model emits a tool-call request in its output text, apfel parses it via `ToolCallHandler.detectToolCall`, runs the tool via `MCPClient`, and feeds the result back. FoundationModels' native `Tool` protocol and in-band invocation are not used, so `FoundationModels.LanguageModelSession.ToolCallError` is unreachable and `ApfelError.classify(_:)` deliberately has no branch for it (see `Sources/Core/ApfelError.swift:23`). If a PR adds `LanguageModelSession(..., tools: [SomeTool()])`, defines a type conforming to `FoundationModels.Tool` inside apfel, or otherwise registers a live tool implementation with the framework, it MUST also add the companion `ApfelError` classifier branch and an integration test that exercises the throw path end-to-end. Reopen #119 with the PR.
 
 ### 7. Test coverage check (code PRs)
 


### PR DESCRIPTION
**Draft PR — needs @franzenzenhofer review.**

Closes the optional acceptance item **AC#2** of #119 ("CLAUDE.md or `docs/tool-calling-guide.md` carries a note that live FoundationModels `Tool` registration requires a companion classifier branch").

## What changed

One bullet added to the **Architecture review** section of CLAUDE.md (step 6 of the PR-review process), so reviewers see the reopen-trigger for #119 in the same checklist they already run on every PR. Points to the code-side breadcrumb at `Sources/Core/ApfelError.swift:23`.

## Why this round, not at #119 creation

I noticed during today's daily-vet triage that AC#1 (code comment, done) and AC#3 (keep open with `wontfix`, done) were both satisfied, but AC#2 was optional-and-undone. Filed under the MVPClaw daily-vet gate — the gate's max action is "open a draft PR with tests" and a docs-only change needs no test.

## What I verified

- Single-file change (`CLAUDE.md`), single-bullet diff.
- No code change, no test impact, no release implication.
- Code-side breadcrumb at `Sources/Core/ApfelError.swift:23` still in place: `// FoundationModels ToolCallError is unreachable - apfel runs tools out-of-band; see #119`.
- Issue #119 stays open by design as a reopen-trigger.

## What I did NOT do

No source changes, no release commands, no merges.

cc @franzenzenhofer - draft stays draft until you mark ready.

_Filed under the MVPClaw daily-vet gate._