### PR TITLE
feat(perf): call LanguageModelSession.prewarm() at startup (#169)

### DIFF
--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -62,6 +62,7 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     let tc = TokenCounter.shared
     let cachedContextSize = await tc.contextSize
     let cachedLangs = await tc.supportedLanguages
+    await tc.prewarm()
 
     let router = Router()
 

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -42,6 +42,16 @@ actor TokenCounter {
         model.isAvailable
     }
 
+    /// Preload model weights so the first inference is fast. No-op when unavailable.
+    func prewarm() {
+        guard isAvailable else {
+            debugLog("prewarm", "skipped - model unavailable")
+            return
+        }
+        debugLog("prewarm", "preloading model weights")
+        LanguageModelSession.prewarm()
+    }
+
     /// Current availability as our pure ApfelCore enum. Adapts Apple's
     /// `SystemLanguageModel.Availability` into our `ModelAvailability`
     /// so the rest of apfel can reason about the specific unavailable

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -189,6 +189,14 @@ default:
     }
 }
 
+// Prewarm the model for inference modes to reduce first-response latency.
+switch parsed.mode {
+case .single, .stream, .chat, .benchmark:
+    await TokenCounter.shared.prewarm()
+default:
+    break
+}
+
 // Initialize MCP servers if any.
 var mcpManager: MCPManager?
 if !parsed.mcpServerPaths.isEmpty {

--- a/Tests/integration/test_prewarm.py
+++ b/Tests/integration/test_prewarm.py
@@ -1,0 +1,99 @@
+"""
+apfel Integration Tests - prewarm() integration hygiene.
+
+Verifies that LanguageModelSession.prewarm() is wired into both the CLI
+and server startup paths, guarded behind model availability.  These are
+source-level structural checks - functional verification requires a local
+test run on a Mac with Apple Intelligence.
+"""
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SOURCES = ROOT / "Sources"
+
+
+def _read(name: str) -> str:
+    return (SOURCES / name).read_text()
+
+
+# -- TokenCounter: prewarm method exists and guards behind availability ------
+
+def test_token_counter_has_prewarm_method():
+    """TokenCounter must expose a prewarm() method."""
+    src = _read("TokenCounter.swift")
+    assert "func prewarm()" in src, (
+        "TokenCounter.swift is missing func prewarm(). "
+        "The model should be prewarmed via TokenCounter.shared.prewarm()."
+    )
+
+
+def test_prewarm_guards_behind_availability():
+    """prewarm() must check isAvailable before calling LanguageModelSession.prewarm()."""
+    src = _read("TokenCounter.swift")
+    guard_pos = src.find("guard isAvailable")
+    call_pos = src.find("LanguageModelSession.prewarm()")
+    assert guard_pos != -1, "prewarm() must guard behind isAvailable"
+    assert call_pos != -1, "prewarm() must call LanguageModelSession.prewarm()"
+    assert guard_pos < call_pos, (
+        "The availability guard must come before the prewarm() call"
+    )
+
+
+# -- Server: prewarm at startup ---------------------------------------------
+
+def test_server_calls_prewarm_at_startup():
+    """startServer() must call prewarm() before setting up routes."""
+    src = _read("Server.swift")
+    assert "prewarm()" in src, (
+        "Server.swift must call prewarm() during startup so the first "
+        "/v1/chat/completions request does not pay cold-start latency."
+    )
+
+
+def test_server_prewarm_after_property_prefetch():
+    """prewarm() should come after the property pre-fetch (contextSize, supportedLanguages)."""
+    src = _read("Server.swift")
+    prefetch_pos = src.find("cachedLangs")
+    prewarm_pos = src.find("prewarm()")
+    router_pos = src.find("let router = Router()")
+    assert prefetch_pos < prewarm_pos < router_pos, (
+        "prewarm() must sit between the property pre-fetch and the router setup"
+    )
+
+
+# -- CLI: prewarm for inference modes ----------------------------------------
+
+def test_main_calls_prewarm_for_inference_modes():
+    """main.swift must call prewarm() for modes that use the model."""
+    src = _read("main.swift")
+    assert "TokenCounter.shared.prewarm()" in src, (
+        "main.swift must call TokenCounter.shared.prewarm() for CLI inference modes."
+    )
+
+
+def test_main_prewarm_covers_all_inference_modes():
+    """The prewarm switch must cover single, stream, chat, and benchmark."""
+    src = _read("main.swift")
+    # Find the prewarm switch block
+    match = re.search(
+        r"case\s+\.single.*?\.stream.*?\.chat.*?\.benchmark.*?prewarm\(\)",
+        src,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "The prewarm call must be guarded by a switch covering "
+        ".single, .stream, .chat, and .benchmark"
+    )
+
+
+def test_main_prewarm_before_mcp_init():
+    """prewarm() should run before MCP servers are initialized."""
+    src = _read("main.swift")
+    prewarm_pos = src.find("TokenCounter.shared.prewarm()")
+    mcp_pos = src.find("MCPManager(paths:")
+    assert prewarm_pos < mcp_pos, (
+        "prewarm() must run before MCP initialization so the model "
+        "is loading while MCP servers start up"
+    )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #169.

## Root cause

apfel never called `LanguageModelSession.prewarm()`. Sessions were created lazily on first use, so the first request after `apfel --serve` starts - and the first CLI prompt - paid full model cold-start latency. The FoundationModels framework provides `prewarm()` specifically to preload model weights ahead of the first inference call.

## The fix

Added `TokenCounter.prewarm()` which calls `LanguageModelSession.prewarm()` guarded behind an `isAvailable` check (no point prewarming an unavailable model). This is called in two places:

1. **Server startup** (`Server.swift`): right after the existing property pre-fetch (contextSize, supportedLanguages) and before route setup - the model loads while Hummingbird binds.
2. **CLI inference modes** (`main.swift`): after the availability check, before MCP server init, for `.single`, `.stream`, `.chat`, and `.benchmark` modes - the model loads while MCP servers start up.

Both paths emit debug log lines (`debug[prewarm]: preloading model weights` / `debug[prewarm]: skipped - model unavailable`) visible with `--debug`.

## Test coverage

- Added `Tests/integration/test_prewarm.py` with 7 source-level structural tests:
  - `test_token_counter_has_prewarm_method` - method exists
  - `test_prewarm_guards_behind_availability` - guard comes before the SDK call
  - `test_server_calls_prewarm_at_startup` - Server.swift wiring
  - `test_server_prewarm_after_property_prefetch` - correct ordering in startup sequence
  - `test_main_calls_prewarm_for_inference_modes` - main.swift wiring
  - `test_main_prewarm_covers_all_inference_modes` - switch covers single/stream/chat/benchmark
  - `test_main_prewarm_before_mcp_init` - prewarm runs before MCP init (parallelism win)

## What I verified (static only)

- Source reads of `TokenCounter.swift`, `Server.swift`, `main.swift`, `Session.swift`, `CLI.swift` to understand session creation flow.
- `prewarm()` is guarded behind `isAvailable` so unavailable models are a no-op.
- Placement in Server.swift follows the existing pre-fetch pattern (contextSize, supportedLanguages cached at startup for the same cold-start reason, per apfel-gui#4).
- Placement in main.swift is after the availability check (model confirmed available) and before MCP init (model loads concurrently with MCP server startup).
- Swift 6 concurrency: `prewarm()` is an actor method on `TokenCounter`, `LanguageModelSession.prewarm()` is a type method - no data races introduced.
- Diff limited to `TokenCounter.swift`, `Server.swift`, `main.swift`, `test_prewarm.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- All 7 integration tests pass.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- First-token latency improvement (needs manual measurement before/after).

## Anything that seemed suspicious

Nothing - straightforward enhancement from the project owner.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXUcK5PKS7pD4m7peSHKwm)_