### PR TITLE
fix(security): scrub APFEL_ env vars from MCP subprocess (#229)

### DIFF
--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -129,6 +129,14 @@ public enum MCPProtocol {
         return ToolCallResult(text: text, isError: isError)
     }
 
+    // MARK: - Environment scrubbing
+
+    /// Returns a copy of `env` with all `APFEL_`-prefixed variables removed.
+    /// MCP subprocesses must not inherit the parent's auth tokens or configuration.
+    public static func scrubbedEnvironment(_ env: [String: String]) -> [String: String] {
+        env.filter { !$0.key.hasPrefix("APFEL_") }
+    }
+
     // MARK: - Private helpers
 
     private static func jsonRPC(id: Int? = nil, method: String, params: [String: Any]? = nil) -> String {

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -42,6 +42,7 @@ final class MCPConnection: @unchecked Sendable {
         proc.standardInput = stdinP
         proc.standardOutput = stdoutP
         proc.standardError = FileHandle.nullDevice
+        proc.environment = MCPProtocol.scrubbedEnvironment(ProcessInfo.processInfo.environment)
 
         self.process = proc
         self.stdinPipe = stdinP

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -310,4 +310,65 @@ func runMCPClientTests() {
         try assertEqual(calls!.first?.id, "call_001")
         try assertTrue(calls!.first!.argumentsString.contains("CLAUDE.md"), "arguments must contain the file path")
     }
+
+    // MARK: - Environment scrubbing (#229)
+
+    test("scrubbedEnvironment removes APFEL_TOKEN") {
+        let env = ["PATH": "/usr/bin", "HOME": "/Users/me", "APFEL_TOKEN": "secret-bearer"]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(env)
+        try assertNil(scrubbed["APFEL_TOKEN"])
+        try assertEqual(scrubbed["PATH"], "/usr/bin")
+    }
+
+    test("scrubbedEnvironment removes APFEL_MCP_TOKEN") {
+        let env = ["PATH": "/usr/bin", "APFEL_MCP_TOKEN": "mcp-secret"]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(env)
+        try assertNil(scrubbed["APFEL_MCP_TOKEN"])
+        try assertEqual(scrubbed["PATH"], "/usr/bin")
+    }
+
+    test("scrubbedEnvironment removes all APFEL_ prefixed vars") {
+        let env = [
+            "PATH": "/usr/bin",
+            "HOME": "/Users/me",
+            "APFEL_TOKEN": "secret",
+            "APFEL_MCP_TOKEN": "mcp-secret",
+            "APFEL_DEBUG": "1",
+            "APFEL_HOST": "0.0.0.0",
+            "APFEL_PORT": "8080",
+            "APFEL_SYSTEM_PROMPT": "be brief",
+            "LANG": "en_US.UTF-8",
+        ]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(env)
+        try assertEqual(scrubbed.count, 3)
+        try assertEqual(scrubbed["PATH"], "/usr/bin")
+        try assertEqual(scrubbed["HOME"], "/Users/me")
+        try assertEqual(scrubbed["LANG"], "en_US.UTF-8")
+    }
+
+    test("scrubbedEnvironment preserves non-apfel vars") {
+        let env = [
+            "PATH": "/usr/bin",
+            "HOME": "/Users/me",
+            "PYTHONPATH": "/lib/python",
+            "VIRTUAL_ENV": "/venv",
+            "NO_COLOR": "1",
+        ]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(env)
+        try assertEqual(scrubbed.count, 5)
+    }
+
+    test("scrubbedEnvironment handles empty environment") {
+        let scrubbed = MCPProtocol.scrubbedEnvironment([:])
+        try assertEqual(scrubbed.count, 0)
+    }
+
+    test("scrubbedEnvironment is case-sensitive on prefix") {
+        let env = ["apfel_token": "lower", "Apfel_Token": "mixed", "APFEL_TOKEN": "upper"]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(env)
+        try assertEqual(scrubbed.count, 2)
+        try assertEqual(scrubbed["apfel_token"], "lower")
+        try assertEqual(scrubbed["Apfel_Token"], "mixed")
+        try assertNil(scrubbed["APFEL_TOKEN"])
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #229.

## Root cause

`MCPConnection.init` (`Sources/MCPClient.swift:32-52`) sets up a `Process` with `executableURL`, `arguments`, and stdio pipes but never assigns `proc.environment`. With `environment == nil`, Foundation's `Process` inherits the full parent environment - including `APFEL_TOKEN`, `APFEL_MCP_TOKEN`, and any other secrets in the operator's shell. A malicious or compromised MCP tool script can read `os.environ` and exfiltrate the server's own bearer token.

## The fix

Added `MCPProtocol.scrubbedEnvironment(_:)` in ApfelCore - a pure function that filters out all `APFEL_`-prefixed environment variables. `MCPConnection.init` now calls it to set `proc.environment`, so child processes get `PATH`, `HOME`, `LANG`, `PYTHONPATH`, etc. but never see apfel's auth tokens or configuration.

The denylist approach (strip `APFEL_*`) was chosen over an allowlist (`PATH`+`HOME` only) because legitimate MCP tools often need env vars like `PYTHONPATH`, `VIRTUAL_ENV`, `NODE_PATH`, `LANG`, etc. Stripping only the apfel-specific prefix is the least disruptive fix while closing the secret-leakage vector.

## Test coverage

- Added `MCPClientTests`: `scrubbedEnvironment removes APFEL_TOKEN`
- Added `MCPClientTests`: `scrubbedEnvironment removes APFEL_MCP_TOKEN`
- Added `MCPClientTests`: `scrubbedEnvironment removes all APFEL_ prefixed vars`
- Added `MCPClientTests`: `scrubbedEnvironment preserves non-apfel vars`
- Added `MCPClientTests`: `scrubbedEnvironment handles empty environment`
- Added `MCPClientTests`: `scrubbedEnvironment is case-sensitive on prefix`

## What I verified (static only)

- Pure function with no side effects - easy to reason about correctness.
- Case-sensitive prefix match (`APFEL_` only, not `apfel_` or `Apfel_`) matches how the CLI reads these vars.
- No data races: the function is a stateless filter over a value-type dictionary.
- Diff limited to `Sources/Core/MCPProtocol.swift`, `Sources/MCPClient.swift`, `Tests/apfelTests/MCPClientTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward security fix. The issue was filed by Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_017Wxs2zZKDR1MDwLepGpzeQ)_