### PR TITLE
fix(cli): warn when piped stdin is empty (#152)

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -64,6 +64,7 @@ if rawArgs.isEmpty {
                 exit(exitCode(for: classified))
             }
         }
+        printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
     }
     printUsage()
     exit(exitUsageError)
@@ -116,6 +117,8 @@ if parsed.mode.acceptsStdinInput && isatty(STDIN_FILENO) == 0 {
         } else {
             fileContents.append(stdinContent)
         }
+    } else if !prompt.isEmpty && !quietMode {
+        printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
     }
 }
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -40,6 +40,15 @@ func exitCode(for error: ApfelError) -> Int32 {
 
 apfel_install_sigint_exit_handler(isatty(STDOUT_FILENO) != 0 ? 1 : 0)
 
+// True when stdin is a FIFO/pipe (`command | apfel`) vs a regular file
+// redirect (`apfel < file`). We only suggest `2>&1` for the pipe case;
+// regular files don't need that advice.
+func stdinIsPipe() -> Bool {
+    var st = stat()
+    guard fstat(STDIN_FILENO, &st) == 0 else { return false }
+    return (st.st_mode & S_IFMT) == S_IFIFO
+}
+
 // MARK: - Argument Parsing
 
 let rawArgs = Array(CommandLine.arguments.dropFirst())
@@ -64,7 +73,9 @@ if rawArgs.isEmpty {
                 exit(exitCode(for: classified))
             }
         }
-        printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
+        if stdinIsPipe() {
+            printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
+        }
     }
     printUsage()
     exit(exitUsageError)
@@ -117,7 +128,7 @@ if parsed.mode.acceptsStdinInput && isatty(STDIN_FILENO) == 0 {
         } else {
             fileContents.append(stdinContent)
         }
-    } else if !prompt.isEmpty && !quietMode {
+    } else if !prompt.isEmpty && !quietMode && stdinIsPipe() {
         printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
     }
 }

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -698,6 +698,31 @@ def test_update_non_interactive():
     assert result.returncode == 0
 
 
+# --- Empty-pipe stderr hint tests (GH-152) ---
+
+
+def test_empty_pipe_no_args_shows_stderr_hint():
+    """When stdin is a pipe but empty and no args given, hint about stderr redirection (#152)."""
+    result = run_cli([], input_text="", timeout=10)
+    assert result.returncode == 2
+    assert "piped input was empty" in result.stderr
+    assert "2>&1" in result.stderr
+
+
+def test_empty_pipe_with_prompt_shows_stderr_hint():
+    """When stdin is a pipe but empty with a prompt, hint about stderr redirection (#152)."""
+    result = run_cli(["What went wrong?"], input_text="", timeout=30)
+    # Hint appears regardless of whether model is available.
+    assert "piped input was empty" in result.stderr
+    assert "2>&1" in result.stderr
+
+
+def test_empty_pipe_quiet_suppresses_hint():
+    """--quiet should suppress the empty-pipe hint (#152)."""
+    result = run_cli(["-q", "What went wrong?"], input_text="", timeout=30)
+    assert "piped input was empty" not in result.stderr
+
+
 # --- Release info tests ---
 
 

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -723,6 +723,27 @@ def test_empty_pipe_quiet_suppresses_hint():
     assert "piped input was empty" not in result.stderr
 
 
+def test_empty_file_redirect_no_hint(tmp_path):
+    """Empty regular-file redirect (`apfel "q" < empty.txt`) should NOT emit the
+    pipe hint - the hint is only useful for `command 2>&1 | apfel` (#152)."""
+    empty_file = tmp_path / "empty.txt"
+    empty_file.write_text("")
+    merged_env = os.environ.copy()
+    for key in ["NO_COLOR", "APFEL_SYSTEM_PROMPT", "APFEL_HOST", "APFEL_PORT",
+                "APFEL_TEMPERATURE", "APFEL_MAX_TOKENS"]:
+        merged_env.pop(key, None)
+    with open(empty_file, "rb") as fh:
+        result = subprocess.run(
+            [str(BINARY), "What went wrong?"],
+            stdin=fh,
+            capture_output=True,
+            text=True,
+            env=merged_env,
+            timeout=30,
+        )
+    assert "piped input was empty" not in result.stderr
+
+
 # --- Release info tests ---
 
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**\n\nFixes #152.\n\n## Root cause\n\nWhen a user pipes a command that sends its errors to stderr (like `rsync`), the standard `|` pipe only carries stdout to apfel's stdin. If the command produced no stdout, apfel receives an empty pipe. Previously, apfel silently ignored the empty input and sent the bare prompt to the model with no context - leading to unhelpful responses like \"Is there something going on?\" because the model had nothing to analyse.\n\n## The fix\n\nDetect when stdin is a pipe but delivers no content, and print a helpful hint to stderr: `apfel: piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel`. This covers both the no-args path (`command | apfel`) and the with-args path (`command | apfel \"question\"`). The hint respects `--quiet` in the with-args path.\n\n## Test coverage\n\n- Added `Tests/integration/cli_e2e_test.py:test_empty_pipe_no_args_shows_stderr_hint` - verifies hint appears with empty pipe + no args (model-free).\n- Added `Tests/integration/cli_e2e_test.py:test_empty_pipe_with_prompt_shows_stderr_hint` - verifies hint appears with empty pipe + prompt argument.\n- Added `Tests/integration/cli_e2e_test.py:test_empty_pipe_quiet_suppresses_hint` - verifies `--quiet` suppresses the hint.\n\n## What I verified (static only)\n\n- Code reads correctly: hint triggers only when stdin is a pipe AND content is empty.\n- No-args path: hint prints before usage, exit code unchanged (2).\n- With-args path: hint prints before model check, does not alter program flow.\n- `--quiet` suppression logic gated on `quietMode` which is set during argument parsing.\n- Swift 6 concurrency: no data races introduced (pure sequential code in main, no shared state changes).\n- Diff limited to `Sources/main.swift` and `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.\n\n## What I did NOT verify\n\n- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.\n\n## Anything that seemed suspicious\n\nNothing - straightforward UX bug with a minimal fix.\n\n---\n\ncc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.\n\n_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_015cuxGjQE9ffqU5wxqBfwrL)_