### PR TITLE
feat: Detect a MacPorts installation on update

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -317,9 +317,23 @@ func performUpdate() {
     if isBrew {
         print("\(appName) v\(current) (installed via Homebrew)")
     } else {
-        print("\(appName) v\(current) (installed from source)")
-        print("To update: git pull && make install")
-        print("Or visit: https://github.com/Arthur-Ficial/apfel/releases")
+        // Detect MacPorts by walking up from the binary to ${prefix}/var/macports.
+        // Default prefix is /opt/local; this works for custom prefixes too.
+        let macportsURL = URL(fileURLWithPath: resolved)
+            .deletingLastPathComponent()  // ${prefix}/bin
+            .deletingLastPathComponent()  // ${prefix}
+            .appendingPathComponent("var/macports")
+        var isDir: ObjCBool = false
+        let isMacPorts = FileManager.default.fileExists(atPath: macportsURL.path, isDirectory: &isDir)
+            && isDir.boolValue
+        if isMacPorts {
+            print("\(appName) v\(current) (installed via MacPorts)")
+            print("To update: sudo port sync && sudo port update apfel")
+        } else {
+            print("\(appName) v\(current) (installed from source)")
+            print("To update: git pull && make install")
+            print("Or visit: https://github.com/Arthur-Ficial/apfel/releases")
+        }
         return
     }
 


### PR DESCRIPTION
I'm adding a MacPorts port for apfel and want to indicate that the source is MacPorts. Unlike a Homebrew upgrade, this should _not_ be managed by the binary itself and its instructions should be accurate for MacPorts.

Until this is merged, we'll be applying a simple patchfile which replaces the whole function with the print statements.

Developed with the assistance of Kiro using Claude Opus 4.7.