### PR TITLE
fix(server): empty/null content returns 400 not 500 (#233)

### DIFF
--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -75,6 +75,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
     case unsupportedParameter(UnsupportedChatParameter)
     /// The final message role was not `user` or `tool`.
     case invalidLastRole
+    /// The final user message has empty or null text content.
+    case emptyLastMessageContent
     /// The request included image content.
     case imageContent
     /// A numeric or string parameter had an invalid value.
@@ -91,6 +93,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
             return parameter.message
         case .invalidLastRole:
             return "Last message must have role 'user' or 'tool'"
+        case .emptyLastMessageContent:
+            return "Last user message must have non-empty text content"
         case .imageContent:
             return "Image content is not supported by the Apple on-device model"
         case .invalidParameterValue(let detail):
@@ -109,6 +113,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
             return "validation failed: unsupported parameter \(parameter.name)"
         case .invalidLastRole:
             return "validation failed: last role != user/tool"
+        case .emptyLastMessageContent:
+            return "validation failed: empty last message content"
         case .imageContent:
             return "rejected: image content"
         case .invalidParameterValue(let detail):
@@ -146,6 +152,12 @@ public enum ChatRequestValidator {
 
         guard let lastRole = request.messages.last?.role, ["user", "tool"].contains(lastRole) else {
             return .invalidLastRole
+        }
+
+        if lastRole == "user" {
+            guard let text = request.messages.last?.textContent, !text.isEmpty else {
+                return .emptyLastMessageContent
+            }
         }
 
         if request.messages.contains(where: \.containsImageContent) {

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -258,6 +258,7 @@ func runApfelCorePublicAPIUsageTests() {
             .emptyMessages,
             .unsupportedParameter(.logprobs),
             .invalidLastRole,
+            .emptyLastMessageContent,
             .imageContent,
             .invalidParameterValue("why"),
             .invalidModel("gpt-5"),

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -185,6 +185,10 @@ func runApfelErrorMessageTests() {
             "Last message must have role 'user' or 'tool'"
         )
         try assertEqual(
+            ChatRequestValidationFailure.emptyLastMessageContent.message,
+            "Last user message must have non-empty text content"
+        )
+        try assertEqual(
             ChatRequestValidationFailure.imageContent.message,
             "Image content is not supported by the Apple on-device model"
         )
@@ -218,6 +222,10 @@ func runApfelErrorMessageTests() {
         try assertEqual(
             ChatRequestValidationFailure.invalidLastRole.event,
             "validation failed: last role != user/tool"
+        )
+        try assertEqual(
+            ChatRequestValidationFailure.emptyLastMessageContent.event,
+            "validation failed: empty last message content"
         )
         try assertEqual(
             ChatRequestValidationFailure.imageContent.event,

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -328,6 +328,57 @@ func runChatRequestValidatorTests() {
         try assertEqual(ChatRequestValidator.validate(request), .unsupportedParameter(.logprobs))
     }
 
+    test("validator rejects empty string content in last user message") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":""}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .emptyLastMessageContent)
+    }
+
+    test("validator rejects null content in last user message") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":null}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .emptyLastMessageContent)
+    }
+
+    test("validator allows tool role with empty content") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"tool","tool_call_id":"call_1","name":"lookup","content":""}]}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator exposes stable emptyLastMessageContent metadata") {
+        try assertEqual(
+            ChatRequestValidationFailure.emptyLastMessageContent.message,
+            "Last user message must have non-empty text content"
+        )
+        try assertEqual(
+            ChatRequestValidationFailure.emptyLastMessageContent.event,
+            "validation failed: empty last message content"
+        )
+    }
+
+    test("validator prioritizes invalid last role before empty content") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"assistant","content":""}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .invalidLastRole)
+    }
+
+    test("validator prioritizes empty content before image content") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":null}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .emptyLastMessageContent)
+    }
+
     test("validator prioritizes invalid last role before image content") {
         let request = try decode(
             ChatCompletionRequest.self,


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #233.

## Summary

- Empty string (`content: ""`) and null (`content: null`) in the last user message now return HTTP 400 `invalid_request_error` instead of HTTP 500 `server_error`.
- Added `ChatRequestValidationFailure.emptyLastMessageContent` to catch the condition at the validation layer before it reaches `ContextManager.makeSession()`.
- Tool-role messages with empty content are intentionally unaffected (ContextManager uses a synthetic prompt for those).

## Root cause

`ContextManager.makeSession()` guards on `conversation.last?.textContent` being non-nil and non-empty, but throws `ApfelError.unknown("Last message has no text content")` when the guard fails. `.unknown` maps to HTTP 500 / `server_error`. This is a client-input problem misreported as a server fault because validation did not catch it earlier.

## The fix

Added a new `ChatRequestValidationFailure.emptyLastMessageContent` case checked in `ChatRequestValidator.validate()` right after the last-role check. When the last role is `"user"` and `textContent` is nil or empty, the validator returns `.emptyLastMessageContent` - which the handler surfaces as HTTP 400 `invalid_request_error` with message "Last user message must have non-empty text content". The check is skipped for `"tool"` role since ContextManager uses a synthetic prompt for tool-result messages.

## Test coverage

- Added `OpenAIModelsTests`: `validator rejects empty string content in last user message`
- Added `OpenAIModelsTests`: `validator rejects null content in last user message`
- Added `OpenAIModelsTests`: `validator allows tool role with empty content`
- Added `OpenAIModelsTests`: `validator exposes stable emptyLastMessageContent metadata`
- Added `OpenAIModelsTests`: `validator prioritizes invalid last role before empty content`
- Added `OpenAIModelsTests`: `validator prioritizes empty content before image content`
- Updated `ApfelErrorMessageTests`: exhaustive message/event coverage for the new case
- Updated `ApfelCorePublicAPIUsageTests`: public API surface includes the new case

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: `curl -X POST http://localhost:11434/v1/chat/completions -d '{"model":"apple-foundationmodel","messages":[{"role":"user","content":""}]}'` returns 400, not 500
- [ ] Verify: `curl -X POST http://localhost:11434/v1/chat/completions -d '{"model":"apple-foundationmodel","messages":[{"role":"user","content":null}]}'` returns 400, not 500

## What I verified (static only)

- Validation order is correct: role check -> empty content -> image content -> numeric params
- New enum case has `message`, `event`, `description`, `debugDescription` coverage
- All three "every case" test suites updated to include the new case
- No data races: pure value-type enum, no concurrency changes
- Diff limited to `ChatRequestValidator.swift` + three test files

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward validation bug. The issue was filed by Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCwV7KftMvV2vLHV13p1Nh)_