### PR TITLE
fix(homebrew): clear depends_on :macos/macos: deprecation without unblocking Linux

### DIFF
--- a/scripts/write-homebrew-formula.sh
+++ b/scripts/write-homebrew-formula.sh
@@ -43,13 +43,18 @@ class Apfel < Formula
   depends_on arch: :arm64
   # macOS-only hard block. Unlike homebrew-core's formula (which builds from
   # source and has \`depends_on xcode: [..., :build]\`, naturally excluding Linux),
-  # this tap installs a prebuilt macOS binary with no xcode build-dep. With only
-  # \`depends_on macos: :tahoe\`, brew reports "macOS >= 26 (or Linux)" and an
-  # arm64 Linux host would install a non-functional macOS binary. The bare
-  # :macos is the only thing that hard-blocks Linux here, so the OSDependsOn
-  # "redundant" cop is a false positive for this binary-install formula.
-  depends_on :macos # rubocop:disable Homebrew/OSDependsOn
-  depends_on macos: :tahoe
+  # this tap installs a prebuilt macOS binary with no xcode build-dep. A bare
+  # top-level \`depends_on :macos\` is the only thing that hard-blocks Linux: a
+  # versioned \`depends_on macos: :tahoe\` is auto-satisfied on Linux (brew shows
+  # "macOS >= 26 (or Linux)"), so an arm64 Linux host would otherwise install a
+  # non-functional macOS binary. The macOS version floor still has to be enforced,
+  # so it lives inside \`on_macos\`: combining a top-level bare \`depends_on :macos\`
+  # with a top-level \`depends_on macos:\` is deprecated and prints a runtime
+  # warning on every brew operation that loads the formula.
+  depends_on :macos
+  on_macos do
+    depends_on macos: :tahoe
+  end
 
   def install
     bin.install "apfel"


### PR DESCRIPTION
## Summary

`brew install/update/upgrade/info Arthur-Ficial/tap/apfel` emits, on every operation that loads the formula:

> Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead.

Homebrew 6 deprecated declaring a **top-level** bare `depends_on :macos` alongside a **top-level** versioned `depends_on macos:` (`software_spec.rb`, `record_os_requirement`). The generated tap formula does exactly that, so users see the warning repeatedly.

This regenerates the formula so the version floor lives inside an `on_macos` block — the exact replacement Homebrew's own deprecation message prescribes.

## Why not just drop the bare line (PR #203)?

#203 proposed removing `depends_on :macos` and keeping only `depends_on macos: :tahoe`. That clears the warning but **reopens a Linux install path**, which is unsafe for this formula:

- This is a **prebuilt-binary** tap (`url` is `...-arm64-macos.tar.gz`, `install` is `bin.install "apfel"`). Unlike homebrew-core's apfel, there is no `depends_on xcode: [..., :build]` to structurally exclude Linux.
- A versioned `depends_on macos:` is **auto-satisfied on Linux** — `MacOSRequirement#satisfy` short-circuits to `true` when a version is set and the host isn't macOS, and `brew info` shows `macOS >= 26 (or Linux)`. arm64 Linux exists, and `arch: :arm64` doesn't exclude it, so an arm64 Linux host could `brew install` a macOS Mach-O binary that can't run.
- The bare top-level `depends_on :macos` (no version) is the **only** requirement that hard-blocks Linux here (it shows as a standalone `macOS`, no "or Linux").

The interim `# rubocop:disable Homebrew/OSDependsOn` on `main` only silences the **style cop**. The warning above is a separate **runtime `odeprecated`** that fires when brew loads the formula, so end users still see it.

## Fix

Keep the bare top-level `depends_on :macos` (the Linux hard-block) and move the version floor into `on_macos`:

```ruby
depends_on :macos
on_macos do
  depends_on macos: :tahoe
end
```

This is the structure the deprecation message itself recommends, so it clears both the runtime deprecation and the `Homebrew/OSDependsOn` cop (the `rubocop:disable` is no longer needed and is removed). The macOS version floor is still enforced on macOS; Linux is still hard-blocked.

The change is in the generator `scripts/write-homebrew-formula.sh` — the tap's `Formula/apfel.rb` is regenerated every `make release`, so fixing the generated file alone would be overwritten.

## Verification (Homebrew 6.0.3)

Generated both the current-`main` formula and this PR's formula, loaded each from a local tap:

| | current `main` | this PR |
|---|---|---|
| `brew info` runtime deprecation | **emitted** | **gone** |
| `brew style` | (cop silenced via disable) | `1 file inspected, no offenses detected` |
| `Requirements` (macOS host) | `arm64 architecture, macOS, macOS >= 26 (or Linux)` | `arm64 architecture, macOS, macOS >= 26 (or Linux)` |

The standalone `macOS` requirement (the Linux hard-block) is preserved in both.

## Test plan

```
bash scripts/write-homebrew-formula.sh --version 9.9.9 --sha256 <64-zeros> --output /tmp/apfel.rb
# place /tmp/apfel.rb in a tap, then:
brew info <tap>/apfel    # no deprecation warning
brew style <tap>/apfel   # no offenses
# Requirements still lists a standalone `macOS`
```

## Credit

Original warning surfaced by @johnpaulashenfelter in #203; the Linux-safety analysis (why the bare line must stay) is @Arthur-Ficial's from that thread. This PR keeps that guarantee while taking Homebrew's prescribed `on_macos` migration.
