### PR TITLE
feat(server): honor top_p and make temperature:0 deterministic (#168)

### DIFF
--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -158,6 +158,9 @@ public enum ChatRequestValidator {
         if let temp = request.temperature, temp < 0 {
             return .invalidParameterValue("'temperature' must be non-negative, got \(temp)")
         }
+        if let topP = request.top_p, topP < 0 || topP > 1 {
+            return .invalidParameterValue("'top_p' must be between 0 and 1, got \(topP)")
+        }
         if let turns = request.x_context_max_turns, turns <= 0 {
             return .invalidParameterValue("'x_context_max_turns' must be a positive integer, got \(turns)")
         }

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -17,6 +17,8 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
     public let stream_options: StreamOptions?
     /// Sampling temperature override.
     public let temperature: Double?
+    /// Nucleus sampling probability threshold (0.0 to 1.0).
+    public let top_p: Double?
     /// Maximum completion tokens requested by the client.
     public let max_tokens: Int?
     /// Optional deterministic seed request.
@@ -53,6 +55,7 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         stream: Bool? = nil,
         stream_options: StreamOptions? = nil,
         temperature: Double? = nil,
+        top_p: Double? = nil,
         max_tokens: Int? = nil,
         seed: Int? = nil,
         tools: [OpenAITool]? = nil,
@@ -73,6 +76,7 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         self.stream = stream
         self.stream_options = stream_options
         self.temperature = temperature
+        self.top_p = top_p
         self.max_tokens = max_tokens
         self.seed = seed
         self.tools = tools

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -77,6 +77,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     // Build session options from request (retry config comes from server config)
     let sessionOpts = SessionOptions(
         temperature: chatRequest.temperature,
+        topP: chatRequest.top_p,
         maxTokens: chatRequest.max_tokens,
         seed: chatRequest.seed.map { UInt64($0) },
         permissive: serverState.config.permissive,

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -98,7 +98,7 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
                 context_window: cachedContextSize,
-                supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
+                supported_parameters: ["temperature", "top_p", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
                 notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(cachedLangs.joined(separator: ", "))"
             )]

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -13,6 +13,7 @@ import ApfelCore
 /// Options forwarded from CLI flags or OpenAI request parameters.
 struct SessionOptions: Sendable {
     let temperature: Double?
+    let topP: Double?
     let maxTokens: Int?
     let seed: UInt64?
     let permissive: Bool
@@ -20,17 +21,46 @@ struct SessionOptions: Sendable {
     let retryEnabled: Bool
     let retryCount: Int
 
-    static let defaults = SessionOptions(
-        temperature: nil, maxTokens: nil, seed: nil, permissive: false,
-        contextConfig: .defaults, retryEnabled: false, retryCount: 3
-    )
+    init(
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        maxTokens: Int? = nil,
+        seed: UInt64? = nil,
+        permissive: Bool = false,
+        contextConfig: ContextConfig = .defaults,
+        retryEnabled: Bool = false,
+        retryCount: Int = 3
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+        self.seed = seed
+        self.permissive = permissive
+        self.contextConfig = contextConfig
+        self.retryEnabled = retryEnabled
+        self.retryCount = retryCount
+    }
+
+    static let defaults = SessionOptions()
 }
 
 // MARK: - Generation Options
 
 func makeGenerationOptions(_ opts: SessionOptions) -> GenerationOptions {
-    let sampling: GenerationOptions.SamplingMode? = opts.seed.map {
-        .random(top: 50, seed: $0)
+    // Precedence: greedy > top_p (nucleus) > seeded top-k > framework default
+    let sampling: GenerationOptions.SamplingMode?
+    if opts.temperature == 0 {
+        sampling = .greedy
+    } else if let topP = opts.topP {
+        if let seed = opts.seed {
+            sampling = .random(probabilityThreshold: topP, seed: seed)
+        } else {
+            sampling = .random(probabilityThreshold: topP)
+        }
+    } else if let seed = opts.seed {
+        sampling = .random(top: 50, seed: seed)
+    } else {
+        sampling = nil
     }
     return GenerationOptions(
         sampling: sampling,

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -209,6 +209,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: Bool?               = req.stream
         let _: StreamOptions?      = req.stream_options
         let _: Double?             = req.temperature
+        let _: Double?             = req.top_p
         let _: Int?                = req.max_tokens
         let _: Int?                = req.seed
         let _: [OpenAITool]?       = req.tools

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -107,6 +107,26 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?[1] as? String, "two")
         try assertEqual(parsed?[2] as? Bool, false)
     }
+
+    test("ChatCompletionRequest decodes top_p") {
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],"top_p":0.9}"#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertEqual(req.top_p, 0.9)
+    }
+
+    test("ChatCompletionRequest top_p is nil when absent") {
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}]}"#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertNil(req.top_p)
+    }
+
+    test("ChatCompletionRequest decodes top_p with temperature and seed") {
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],"temperature":0.7,"top_p":0.95,"seed":42}"#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertEqual(req.top_p, 0.95)
+        try assertEqual(req.temperature, 0.7)
+        try assertEqual(req.seed, 42)
+    }
 }
 
 func runChatRequestValidatorTests() {
@@ -211,6 +231,74 @@ func runChatRequestValidatorTests() {
             from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"temperature":0.7}"#
         )
         try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator rejects top_p below 0") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"top_p":-0.1}"#
+        )
+        if case .invalidParameterValue(let msg) = ChatRequestValidator.validate(request) {
+            try assertTrue(msg.contains("top_p"), "error should mention top_p")
+        } else {
+            throw TestFailure("expected .invalidParameterValue for top_p=-0.1")
+        }
+    }
+
+    test("validator rejects top_p above 1") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"top_p":1.5}"#
+        )
+        if case .invalidParameterValue(let msg) = ChatRequestValidator.validate(request) {
+            try assertTrue(msg.contains("top_p"), "error should mention top_p")
+        } else {
+            throw TestFailure("expected .invalidParameterValue for top_p=1.5")
+        }
+    }
+
+    test("validator accepts valid top_p") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"top_p":0.9}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator accepts top_p boundary values 0 and 1") {
+        let req0 = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"top_p":0}"#
+        )
+        try assertNil(ChatRequestValidator.validate(req0))
+        let req1 = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"top_p":1}"#
+        )
+        try assertNil(ChatRequestValidator.validate(req1))
+    }
+
+    test("validator reports temperature before top_p in validation order") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"temperature":-1,"top_p":5.0}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'temperature' must be non-negative, got -1.0")
+        )
+    }
+
+    test("validator reports top_p before x_context_max_turns in validation order") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"top_p":2.0,"x_context_max_turns":0}"#
+        )
+        if case .invalidParameterValue(let msg) = ChatRequestValidator.validate(request) {
+            try assertTrue(msg.contains("top_p"), "should report top_p before x_context_max_turns")
+        } else {
+            throw TestFailure("expected .invalidParameterValue for top_p=2.0")
+        }
     }
 
     test("validator rejects x_context_max_turns <= 0") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #168.

## Root cause

Two sampling gaps in the OpenAI-compatible server make `--serve` less faithful to OpenAI semantics:

1. `top_p` (nucleus sampling) is silently ignored. OpenAI clients routinely send it, but `ChatCompletionRequest` had no field for it, so it was never decoded or plumbed to FoundationModels.
2. `temperature: 0` does not produce deterministic output. The `makeGenerationOptions` function only set a sampling mode when `seed` was present (`.random(top: 50, seed:)`). With `temperature: 0` and no seed, the framework default sampling was used, which is non-deterministic - violating the OpenAI convention that `temperature: 0` means deterministic.

## The fix

Adds `top_p` to the full request pipeline (`ChatCompletionRequest` -> `ChatRequestValidator` -> `SessionOptions` -> `makeGenerationOptions`) and implements a clear sampling precedence in `makeGenerationOptions`:

1. `temperature == 0` -> `.greedy` (true determinism, highest priority)
2. `top_p` present -> `.random(probabilityThreshold: topP, seed: seed)` (nucleus sampling)
3. `seed` present (no `top_p`) -> `.random(top: 50, seed: seed)` (existing top-k behavior, unchanged)
4. None of the above -> `nil` (framework default, unchanged)

The `top_p` field is validated to `[0, 1]` range in `ChatRequestValidator`, advertised in `/v1/models` `supported_parameters`, and plumbed from the server handler. The CLI does not get a `--top-p` flag (not in scope for this issue) - `SessionOptions.topP` defaults to `nil`.

## Test coverage

- Added 3 decoding tests in `OpenAIModelsTests`: `top_p` present, absent, combined with temperature+seed.
- Added 7 validation tests in `ChatRequestValidatorTests`: rejects below 0, rejects above 1, accepts 0.9, accepts boundary 0 and 1, validation order (temperature before top_p, top_p before x_context_max_turns).
- Updated `ApfelCorePublicAPIUsageTests` to exercise the new `top_p` property (compile-time API lockdown).

## What I verified (static only)

- All existing `SessionOptions(...)` call sites (`main.swift`, `Handlers.swift`, `Benchmark.swift`, `.defaults`) remain compatible - `topP` has a default value of `nil` so existing callers compile without changes.
- `CLIServerParityTests` has no `top_p` references and won't break.
- Validation order in `ChatRequestValidator.validate` is preserved: `max_tokens` -> `temperature` -> `top_p` -> `x_context_max_turns` -> `x_context_output_reserve`.
- Swift 6 concurrency: no data races introduced. `SessionOptions` remains `Sendable` (all `let` properties, value types).
- Diff limited to the request pipeline + tests. No touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. Specifically:
  - `.greedy` - I trust the issue's API reference but cannot verify the symbol exists in the SDK.
  - `.random(probabilityThreshold:)` (without seed) - if this overload doesn't exist, the seedless `top_p` branch will need `seed: UInt64.random(in: .min...(.max))` as a fallback.
  - `.random(probabilityThreshold:seed:)` - same caveat.
- Integration test for deterministic output (`temperature: 0` producing identical content across two requests) is not included here - it needs the model running.

## File count note

This touches 5 source files + 2 test files. That's above the 3-file guideline for the bug-solver routine, but each change is minimal plumbing through the request pipeline (1-3 lines per file) except `Session.swift` which contains the actual logic. Total: +134 / -7 lines, well under 100 lines of logic.

## Anything that seemed suspicious

Nothing - straightforward feature request from the project owner with clear API references.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UX3AxkVVeH8sZTR2aPoPZo)_