### PR TITLE
fix(tokens): fallback counter accounts for tool args and definitions (#176)

### DIFF
--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -102,6 +102,11 @@ actor TokenCounter {
             switch entry {
             case .instructions(let i):
                 for seg in i.segments { if case .text(let t) = seg { total += max(1, t.content.count / 4) } }
+                for def in i.toolDefinitions {
+                    total += max(1, def.name.count / 4)
+                    total += max(1, def.description.count / 4)
+                    total += 20
+                }
             case .prompt(let p):
                 for seg in p.segments { if case .text(let t) = seg { total += max(1, t.content.count / 4) } }
             case .response(let r):
@@ -109,7 +114,11 @@ actor TokenCounter {
             case .toolOutput(let o):
                 for seg in o.segments { if case .text(let t) = seg { total += max(1, t.content.count / 4) } }
             case .toolCalls(let tc):
-                total += tc.count * 20
+                for call in tc {
+                    total += 5
+                    total += max(1, call.toolName.count / 4)
+                    total += max(1, call.arguments.json.count / 4)
+                }
             @unknown default:
                 break
             }

--- a/Tests/apfelTests/TokenCounterFallbackTests.swift
+++ b/Tests/apfelTests/TokenCounterFallbackTests.swift
@@ -1,0 +1,44 @@
+// ============================================================================
+// TokenCounterFallbackTests.swift - Asserts fallbackCount accounts for tool
+// arguments and tool definitions (not just text segments and flat call counts).
+// Source-level checks: TokenCounter lives in the apfel target (FoundationModels),
+// so we verify the code structure rather than calling fallbackCount directly.
+// ============================================================================
+
+import Foundation
+
+func runTokenCounterFallbackTests() {
+    let src = (try? String(contentsOfFile: "Sources/TokenCounter.swift", encoding: .utf8)) ?? ""
+
+    test("fallbackCount: tool calls iterate individual calls, not flat count") {
+        try assertTrue(src.contains("for call in tc"),
+                       "fallbackCount must iterate tool calls individually, not use tc.count * N")
+        try assertTrue(!src.contains("tc.count * 20"),
+                       "fallbackCount must not use flat tc.count * 20 (ignores arguments)")
+    }
+
+    test("fallbackCount: tool call arguments are counted") {
+        try assertTrue(src.contains("call.arguments"),
+                       "fallbackCount must access call.arguments to count argument tokens")
+    }
+
+    test("fallbackCount: tool call name is counted") {
+        try assertTrue(src.contains("call.toolName.count"),
+                       "fallbackCount must count tool call name tokens")
+    }
+
+    test("fallbackCount: instructions count tool definitions") {
+        try assertTrue(src.contains("i.toolDefinitions"),
+                       "fallbackCount must iterate toolDefinitions in instructions")
+    }
+
+    test("fallbackCount: tool definition name is counted") {
+        try assertTrue(src.contains("def.name.count"),
+                       "fallbackCount must count tool definition name tokens")
+    }
+
+    test("fallbackCount: tool definition description is counted") {
+        try assertTrue(src.contains("def.description.count"),
+                       "fallbackCount must count tool definition description tokens")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -105,6 +105,7 @@ suite("ApfelErrorMessageTests") { runApfelErrorMessageTests() }
 suite("OpenAIWireFormatTests") { runOpenAIWireFormatTests() }
 suite("ApfelCorePublicAPIUsageTests") { runApfelCorePublicAPIUsageTests() }
 suite("InstallMethodTests") { runInstallMethodTests() }
+suite("TokenCounterFallbackTests") { runTokenCounterFallbackTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #176.

## Root cause

`TokenCounter.fallbackCount` (used on macOS 26.0-26.3 where `tokenCount(for:)` is unavailable) systematically undercounts when tools are in play. Two gaps:

1. **Tool-call arguments ignored.** Line 112 used a flat `tc.count * 20`, completely ignoring the `arguments` JSON payload on each `Transcript.ToolCall`. Large argument payloads (common with MCP tools) were invisible to the counter.

2. **Tool definitions in instructions ignored.** Line 103-104 only counted text segments in `.instructions` entries, skipping `toolDefinitions` entirely. Sessions with many tool definitions (each carrying a name, description, and parameter schema) appeared far smaller than they actually are.

Both gaps cause every context-trimming strategy to think the transcript fits when it doesn't, risking overflow of the real 4096-token window.

## The fix

**Tool calls** (`Sources/TokenCounter.swift:116-121`): replaced the flat `tc.count * 20` with per-call iteration that counts `toolName` characters, `arguments.json` byte count, and a small structural overhead - all divided by 4, matching the chars/4 approximation used throughout `fallbackCount`.

**Tool definitions** (`Sources/TokenCounter.swift:105-109`): added a loop over `i.toolDefinitions` that counts each definition's `name` and `description` plus a flat 20-token estimate for the parameter schema structure. Conservative but far better than zero.

## Test coverage

- Added `Tests/apfelTests/TokenCounterFallbackTests.swift` with 6 source-reading tests that verify the fallback counter:
  - Iterates individual tool calls (not flat `tc.count * 20`)
  - Accesses `call.arguments` for argument token counting
  - Counts `call.toolName`
  - Iterates `i.toolDefinitions` in instructions
  - Counts `def.name` and `def.description`
- Registered the suite in `Tests/apfelTests/main.swift`.

## What I verified (static only)

- Diff is limited to `Sources/TokenCounter.swift`, `Tests/apfelTests/TokenCounterFallbackTests.swift`, and `Tests/apfelTests/main.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.
- The fix follows the existing chars/4 approximation pattern used for all other entry types.
- Swift 6 concurrency: no new sendability concerns - `fallbackCount` is a private method on the `TokenCounter` actor.
- No `@unchecked Sendable`, no new dependencies, no changes to forbidden files.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. Specifically, `call.arguments.json.count` assumes `GeneratedContent.json` returns a type with a `.count` property (likely `Data` or `String`) - if the API shape differs slightly, the compiler will flag it. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by our own deep bug-hunt workflow. The issue body's suggested fix snippets were used as directional guidance only; the implementation was written independently.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_013DRpSMCqpUTjTE3dUZ7itJ)_