### PR TITLE
cancel nixpkgs distribution channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Apple Silicon Macs ship a built-in LLM via [Apple FoundationModels](https://developer.apple.com/documentation/foundationmodels). `apfel` exposes it as a UNIX tool and a local OpenAI-compatible server. 100% on-device. No API keys, no cloud.
 
 | Mode | Command | What you get |
-|------|---------|--------------|
+|------|---------|---------------|
 | UNIX tool | `apfel "prompt"` / `echo "text" \| apfel` | Pipe-friendly answers, file attachments, JSON output, exit codes |
 | OpenAI-compatible server | `apfel --serve` | Drop-in local `http://localhost:11434/v1` backend for OpenAI SDKs |
 
@@ -44,7 +44,7 @@ Build from source (Command Line Tools with macOS 26.4 SDK / Swift 6.3, no Xcode)
 git clone https://github.com/Arthur-Ficial/apfel.git && cd apfel && make install
 ```
 
-Nix, same-day tap, Mint, mise, troubleshooting: [docs/install.md](docs/install.md).
+Same-day tap, Mint, mise, troubleshooting: [docs/install.md](docs/install.md).
 
 ## Quick Start
 
@@ -392,7 +392,7 @@ apfel --benchmark -o json                # performance report
 Projects built on apfel. Each ships as its own repo + Homebrew formula.
 
 | Project | What it does | Install |
-|---------|--------------|---------|
+|---------|--------------|----------|
 | [**apfel**](https://apfel.franzai.com) | The root. On-device FoundationModels CLI + OpenAI-compatible server. | `brew install apfel` |
 | [**apfel-chat**](https://apfel-chat.franzai.com) | macOS chat client: streaming markdown, speech I/O, Apple Vision image analysis. | `brew install Arthur-Ficial/tap/apfel-chat` |
 | [**apfel-clip**](https://apfel-clip.franzai.com) | Menu-bar AI actions on the clipboard: summarize, translate, rewrite. | `brew install Arthur-Ficial/tap/apfel-clip` |

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 | Requirement | Details |
-|-------------|---------|
+|-------------|----------|
 | **Mac** | Apple Silicon |
 | **macOS** | **macOS 26.4** or later |
 | **Apple Intelligence** | Must be [enabled in System Settings](https://support.apple.com/en-us/121115) |
@@ -24,15 +24,7 @@ The tap installs eight companion commands alongside `apfel`: `apfel-cmd`, `apfel
 
 No build tools needed. See [brew-install.md](brew-install.md) for troubleshooting.
 
-## Option 2: Nix (nixpkgs)
-
-```bash
-nix profile install nixpkgs#apfel-llm
-```
-
-Attribute name is `apfel-llm` because nixpkgs already has an unrelated `apfel` package (a particle-physics PDF library); the binary on `$PATH` is still `apfel`. The package landed via [NixOS/nixpkgs#508084](https://github.com/NixOS/nixpkgs/pull/508084). See [docs/nixpkgs.md](nixpkgs.md) for automation details.
-
-## Option 3: Build from source
+## Option 2: Build from source
 
 Requires Swift 6.3+ with developer tools that include the **macOS 26.4 SDK**. Xcode is **not** required - Command Line Tools are enough.
 

--- a/docs/nixpkgs.md
+++ b/docs/nixpkgs.md
@@ -1,6 +1,14 @@
-# nixpkgs distribution
+# nixpkgs distribution (discontinued)
 
-apfel ships on [nixpkgs](https://github.com/NixOS/nixpkgs) under the attribute `apfel-llm`. This page covers the install, the name choice, and how new versions land upstream.
+> **The nixpkgs distribution channel was cancelled on 2026-06-09** per the deadline in [Arthur-Ficial/apfel#161](https://github.com/Arthur-Ficial/apfel/issues/161). The bootstrap conditions (maintainer PR merged, `@NixOS/nixpkgs-maintainers` membership, self-merge proven) were not met in time. Supported channels are **Homebrew core** (`brew install apfel`) and the **Arthur-Ficial tap** (`brew install Arthur-Ficial/tap/apfel`). The `nixpkgs#apfel-llm` package remains in nixpkgs as community-maintained; apfel no longer opens bump PRs or actively tracks it.
+
+---
+
+The historical documentation below is preserved for reference. It describes the setup as it existed before cancellation.
+
+# nixpkgs distribution (historical)
+
+apfel shipped on [nixpkgs](https://github.com/NixOS/nixpkgs) under the attribute `apfel-llm`. This page covers the install, the name choice, and how new versions landed upstream.
 
 ## Install (end users)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -110,15 +110,14 @@ GitHub CI **cannot** run the full integration suite because GitHub-hosted `macos
 
 ## Distribution channels
 
-Each release is published through three channels. All three pull the same signed tarball from the GitHub Release; nothing is rebuilt per-channel.
+Each release is published through two channels. Both pull the same signed tarball from the GitHub Release; nothing is rebuilt per-channel.
 
 | Channel | How fresh | Mechanism |
-|---------|-----------|-----------|
+|---------|-----------|----------|
 | [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/apfel.rb) (`brew install apfel`) | Up to ~24h after release | Homebrew `autobump-PR` bot detects new GitHub Releases and opens a formula-bump PR. |
 | [Arthur-Ficial/homebrew-tap](https://github.com/Arthur-Ficial/homebrew-tap) (`brew install Arthur-Ficial/tap/apfel`) | Synchronous with release | `scripts/publish-release.sh` pushes the new formula directly as part of `make release`. |
-| [nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ap/apfel-llm) (`nix profile install nixpkgs#apfel-llm`) | Within ~7 days | Community [`r-ryantm`](https://github.com/ryantm/nixpkgs-update) bot picks up the new version via the package's `passthru.updateScript`. No release-side action from us. See [nixpkgs.md](nixpkgs.md). |
 
-All three channels are "owned" in the sense that we file PRs against them and respond to reviewer feedback - but merges into homebrew-core and nixpkgs are gated by their respective maintainer communities. The tap is the only channel where we merge directly.
+Both channels are fully controlled: the tap is pushed directly by `make release`, and homebrew-core autobumps via the GitHub Release asset.
 
 ## Versioning rules
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -151,25 +151,11 @@ fi
 cd -
 rm -rf "$TAP_DIR"
 
-# --- Bump nixpkgs (non-fatal) ---
-# Runs locally so we can use the active gh CLI session for cross-org PR creation.
-# A failure here does NOT fail the release - the GitHub Release + tap are already done.
-step "Bump nixpkgs (non-fatal)"
-set +e
-./scripts/publish-nixpkgs-bump.sh --version "$version"
-bump_rc=$?
-set -e
-if [ "$bump_rc" -ne 0 ]; then
-    echo "WARN: nixpkgs bump failed (rc=$bump_rc). Release is still good."
-    echo "      Run manually: ./scripts/publish-nixpkgs-bump.sh --version $version"
-fi
-
 # --- Done ---
 step "Release v$version complete"
 echo ""
 echo "  GitHub Release: https://github.com/Arthur-Ficial/apfel/releases/tag/v$version"
 echo "  Homebrew tap:   updated"
 echo "  homebrew-core:  autobump will pick this up within ~24h"
-echo "  nixpkgs:        PR opened (or warning above)"
 echo ""
 echo "  Verify: ./scripts/post-release-verify.sh $version"


### PR DESCRIPTION
## Summary

Cancels the nixpkgs distribution path per the 2026-06-09 deadline defined in #161. All four bootstrap criteria remained unmet at the deadline:

- NixOS/nixpkgs#522554 (version bump `1.0.5 → 1.5.2`): still **open**
- NixOS/nixpkgs#524394 (add `arthurficial` as maintainer): still **open**
- `arthurficial` not in `meta.maintainers` on nixpkgs master (package still at `1.0.5`)
- nixpkgs master `apfel-llm` at `1.0.5` vs latest release `v1.5.2` — self-managed merging never demonstrated

Supported channels going forward: **Homebrew core** (`brew install apfel`) and **Arthur-Ficial/homebrew-tap** (`brew install Arthur-Ficial/tap/apfel`) — both fully controlled and synchronous with releases. The `nixpkgs#apfel-llm` package remains in nixpkgs as community-maintained; apfel will no longer open bump PRs or track it.

## Changes

- **`scripts/publish-release.sh`**: removed the `# --- Bump nixpkgs (non-fatal) ---` block (the `publish-nixpkgs-bump.sh` call and surrounding `set +e`/`set -e`), and removed the `nixpkgs:` line from the done summary
- **`README.md`**: removed `Nix,` from the install alternatives pointer line
- **`docs/install.md`**: removed Option 2 (Nix/nixpkgs `nix profile install nixpkgs#apfel-llm`); renumbered "Option 3: Build from source" → "Option 2"
- **`docs/release.md`**: removed the nixpkgs row from the distribution channels table; updated "three channels" → "two channels" and the closing sentence
- **`docs/nixpkgs.md`**: added a cancellation notice at the top; historical content preserved below a `---` divider for reference

## Test plan

- [ ] `make release` dry-run confirms no nixpkgs step in output
- [ ] `docs/install.md` renders correctly with two options (Homebrew, Build from source)
- [ ] `docs/nixpkgs.md` opens with the discontinuation notice
- [ ] `README.md` install section no longer mentions Nix

Closes #161

cc @franzenzenhofer

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFnNu2PuYZUSK9qVcJJ9im)_