### PR TITLE
fix(tool-calling): repair unclosed bracket in model tool call JSON (#187)

### DIFF
--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -81,6 +81,10 @@ public enum ToolCallHandler {
             if let calls = parseToolCallJSON(candidate), !calls.isEmpty {
                 return calls
             }
+            if let repaired = repairUnclosedBrackets(candidate),
+               let calls = parseToolCallJSON(repaired), !calls.isEmpty {
+                return calls
+            }
         }
         return nil
     }
@@ -184,6 +188,39 @@ public enum ToolCallHandler {
         if trimmed.hasPrefix("{") || trimmed.hasPrefix("[") { return s }
         // Plain string — wrap as {"value": "..."} using the JSON encoder for escaping.
         return jsonObjectString(["value": trimmed]) ?? "{}"
+    }
+
+    /// The model sometimes omits the closing `]` for the tool_calls array,
+    /// producing invalid JSON. This repair inserts missing brackets (string-aware)
+    /// before the outermost closing `}` so the candidate can be re-parsed.
+    private static func repairUnclosedBrackets(_ json: String) -> String? {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{"), trimmed.hasSuffix("}") else { return nil }
+
+        var bracketDepth = 0
+        var inString = false
+        var escaped = false
+
+        for ch in trimmed {
+            if inString {
+                if escaped { escaped = false }
+                else if ch == "\\" { escaped = true }
+                else if ch == "\"" { inString = false }
+            } else if ch == "\"" {
+                inString = true
+            } else if ch == "[" {
+                bracketDepth += 1
+            } else if ch == "]" {
+                bracketDepth -= 1
+            }
+        }
+
+        guard bracketDepth > 0 else { return nil }
+
+        let insertPos = trimmed.index(before: trimmed.endIndex)
+        var repaired = trimmed
+        repaired.insert(contentsOf: String(repeating: "]", count: bracketDepth), at: insertPos)
+        return repaired
     }
 
     private static func parseToolCallJSON(_ json: String) -> [ParsedToolCall]? {

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -77,6 +77,46 @@ func runToolCallHandlerTests() {
 
     // MARK: - Edge cases (bug fixes)
 
+    test("detects tool call with missing closing bracket (#187)") {
+        let response = #"{"tool_calls": [{"id": "call_123", "type": "function", "function": {"name": "HassTurnOff", "arguments": {"entity_id": "office_light"}}}}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "HassTurnOff")
+        try assertEqual(result!.first?.id, "call_123")
+        try assertTrue(result!.first!.argumentsString.contains("office_light"))
+    }
+
+    test("detects tool call with missing bracket and string arguments (#187)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"Vienna\"}"}}}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "get_weather")
+        try assertEqual(result!.first?.argumentsString, #"{"city":"Vienna"}"#)
+    }
+
+    test("detects tool call with missing bracket after preamble (#187)") {
+        let response = "Sure, I'll turn that off.\n" + #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "toggle", "arguments": "{}"}}}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "toggle")
+    }
+
+    test("detects multiple tool calls with missing bracket (#187)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn1", "arguments": "{}"}}, {"id": "c2", "type": "function", "function": {"name": "fn2", "arguments": "{}"}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 2)
+    }
+
+    test("repairs missing bracket with multiple tool calls (#187)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn1", "arguments": "{}"}}, {"id": "c2", "type": "function", "function": {"name": "fn2", "arguments": "{}"}}}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 2)
+        try assertEqual(result!.first?.name, "fn1")
+        try assertEqual(result!.last?.name, "fn2")
+    }
+
     test("handles trailing backticks without crash") {
         try assertNil(ToolCallHandler.detectToolCall(in: "```"))
     }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #187.

## Root cause

Apple's FoundationModels model sometimes emits tool call JSON without the closing `]` for the `tool_calls` array. For example, the model outputs `{"tool_calls": [{"id": "call_123", ...}}}}` instead of `{"tool_calls": [{"id": "call_123", ...}]}`. `JSONSerialization` rejects this malformed JSON, so `ToolCallHandler.detectToolCall` returns nil. The raw JSON then leaks through as `message.content` with `finish_reason: "stop"` instead of being structured as `message.tool_calls` with `finish_reason: "tool_calls"`.

## The fix

Adds a `repairUnclosedBrackets` private method to `ToolCallHandler` that performs a string-aware scan of bracket depth (`[`/`]`). When bracket depth is positive (more `[` than `]` outside of quoted strings), the missing `]` characters are inserted before the outermost closing `}`. This repair step is only attempted after normal JSON parsing fails, so well-formed responses take the existing fast path with zero overhead.

## Test coverage

- Added 5 tests in `Tests/apfelTests/ToolCallHandlerTests.swift`:
  - `detects tool call with missing closing bracket (#187)` - exact reproducer from the issue (arguments-as-object, single tool call, missing `]`)
  - `detects tool call with missing bracket and string arguments (#187)` - arguments-as-string variant
  - `detects tool call with missing bracket after preamble (#187)` - preamble text before the JSON
  - `detects multiple tool calls with missing bracket (#187)` - validates existing valid-JSON multi-call still works
  - `repairs missing bracket with multiple tool calls (#187)` - two tool calls with missing `]`
- Existing tests (clean JSON, markdown blocks, preamble text, nil cases) still cover the happy paths and ensure no false positives from the repair.

## What I verified (static only)

- Read every line of `ToolCallHandler.detectToolCall`, `extractCandidates`, and `parseToolCallJSON` to trace the failure path.
- Confirmed the balanced-brace extraction (method 3 in `extractCandidates`) only tracks `{}`/`}` and ignores `[`/`]`, which is why it can't fix this alone.
- Verified the repair function is string-aware (brackets inside JSON strings are ignored), handles nested brackets in arguments objects, and returns nil when brackets are already balanced.
- Swift 6 concurrency: no data races introduced - the new method is a pure static function with no shared state.
- Diff limited to `Sources/Core/ToolCallHandler.swift` and `Tests/apfelTests/ToolCallHandlerTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug report with a clear reproducer. The reporter's curl command and response output are consistent with the code path analysis.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFemuQeoYg5niRwGhA6GE3)_