### PR TITLE
fix(homebrew): drop redundant `depends_on :macos` from tap formula

### DIFF
--- a/scripts/write-homebrew-formula.sh
+++ b/scripts/write-homebrew-formula.sh
@@ -41,7 +41,6 @@ class Apfel < Formula
   license "MIT"
 
   depends_on arch: :arm64
-  depends_on :macos
   depends_on macos: :tahoe
 
   def install


### PR DESCRIPTION
## Summary

`brew install Arthur-Ficial/tap/apfel` (and any `brew` operation that loads the formula) emits:

> Calling `depends_on :macos` with `depends_on macos:` is deprecated!

The tap formula declares both `depends_on :macos` and `depends_on macos: :tahoe`. The version form already implies macOS, so the bare requirement is redundant. `brew style` flags it as `Homebrew/OSDependsOn: Remove redundant depends_on :macos` (autocorrectable).

The tap's `Formula/apfel.rb` is generated by `scripts/write-homebrew-formula.sh` on every `make release`, so the fix belongs at the generator source — editing the tap directly would be overwritten on the next release. This drops the redundant line; `depends_on macos: :tahoe` continues to enforce the macOS 26 Tahoe minimum.

Scope: only the `Arthur-Ficial/homebrew-tap` formula is generated from this script. homebrew-core maintains its own formula (autobump only touches url/sha256) and is unaffected.

## Test plan

- `bash scripts/write-homebrew-formula.sh --version 9.9.9 --sha256 <64-zeros> --output /tmp/apfel.rb`
- `brew style /tmp/apfel.rb` — the `Homebrew/OSDependsOn` offense is gone (the remaining generic cops only fire when linting a standalone file outside a tap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
