### PR TITLE
feat(cli): support APFEL_DEBUG env var for debug logging (#164)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -493,6 +493,7 @@ func printUsage() {
       APFEL_CONTEXT_MAX_TURNS   Max turns for sliding-window
       APFEL_CONTEXT_OUTPUT_RESERVE
                                 Tokens reserved for output
+      APFEL_DEBUG               Enable debug logging (same as --debug)
       NO_COLOR                  Disable colored output (https://no-color.org)
 
     \(styled("EXIT CODES:", .yellow, .bold))

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -188,6 +188,9 @@ extension CLIArguments {
         result.contextMaxTurns = env["APFEL_CONTEXT_MAX_TURNS"].flatMap { Int($0) }
         result.contextOutputReserve = env["APFEL_CONTEXT_OUTPUT_RESERVE"]
             .flatMap { Int($0) }.flatMap { $0 > 0 ? $0 : nil }
+        if let debugVal = env["APFEL_DEBUG"], !debugVal.isEmpty {
+            result.debug = true
+        }
 
         // Parser-phase state. Mode-setting flags are recorded in
         // `context.modeFlagsSeen` so the post-parse validate() step can detect

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -640,6 +640,26 @@ func runCLIArgumentsTests() {
         try assertEqual(args.contextOutputReserve, 1024)
     }
 
+    test("APFEL_DEBUG env enables debug") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_DEBUG": "1"])
+        try assertTrue(args.debug)
+    }
+
+    test("APFEL_DEBUG env with any non-empty value enables debug") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_DEBUG": "true"])
+        try assertTrue(args.debug)
+    }
+
+    test("APFEL_DEBUG env empty string does not enable debug") {
+        let args = try CLIArguments.parse(["hi"], env: ["APFEL_DEBUG": ""])
+        try assertTrue(!args.debug)
+    }
+
+    test("--debug CLI flag works without APFEL_DEBUG env") {
+        let args = try CLIArguments.parse(["--debug", "hi"])
+        try assertTrue(args.debug)
+    }
+
     test("APFEL_MCP env splits on colon separator") {
         let args = try CLIArguments.parse(["hi"], env: ["APFEL_MCP": "a.py:b.py"])
         try assertEqual(args.mcpServerPaths, ["a.py", "b.py"])


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #164.

## Root cause

apfel supports a full family of `APFEL_*` environment variables (`APFEL_PORT`, `APFEL_TOKEN`, `APFEL_SYSTEM_PROMPT`, etc.) but `--debug` was only available as a CLI flag. Users who always want debug output - e.g. when integrating apfel into pipelines or tools like MacParakeet - had to pass `--debug` on every invocation. A `APFEL_DEBUG` env var was the missing piece.

## The fix

Added `APFEL_DEBUG` environment variable support in `CLIArguments.parse()`, following the exact same pattern as the other `APFEL_*` env vars. When `APFEL_DEBUG` is set to any non-empty value (e.g. `1`, `true`, `yes`), debug logging is enabled. Empty string is treated as unset. The `--debug` CLI flag still works and takes precedence (CLI flags are parsed after env defaults, matching existing behaviour).

Also added `APFEL_DEBUG` to the help text's ENVIRONMENT section.

## Test coverage

- Added `CLIArgumentsTests`: "APFEL_DEBUG env enables debug" - basic `APFEL_DEBUG=1` case
- Added `CLIArgumentsTests`: "APFEL_DEBUG env with any non-empty value enables debug" - `APFEL_DEBUG=true`
- Added `CLIArgumentsTests`: "APFEL_DEBUG env empty string does not enable debug" - empty string guard
- Added `CLIArgumentsTests`: "--debug CLI flag works without APFEL_DEBUG env" - confirms existing flag still works
- Existing `--debug sets debug` test at line 268 covers the original flag path

## What I verified (static only)

- Diff is 3 files, 24 lines added, zero lines removed
- Follows the identical env var pattern used by every other `APFEL_*` variable in `CLIArguments.parse()`
- `--debug` CLI flag (line 306) runs after env defaults (line 191), so CLI always wins - same precedence as `--port` vs `APFEL_PORT`
- No new dependencies, no changes to `Package.swift`
- No touches to `.version`, `BuildInfo.swift`, release scripts, CI workflows, or guardrail files
- Swift 6 concurrency: no new shared mutable state - `debug` is a plain `Bool` on a `Sendable` struct, written once during parsing

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward enhancement request from a legitimate user with a clear use case (MacParakeet dictation cleanup).

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdirsgUeRsXhNEqzHVJiGY)_