### PR TITLE
Handle function-name string tool calls

### DIFF
--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -231,13 +231,25 @@ public enum ToolCallHandler {
 
         var result: [ParsedToolCall] = []
         for call in rawCalls {
-            guard let id = call["id"] as? String,
-                  let fn = call["function"] as? [String: Any],
-                  let name = fn["name"] as? String else { continue }
+            guard let id = call["id"] as? String else { continue }
+
+            let name: String
+            let rawArguments: Any?
+            if let fn = call["function"] as? [String: Any],
+               let fnName = fn["name"] as? String {
+                name = fnName
+                rawArguments = fn["arguments"]
+            } else if let fnName = call["function"] as? String {
+                name = fnName
+                rawArguments = call["arguments"]
+            } else {
+                continue
+            }
+
             let args: String
-            if let s = fn["arguments"] as? String {
+            if let s = rawArguments as? String {
                 args = ensureJSONArguments(s)
-            } else if let obj = fn["arguments"],
+            } else if let obj = rawArguments,
                       let data = try? JSONSerialization.data(withJSONObject: obj),
                       let s = String(data: data, encoding: .utf8) {
                 args = s

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -48,6 +48,13 @@ func runToolCallHandlerTests() {
         try assertNotNil(result)
         try assertEqual(result!.first?.argumentsString, "{\"key\":\"val\"}")
     }
+    test("parses function name string shape with sibling arguments") {
+        let response = #"{"tool_calls": [{"id": "call_unique1", "type": "function", "function": "get_current_conditions", "arguments": "{\"latitude\": 37.7749, \"longitude\": -122.4194}"}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "get_current_conditions")
+        try assertEqual(result!.first?.argumentsString, "{\"latitude\": 37.7749, \"longitude\": -122.4194}")
+    }
     test("detects multiple tool calls") {
         let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn1", "arguments": "{}"}}, {"id": "c2", "type": "function", "function": {"name": "fn2", "arguments": "{}"}}]}"#
         let result = ToolCallHandler.detectToolCall(in: response)


### PR DESCRIPTION
## Summary

  Accept tool call payloads where `function` is emitted as a string and
  `arguments` is provided as a sibling field. This lets MCP auto-execution
  handle an additional FoundationModels tool-call shape instead of leaking
  raw tool_calls JSON back to clients.


## Test plan
- [x] `swift build -c release`
- [x] `swift run apfel-tests`
- [x] `make install` and manual smoke test
