### PR TITLE
feat(server): json_schema response_format via DynamicGenerationSchema (#167)

### DIFF
--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -152,6 +152,15 @@ public enum ChatRequestValidator {
             return .imageContent
         }
 
+        if let rf = request.response_format, rf.type == "json_schema" {
+            guard let spec = rf.json_schema else {
+                return .invalidParameterValue("'response_format.json_schema' is required when type is 'json_schema'")
+            }
+            if spec.name.isEmpty {
+                return .invalidParameterValue("'response_format.json_schema.name' must not be empty")
+            }
+        }
+
         if let maxTokens = request.max_tokens, maxTokens <= 0 {
             return .invalidParameterValue("'max_tokens' must be a positive integer, got \(maxTokens)")
         }

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -363,12 +363,32 @@ public enum ToolChoice: Decodable, Sendable, Equatable, Hashable {
 
 /// OpenAI-compatible response-format request.
 public struct ResponseFormat: Decodable, Sendable, Equatable, Hashable {
-    /// The requested response format type, such as `text` or `json_object`.
+    /// The requested response format type: `text`, `json_object`, or `json_schema`.
     public let type: String
+    /// Schema specification, required when `type` is `json_schema`.
+    public let json_schema: JSONSchemaResponseParam?
 
     /// Creates a response-format request.
-    public init(type: String) {
+    public init(type: String, json_schema: JSONSchemaResponseParam? = nil) {
         self.type = type
+        self.json_schema = json_schema
+    }
+}
+
+/// The `json_schema` object within an OpenAI `response_format` request.
+public struct JSONSchemaResponseParam: Decodable, Sendable, Equatable, Hashable {
+    /// Caller-supplied name for the schema (used in logging/tracing).
+    public let name: String
+    /// Whether the model must strictly conform (OpenAI always treats this as true).
+    public let strict: Bool?
+    /// The JSON Schema the response must satisfy.
+    public let schema: RawJSON
+
+    /// Creates a JSON schema response parameter.
+    public init(name: String, strict: Bool? = nil, schema: RawJSON) {
+        self.name = name
+        self.strict = strict
+        self.schema = schema
     }
 }
 

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -52,6 +52,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     let isStreaming = chatRequest.stream == true
     let includeUsage = chatRequest.stream_options?.include_usage == true
     let jsonMode = chatRequest.response_format?.type == "json_object"
+    let jsonSchemaSpec = chatRequest.response_format?.type == "json_schema" ? chatRequest.response_format?.json_schema : nil
 
     if let failure = ChatRequestValidator.validate(chatRequest) {
         return chatFailure(
@@ -134,6 +135,34 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
             id: requestId, created: created, genOpts: genOpts,
             promptTokens: promptTokens, streaming: isStreaming,
             includeUsage: includeUsage, jsonMode: jsonMode,
+            requestBody: requestBodyString, events: events
+        )
+        return (result.response, result.trace)
+    }
+
+    // Schema-constrained generation for response_format: { type: "json_schema" }
+    if let spec = jsonSchemaSpec {
+        let responseSchema: GenerationSchema
+        do {
+            responseSchema = try SchemaConverter.convertResponseSchema(json: spec.schema.value, name: spec.name)
+        } catch {
+            let msg = "Invalid response_format.json_schema.schema: \(error.localizedDescription)"
+            return chatFailure(
+                status: .badRequest,
+                message: msg,
+                type: "invalid_request_error",
+                stream: isStreaming,
+                requestBody: requestBodyString,
+                events: events,
+                event: "json_schema conversion failed: \(msg)"
+            )
+        }
+        events.append("json_schema: converted schema '\(spec.name)'")
+        let result = try await jsonSchemaResponse(
+            session: session, prompt: finalPrompt, schema: responseSchema,
+            id: requestId, created: created, genOpts: genOpts,
+            promptTokens: promptTokens, streaming: isStreaming,
+            includeUsage: includeUsage,
             requestBody: requestBodyString, events: events
         )
         return (result.response, result.trace)
@@ -310,6 +339,146 @@ private func mcpAutoExecuteResponse(
                 requestBody: requestBody,
                 responseBody: captureTruncatedLogBody(body, enabled: serverState.config.debug),
                 events: events + ["mcp non-stream finish_reason=\(finishReason)"]
+            )
+        )
+    }
+}
+
+// MARK: - JSON Schema Constrained Response
+
+/// Generate a response constrained by a caller-supplied JSON Schema.
+/// Uses FoundationModels' `respond(to:generating:)` with a `GenerationSchema`
+/// so the output is guaranteed to conform. For streaming requests, the
+/// constrained output is collected then delivered as an SSE burst.
+private func jsonSchemaResponse(
+    session: LanguageModelSession,
+    prompt: String,
+    schema: GenerationSchema,
+    id: String,
+    created: Int,
+    genOpts: GenerationOptions,
+    promptTokens: Int,
+    streaming: Bool,
+    includeUsage: Bool,
+    requestBody: String?,
+    events: [String]
+) async throws -> (response: Response, trace: ChatRequestTrace) {
+    var events = events
+
+    let srvRetryMax = serverState.config.retryEnabled ? serverState.config.retryCount : 0
+    let generatedContent: GeneratedContent
+    do {
+        generatedContent = try await withRetry(maxRetries: srvRetryMax) {
+            try await session.respond(to: prompt, generating: schema, includeSchemaInPrompt: true, options: genOpts)
+        }
+    } catch {
+        let classified = ApfelError.classify(error)
+        if case .refusal(let explanation) = classified {
+            if streaming {
+                return await refusalStreamingResponse(
+                    id: id, created: created, promptTokens: promptTokens,
+                    refusal: explanation, includeUsage: includeUsage,
+                    requestBody: requestBody,
+                    events: events + ["json_schema refusal: \(classified.cliLabel)"]
+                )
+            }
+            return await refusalNonStreamingResponse(
+                id: id, created: created, promptTokens: promptTokens,
+                refusal: explanation, requestBody: requestBody,
+                events: events + ["json_schema refusal: \(classified.cliLabel)"]
+            )
+        }
+        // decodingFailure from constrained generation is a 400 (bad schema / unsatisfiable)
+        let isDecodingFailure: Bool
+        if case .decodingFailure = classified { isDecodingFailure = true } else { isDecodingFailure = false }
+        let msg = classified.openAIMessage
+        return chatFailure(
+            status: .init(code: isDecodingFailure ? 400 : classified.httpStatusCode),
+            message: msg,
+            type: isDecodingFailure ? "invalid_request_error" : classified.openAIType,
+            stream: streaming,
+            requestBody: requestBody,
+            events: events,
+            event: "json_schema generation failed: \(classified.cliLabel)"
+        )
+    }
+
+    let deliveredContent: String
+    do {
+        let jsonData = try JSONEncoder().encode(generatedContent)
+        deliveredContent = String(data: jsonData, encoding: .utf8) ?? "{}"
+    } catch {
+        return chatFailure(
+            status: .internalServerError,
+            message: "Failed to serialize generated content: \(error.localizedDescription)",
+            type: "server_error",
+            stream: streaming,
+            requestBody: requestBody,
+            events: events,
+            event: "json_schema serialization failed: \(error)"
+        )
+    }
+    let completionTokens = await TokenCounter.shared.count(deliveredContent)
+    let finishReason = "stop"
+    events.append("json_schema: generated \(deliveredContent.count) chars")
+
+    if streaming {
+        var chunks: [String] = [
+            sseDataLine(sseRoleChunk(id: id, created: created)),
+            sseDataLine(sseContentChunk(id: id, created: created, content: deliveredContent)),
+            sseDataLine(ChatCompletionChunk(
+                id: id, object: "chat.completion.chunk", created: created, model: modelName,
+                choices: [.init(index: 0, delta: .init(role: nil, content: nil, tool_calls: nil), finish_reason: finishReason, logprobs: nil)],
+                usage: nil
+            )),
+        ]
+        if includeUsage {
+            chunks.append(sseDataLine(sseUsageChunk(id: id, created: created, promptTokens: promptTokens, completionTokens: completionTokens)))
+        }
+        chunks.append(sseDone)
+        let body = chunks.joined()
+        var headers = HTTPFields()
+        headers[.contentType] = "text/event-stream"
+        headers[.cacheControl] = "no-cache"
+        headers[.init("Connection")!] = "keep-alive"
+        let response = Response(status: .ok, headers: headers,
+                                 body: .init(byteBuffer: ByteBuffer(string: body)))
+        return (
+            response,
+            ChatRequestTrace(
+                stream: true,
+                estimatedTokens: promptTokens + completionTokens,
+                error: nil,
+                requestBody: requestBody,
+                responseBody: captureTruncatedLogBody(body, enabled: serverState.config.debug),
+                events: events + ["json_schema sse finish_reason=\(finishReason)"]
+            )
+        )
+    } else {
+        let responseMessage = OpenAIMessage(role: "assistant", content: .text(deliveredContent))
+        let payload = ChatCompletionResponse(
+            id: id,
+            object: "chat.completion",
+            created: created,
+            model: modelName,
+            choices: [.init(index: 0, message: responseMessage, finish_reason: finishReason, logprobs: nil)],
+            usage: .init(prompt_tokens: promptTokens, completion_tokens: completionTokens,
+                         total_tokens: promptTokens + completionTokens)
+        )
+        let body = jsonString(payload)
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json"
+        let response = Response(status: .ok, headers: headers,
+                                 body: .init(byteBuffer: ByteBuffer(string: body)))
+        return (
+            response,
+            ChatRequestTrace(
+                stream: false,
+                estimatedTokens: promptTokens + completionTokens,
+                error: nil,
+                requestBody: requestBody,
+                responseBody: captureTruncatedLogBody(body, enabled: serverState.config.debug),
+                events: events + ["json_schema non-stream finish_reason=\(finishReason)"]
             )
         )
     }

--- a/Sources/SchemaConverter.swift
+++ b/Sources/SchemaConverter.swift
@@ -104,6 +104,14 @@ enum SchemaConverter {
         return (native, fallback)
     }
 
+    /// Convert a caller-supplied JSON Schema into a GenerationSchema for
+    /// constrained generation via `response_format: { type: "json_schema" }`.
+    static func convertResponseSchema(json: String, name: String) throws -> GenerationSchema {
+        let ir = try SchemaParser.parse(json: json, name: name)
+        let dynSchema = try dynamicSchema(from: ir)
+        return try GenerationSchema(root: dynSchema, dependencies: [])
+    }
+
     /// Convert a tool call's arguments JSON string to GeneratedContent.
     /// Returns nil on failure instead of crashing the process.
     static func makeArguments(_ json: String) -> GeneratedContent? {

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -183,12 +183,27 @@ func runApfelCorePublicAPIUsageTests() {
         // ResponseFormat
         let fmt = ResponseFormat(type: "text")
         let _: String = fmt.type
+        let _: JSONSchemaResponseParam? = fmt.json_schema
         let _ = requireSendable(fmt)
         let _: Set<ResponseFormat> = [fmt]
         try assertEqual(
             try JSONDecoder().decode(ResponseFormat.self, from: Data(#"{"type":"text"}"#.utf8)),
             fmt
         )
+
+        // JSONSchemaResponseParam
+        let schemaParam = JSONSchemaResponseParam(
+            name: "test",
+            strict: true,
+            schema: RawJSON(rawValue: #"{"type":"object"}"#)
+        )
+        let _: String = schemaParam.name
+        let _: Bool? = schemaParam.strict
+        let _: RawJSON = schemaParam.schema
+        let _ = requireSendable(schemaParam)
+        let _: Set<JSONSchemaResponseParam> = [schemaParam]
+        let fmtWithSchema = ResponseFormat(type: "json_schema", json_schema: schemaParam)
+        try assertEqual(fmtWithSchema.json_schema?.name, "test")
 
         // StreamOptions
         let opts = StreamOptions(include_usage: true)

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -337,6 +337,44 @@ func runChatRequestValidatorTests() {
             .invalidParameterValue("'x_context_max_turns' must be a positive integer, got 0")
         )
     }
+
+    // MARK: - json_schema response_format validation
+
+    test("validator rejects json_schema without json_schema field") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_schema"}}"#
+        )
+        if case .invalidParameterValue(let msg) = ChatRequestValidator.validate(request) {
+            try assertTrue(msg.contains("json_schema"))
+        } else {
+            throw TestFailure("expected .invalidParameterValue for json_schema without spec")
+        }
+    }
+
+    test("validator rejects json_schema with empty name") {
+        let json = #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_schema","json_schema":{"name":"","schema":{"type":"object"}}}}"#
+        let request = try decode(ChatCompletionRequest.self, from: json)
+        if case .invalidParameterValue(let msg) = ChatRequestValidator.validate(request) {
+            try assertTrue(msg.contains("name"))
+        } else {
+            throw TestFailure("expected .invalidParameterValue for empty json_schema name")
+        }
+    }
+
+    test("validator accepts valid json_schema response_format") {
+        let json = #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_schema","json_schema":{"name":"test","schema":{"type":"object","properties":{"x":{"type":"string"}}}}}}"#
+        let request = try decode(ChatCompletionRequest.self, from: json)
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator still accepts json_object response_format") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_object"}}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
 }
 
 private func unwrap<T>(_ value: T?, _ message: String) throws -> T {

--- a/Tests/apfelTests/OpenAIWireFormatTests.swift
+++ b/Tests/apfelTests/OpenAIWireFormatTests.swift
@@ -284,11 +284,78 @@ func runOpenAIWireFormatTests() {
     test("ResponseFormat decodes type=json_object") {
         let fmt = try decode(ResponseFormat.self, from: #"{"type":"json_object"}"#)
         try assertEqual(fmt.type, "json_object")
+        try assertNil(fmt.json_schema)
     }
 
     test("ResponseFormat decodes type=text") {
         let fmt = try decode(ResponseFormat.self, from: #"{"type":"text"}"#)
         try assertEqual(fmt.type, "text")
+        try assertNil(fmt.json_schema)
+    }
+
+    test("ResponseFormat decodes type=json_schema with full spec") {
+        let json = #"""
+        {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "math_response",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {"type": "number"},
+                "explanation": {"type": "string"}
+              },
+              "required": ["result", "explanation"],
+              "additionalProperties": false
+            }
+          }
+        }
+        """#
+        let fmt = try decode(ResponseFormat.self, from: json)
+        try assertEqual(fmt.type, "json_schema")
+        try assertNotNil(fmt.json_schema)
+        try assertEqual(fmt.json_schema?.name, "math_response")
+        try assertEqual(fmt.json_schema?.strict, true)
+        try assertNotNil(fmt.json_schema?.schema)
+        try assertTrue(fmt.json_schema!.schema.value.contains("result"))
+    }
+
+    test("ResponseFormat decodes json_schema without strict field") {
+        let json = #"""
+        {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "simple",
+            "schema": {"type": "object", "properties": {}}
+          }
+        }
+        """#
+        let fmt = try decode(ResponseFormat.self, from: json)
+        try assertEqual(fmt.type, "json_schema")
+        try assertEqual(fmt.json_schema?.name, "simple")
+        try assertNil(fmt.json_schema?.strict)
+    }
+
+    test("ChatCompletionRequest decodes json_schema response_format") {
+        let json = #"""
+        {
+          "model": "apple-foundationmodel",
+          "messages": [{"role": "user", "content": "hi"}],
+          "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+              "name": "test_schema",
+              "strict": true,
+              "schema": {"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]}
+            }
+          }
+        }
+        """#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertEqual(req.response_format?.type, "json_schema")
+        try assertEqual(req.response_format?.json_schema?.name, "test_schema")
+        try assertEqual(req.response_format?.json_schema?.strict, true)
     }
 
     // MARK: - ContextStrategy raw values (wire contract for x_context_strategy)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #167.

## Root cause

The OpenAI-compatible server only handled `response_format: { type: "json_object" }` via prompt injection + fence stripping - no schema enforcement, no `json_schema` support. FoundationModels already has the machinery for guaranteed structured outputs via `DynamicGenerationSchema`, and apfel already has the conversion pipeline (`SchemaParser` -> `SchemaIR` -> `DynamicGenerationSchema`) for tool-call arguments - it just was not wired to `response_format`.

## The fix

Extends the request model, validator, schema converter, and handler to support the full OpenAI `json_schema` response format variant:

1. **`Sources/Core/OpenAIModels.swift`** - Added `JSONSchemaResponseParam` struct (name/strict/schema) and an optional `json_schema` field on `ResponseFormat`. Backward-compatible: existing `json_object` and `text` callers are unaffected.

2. **`Sources/Core/ChatRequestValidator.swift`** - Validates that `type: "json_schema"` requests include the `json_schema` object with a non-empty `name`.

3. **`Sources/SchemaConverter.swift`** - Exposed `convertResponseSchema(json:name:)` that reuses the existing `SchemaParser` -> `dynamicSchema` -> `GenerationSchema` pipeline.

4. **`Sources/Handlers.swift`** - New `jsonSchemaResponse` handler that:
   - Converts the caller's JSON Schema to a `GenerationSchema`
   - Calls `session.respond(to:generating:includeSchemaInPrompt:options:)` for guaranteed-conforming output
   - Serializes `GeneratedContent` back to JSON for the OpenAI wire format
   - Maps `decodingFailure` to HTTP 400 (`invalid_request_error`) per the issue spec
   - For streaming requests, collects the constrained output then delivers as an SSE burst (same pattern as MCP auto-execute)

## Test coverage

- Added 4 wire-format tests in `OpenAIWireFormatTests.swift`: full json_schema decode, without strict, backward compat for json_object/text, ChatCompletionRequest round-trip
- Added 4 validator tests in `OpenAIModelsTests.swift`: rejects missing spec, rejects empty name, accepts valid json_schema, backward compat for json_object
- Added 3 public API surface checks in `ApfelCorePublicAPIUsageTests.swift`: JSONSchemaResponseParam fields, Sendable/Hashable, ResponseFormat with schema

## What I verified (static only)

- Wire-format decoding tests cover backward compatibility (existing `json_object` and `text` still decode identically)
- Validator tests cover both rejection and acceptance paths
- `ResponseFormat` init is backward-compatible (json_schema defaults to nil)
- Schema conversion reuses the existing, tested `SchemaParser` + `dynamicSchema` pipeline
- Handler follows the same response-building patterns as `mcpAutoExecuteResponse` and `nonStreamingResponse`
- Swift 6 concurrency: no data races introduced, all new types are Sendable
- Diff limited to model types, validator, schema converter, handler, and tests - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. Specifically:
  - The exact `session.respond(to:generating:includeSchemaInPrompt:options:)` signature and return type
  - Whether `JSONEncoder().encode(generatedContent)` produces the raw JSON callers expect (not a FoundationModels wrapper format)
  - Whether the schema conversion handles all edge cases the OpenAI API allows
  - Integration test with a real model generating against a schema

## Anything that seemed suspicious

Nothing - straightforward feature request from the repo owner, well-scoped to the existing schema conversion pipeline.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_017U37Zhx3jVyAbbeKksd9nZ)_