### PR TITLE
fix(context): bound summary generation and verify budget post-assembly (#175)

### DIFF
--- a/Sources/Summarizer.swift
+++ b/Sources/Summarizer.swift
@@ -44,8 +44,13 @@ func trimWithSummary(
             base: base, history: history, final: final, budget: budget)
     }
 
+    // Compute token budget for the summary: total budget minus base, recent, and final
+    let recentAssembly = assembleTranscriptEntries(base: base, history: recentEntries, final: final)
+    let usedTokens = await TokenCounter.shared.count(entries: recentAssembly)
+    let summaryBudget = max(50, budget - usedTokens)
+
     // Summarize using the on-device model
-    let summaryText = await generateSummary(oldText, permissive: permissive)
+    let summaryText = await generateSummary(oldText, permissive: permissive, maxTokens: summaryBudget)
     guard let summaryText else {
         return await trimNewestFirst(
             base: base, history: history, final: final, budget: budget)
@@ -54,6 +59,12 @@ func trimWithSummary(
     let segment = Transcript.TextSegment(content: "[Summary of prior conversation]: \(summaryText)")
     let summaryEntry = Transcript.Entry.response(
         Transcript.Response(assetIDs: [], segments: [.text(segment)]))
+
+    let candidate = assembleTranscriptEntries(base: base, history: [summaryEntry] + recentEntries, final: final)
+    guard await fitsTranscriptBudget(candidate, budget: budget) else {
+        return await trimNewestFirst(
+            base: base, history: history, final: final, budget: budget)
+    }
 
     return assembleTranscriptEntries(base: base, history: [summaryEntry] + recentEntries)
 }
@@ -76,14 +87,15 @@ private func renderEntries(_ entries: [Transcript.Entry]) -> String {
     }.joined(separator: "\n")
 }
 
-private func generateSummary(_ text: String, permissive: Bool = false) async -> String? {
+private func generateSummary(_ text: String, permissive: Bool = false, maxTokens: Int = 200) async -> String? {
     let model = makeModel(permissive: permissive)
     let session = LanguageModelSession(
         model: model,
         instructions: "Summarize the following conversation in 2-3 sentences. Be concise."
     )
     do {
-        let response = try await session.respond(to: text)
+        let options = GenerationOptions(maximumResponseTokens: maxTokens)
+        let response = try await session.respond(to: text, options: options)
         let summary = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
         return summary.isEmpty ? nil : summary
     } catch {

--- a/Tests/integration/openai_client_test.py
+++ b/Tests/integration/openai_client_test.py
@@ -517,6 +517,75 @@ def test_omitted_max_tokens_does_not_reference_a_default_constant():
         )
 
 
+# MARK: - Summarize strategy budget (#175)
+
+def test_summarize_strategy_source_passes_generation_options():
+    """Source-level lock for #175. generateSummary() in Summarizer.swift must
+    pass GenerationOptions with maximumResponseTokens to session.respond(),
+    and the result must be checked against the budget before returning.
+    """
+    import os
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    with open(os.path.join(repo_root, "Sources", "Summarizer.swift")) as f:
+        src = f.read()
+    assert "GenerationOptions" in src, (
+        "Summarizer.swift must use GenerationOptions to cap summary length"
+    )
+    assert "maximumResponseTokens" in src, (
+        "Summarizer.swift must pass maximumResponseTokens to bound the summary"
+    )
+    assert "fitsTranscriptBudget" in src, (
+        "Summarizer.swift must verify the assembled result fits the budget"
+    )
+
+
+def test_summarize_strategy_respects_token_budget():
+    """Regression guard for #175. The summarize context strategy must never
+    return a transcript that exceeds its token budget. Before the fix,
+    generateSummary() passed no maximumResponseTokens and the assembled
+    result was never checked against the budget - an unbounded summary could
+    cascade into contextOverflow downstream.
+
+    This test builds a multi-turn history long enough to trigger
+    summarization (history.count > 2), then requests a completion with
+    x_context_strategy: "summarize". A successful HTTP 200 with valid
+    content proves the strategy stayed within budget. A 500 or empty
+    response would indicate the old budget-overflow path.
+    """
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me about the history of computing. Be detailed."},
+        {"role": "assistant", "content": "Computing has a rich history spanning centuries. Charles Babbage designed the Analytical Engine in the 1830s. Ada Lovelace wrote the first algorithm. Alan Turing formalized computation in 1936. ENIAC was built in 1945. The transistor was invented in 1947. Integrated circuits followed in the 1950s. Personal computers emerged in the 1970s. The internet connected the world in the 1990s."},
+        {"role": "user", "content": "What about the 2000s and beyond?"},
+        {"role": "assistant", "content": "The 2000s saw the rise of smartphones with the iPhone in 2007. Cloud computing became mainstream. Social media transformed communication. Machine learning and deep learning advanced rapidly. GPUs enabled massive parallel computation. Large language models emerged in the 2020s. Quantum computing research progressed."},
+        {"role": "user", "content": "Summarize all of this in one sentence."},
+    ]
+    resp = httpx.post(
+        f"{BASE_URL}/chat/completions",
+        json={
+            "model": MODEL,
+            "messages": messages,
+            "max_tokens": 128,
+            "x_context_strategy": "summarize",
+        },
+        timeout=120,
+    )
+    assert resp.status_code == 200, (
+        f"summarize strategy must not overflow budget; got HTTP {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    choice = body["choices"][0]
+    assert choice["finish_reason"] in {"stop", "length"}, (
+        f"finish_reason must be stop or length, got {choice['finish_reason']!r}"
+    )
+    content = choice["message"].get("content")
+    assert isinstance(content, str) and content, (
+        f"summarize strategy must produce non-empty content, got {content!r}"
+    )
+    assert body["usage"]["prompt_tokens"] > 0
+    assert body["usage"]["completion_tokens"] > 0
+
+
 # MARK: - Health
 
 def test_health_endpoint():


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #175.

## Root cause

The `summarize` context strategy in `Sources/Summarizer.swift` had two coupled defects that could let it return a transcript exceeding the token budget it was asked to fit. First, `generateSummary()` called `session.respond(to:)` with no `maximumResponseTokens` - the "2-3 sentences" instruction hint was unenforceable and the model could emit an arbitrarily long summary. Second, after prepending the summary entry to the recent entries, the assembled result was returned without re-checking that it fits the original budget - so an oversized summary would cascade into `contextOverflow` downstream in `ContextManager`.

## The fix

Two changes in `Summarizer.swift`, both minimal:

1. **Bound the summary generation.** Compute the remaining token budget after base + recent + final entries, then pass it as `GenerationOptions(maximumResponseTokens: summaryBudget)` to the `session.respond()` call. This aligns `generateSummary()` with every other `respond()` call in the codebase, all of which pass explicit generation options.

2. **Verify the final assembly.** After building `[summaryEntry] + recentEntries`, check `fitsTranscriptBudget(candidate, budget:)` before returning. If the summary still overflows (edge case: summary prefix text plus overhead), fall back gracefully to `trimNewestFirst` instead of returning an over-budget transcript.

## Test coverage

- Added `test_summarize_strategy_source_passes_generation_options` in `Tests/integration/openai_client_test.py` - source-level lock verifying `Summarizer.swift` uses `GenerationOptions`, `maximumResponseTokens`, and `fitsTranscriptBudget`. Runnable in CI without Apple Intelligence.
- Added `test_summarize_strategy_respects_token_budget` in `Tests/integration/openai_client_test.py` - end-to-end integration test sending a multi-turn conversation with `x_context_strategy: "summarize"` through the server and asserting HTTP 200 with valid content (not `contextOverflow`). Requires Apple Intelligence.
- Existing `ContextStrategyTests` cover the pure-data `ContextStrategy`/`ContextConfig` types.

## What I verified (static only)

- Read `Summarizer.swift` end-to-end, traced both bug paths confirmed in the issue.
- Verified every other `session.respond()` call in the codebase passes `GenerationOptions` - this was the sole outlier.
- Confirmed `fitsTranscriptBudget` and `assembleTranscriptEntries` are already available at module scope (defined in `Session.swift`).
- Confirmed `trimNewestFirst` is a safe fallback (already used by all other error paths in `trimWithSummary`).
- Swift 6 concurrency: no new shared state, no `@unchecked Sendable`, all existing actor isolation preserved.
- Diff limited to `Sources/Summarizer.swift` and `Tests/integration/openai_client_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. Issue #175 was filed by `Arthur-Ficial` (us) via the deep multi-agent bug-hunt workflow. The suggested fixes in the issue body align with what the code analysis shows.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTuS6Za8vA2MGseMoPmFK)_