### PR TITLE
fix(server): validate negative seed to prevent remote DoS crash (#212)

### DIFF
--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -158,6 +158,9 @@ public enum ChatRequestValidator {
         if let temp = request.temperature, temp < 0 {
             return .invalidParameterValue("'temperature' must be non-negative, got \(temp)")
         }
+        if let seed = request.seed, seed < 0 {
+            return .invalidParameterValue("'seed' must be a non-negative integer, got \(seed)")
+        }
         if let turns = request.x_context_max_turns, turns <= 0 {
             return .invalidParameterValue("'x_context_max_turns' must be a positive integer, got \(turns)")
         }

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -225,6 +225,33 @@ func runChatRequestValidatorTests() {
         try assertNil(ChatRequestValidator.validate(request))
     }
 
+    test("validator rejects negative seed") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"seed":-1}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'seed' must be a non-negative integer, got -1")
+        )
+    }
+
+    test("validator accepts non-negative seed") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"seed":42}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator accepts seed of zero") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"seed":0}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
     test("validator rejects x_context_max_turns <= 0") {
         let request = try decode(
             ChatCompletionRequest.self,
@@ -325,6 +352,28 @@ func runChatRequestValidatorTests() {
         try assertEqual(
             ChatRequestValidator.validate(request),
             .invalidParameterValue("'max_tokens' must be a positive integer, got 0")
+        )
+    }
+
+    test("validator reports temperature before negative seed") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"temperature":-1,"seed":-1}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'temperature' must be non-negative, got -1.0")
+        )
+    }
+
+    test("validator reports negative seed before invalid context knobs") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"seed":-1,"x_context_max_turns":0,"x_context_output_reserve":0}"#
+        )
+        try assertEqual(
+            ChatRequestValidator.validate(request),
+            .invalidParameterValue("'seed' must be a non-negative integer, got -1")
         )
     }
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #212.

## Summary

A request with `"seed": -1` traps `UInt64.init` at `Handlers.swift:115`, killing the entire server process. This is a remote, unauthenticated DoS - one malformed curl request takes down `apfel --serve`.

The fix adds a validation check in `ChatRequestValidator.validate()` that rejects negative `seed` values with a clear 400 error before the value ever reaches the `UInt64` conversion. Placed in the existing numeric-parameter validation block, between `temperature` and the `x_context_*` knobs.

## Root cause

`Sources/Handlers.swift:115` does `chatRequest.seed.map { UInt64($0) }`. The `seed` field is decoded as `Int?` (`OpenAIModels.swift:25`), so negative values are valid JSON but `UInt64(-1)` is a Swift runtime trap. No validation existed in `ChatRequestValidator` to catch this before the conversion.

## The fix

Three lines in `ChatRequestValidator.swift`: if `seed` is present and negative, return `.invalidParameterValue("'seed' must be a non-negative integer, got \(seed)")`. The server now returns HTTP 400 instead of crashing.

## Test coverage

- Added 5 new tests in `Tests/apfelTests/OpenAIModelsTests.swift`:
  - `validator rejects negative seed` - locks the bug in place
  - `validator accepts non-negative seed` - happy path (seed=42)
  - `validator accepts seed of zero` - boundary (seed=0 is valid)
  - `validator reports temperature before negative seed` - ordering
  - `validator reports negative seed before invalid context knobs` - ordering
- Existing `runChatRequestValidatorTests` suite still covers all other validation paths.

## What I verified (static only)

- Validator check fires before `Handlers.swift:115` because `validate()` is called at `Handlers.swift:57-67`, well before the `UInt64` conversion at line 115.
- The `.invalidParameterValue` case is already wired to HTTP 400 in the handler's error response path.
- Swift 6 concurrency: no data races introduced (pure function, no shared state).
- Diff limited to `Sources/Core/ChatRequestValidator.swift` and `Tests/apfelTests/OpenAIModelsTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward validation gap. The issue report is clean and accurate.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify `curl ... -d '{"seed":-1, ...}'` returns 400 instead of crashing the server

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_012vau5skBeSjhTzEgjupAaT)_