### PR TITLE
fix(security): scrub apfel auth vars from MCP subprocess env (#229)

### DIFF
--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -129,6 +129,21 @@ public enum MCPProtocol {
         return ToolCallResult(text: text, isError: isError)
     }
 
+    // MARK: - Subprocess environment scrubbing
+
+    /// Environment variable keys stripped from MCP subprocess environments
+    /// to prevent secret leakage to third-party tool scripts.
+    public static let sensitiveEnvironmentKeys: Set<String> = [
+        "APFEL_TOKEN",
+        "APFEL_MCP_TOKEN",
+    ]
+
+    /// Returns a copy of the given environment with apfel-specific auth
+    /// variables removed, suitable for passing to an MCP subprocess.
+    public static func scrubbedEnvironment(from env: [String: String]) -> [String: String] {
+        env.filter { !sensitiveEnvironmentKeys.contains($0.key) }
+    }
+
     // MARK: - Private helpers
 
     private static func jsonRPC(id: Int? = nil, method: String, params: [String: Any]? = nil) -> String {

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -42,6 +42,7 @@ final class MCPConnection: @unchecked Sendable {
         proc.standardInput = stdinP
         proc.standardOutput = stdoutP
         proc.standardError = FileHandle.nullDevice
+        proc.environment = MCPProtocol.scrubbedEnvironment(from: ProcessInfo.processInfo.environment)
 
         self.process = proc
         self.stdinPipe = stdinP

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -299,6 +299,70 @@ func runMCPClientTests() {
         try assertTrue(formatInstructions.contains("tool_calls"), "format must contain call format")
     }
 
+    // MARK: - MCP subprocess environment scrubbing (#229)
+
+    test("scrubbedEnvironment strips APFEL_TOKEN") {
+        let env = ["PATH": "/usr/bin", "HOME": "/Users/me", "APFEL_TOKEN": "secret-bearer-token"]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(from: env)
+        try assertNil(scrubbed["APFEL_TOKEN"], "APFEL_TOKEN must be stripped")
+        try assertEqual(scrubbed["PATH"], "/usr/bin")
+        try assertEqual(scrubbed["HOME"], "/Users/me")
+    }
+
+    test("scrubbedEnvironment strips APFEL_MCP_TOKEN") {
+        let env = ["PATH": "/usr/bin", "APFEL_MCP_TOKEN": "mcp-secret"]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(from: env)
+        try assertNil(scrubbed["APFEL_MCP_TOKEN"], "APFEL_MCP_TOKEN must be stripped")
+        try assertEqual(scrubbed["PATH"], "/usr/bin")
+    }
+
+    test("scrubbedEnvironment strips both token vars simultaneously") {
+        let env = [
+            "PATH": "/usr/bin",
+            "APFEL_TOKEN": "server-token",
+            "APFEL_MCP_TOKEN": "mcp-token",
+            "APFEL_SYSTEM_PROMPT": "Be helpful",
+            "LANG": "en_US.UTF-8",
+        ]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(from: env)
+        try assertNil(scrubbed["APFEL_TOKEN"])
+        try assertNil(scrubbed["APFEL_MCP_TOKEN"])
+        try assertEqual(scrubbed["APFEL_SYSTEM_PROMPT"], "Be helpful")
+        try assertEqual(scrubbed["LANG"], "en_US.UTF-8")
+        try assertEqual(scrubbed["PATH"], "/usr/bin")
+        try assertEqual(scrubbed.count, 3)
+    }
+
+    test("scrubbedEnvironment preserves all non-sensitive vars") {
+        let env = [
+            "PATH": "/usr/bin",
+            "HOME": "/Users/me",
+            "APFEL_SYSTEM_PROMPT": "Be brief",
+            "APFEL_PORT": "11434",
+            "APFEL_HOST": "127.0.0.1",
+            "APFEL_MCP": "mcp/calc.py",
+            "APFEL_DEBUG": "1",
+            "PYTHONPATH": "/opt/venv",
+        ]
+        let scrubbed = MCPProtocol.scrubbedEnvironment(from: env)
+        try assertEqual(scrubbed.count, env.count)
+        for (key, value) in env {
+            try assertEqual(scrubbed[key], value, "expected \(key) to be preserved")
+        }
+    }
+
+    test("scrubbedEnvironment handles empty environment") {
+        let scrubbed = MCPProtocol.scrubbedEnvironment(from: [:])
+        try assertEqual(scrubbed.count, 0)
+    }
+
+    test("sensitiveEnvironmentKeys contains both token vars") {
+        try assertTrue(MCPProtocol.sensitiveEnvironmentKeys.contains("APFEL_TOKEN"))
+        try assertTrue(MCPProtocol.sensitiveEnvironmentKeys.contains("APFEL_MCP_TOKEN"))
+        try assertTrue(!MCPProtocol.sensitiveEnvironmentKeys.contains("APFEL_SYSTEM_PROMPT"))
+        try assertTrue(!MCPProtocol.sensitiveEnvironmentKeys.contains("PATH"))
+    }
+
     test("Tool call detection works on object-argument format from #144 report") {
         // The #144 reporter showed the model producing arguments as a JSON object
         // (not an escaped string). Detection must handle both forms.


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #229.

## Summary

- Local MCP subprocesses (`apfel --serve --mcp server.py`) inherited the full parent environment via Foundation `Process`'s default behaviour, leaking `APFEL_TOKEN`, `APFEL_MCP_TOKEN`, and any other secrets present in the shell to third-party tool scripts.
- Added `MCPProtocol.scrubbedEnvironment(from:)` in `ApfelCore` that strips the two auth-sensitive keys from a given environment dictionary.
- `MCPConnection.init` now sets `proc.environment` explicitly using the scrubbed copy before spawning the child process.

## Root cause

`Sources/MCPClient.swift:32-52` - `MCPConnection.init` creates a `Process()` and sets `executableURL`, `arguments`, and the stdio pipes, but never assigns `proc.environment`. With `environment == nil`, Foundation `Process` inherits the parent's entire environment - including `APFEL_TOKEN` (the server bearer token) and `APFEL_MCP_TOKEN` (the remote MCP bearer token). A malicious or compromised MCP tool script could read `os.environ` and exfiltrate these credentials.

## The fix

Added a pure, testable `MCPProtocol.scrubbedEnvironment(from:)` method in `ApfelCore` that filters out the two known auth variables (`APFEL_TOKEN`, `APFEL_MCP_TOKEN`) from a given environment dictionary. All other environment variables (including non-sensitive `APFEL_*` config vars like `APFEL_SYSTEM_PROMPT`, `APFEL_PORT`, plus standard vars like `PATH`, `HOME`, `PYTHONPATH`) are preserved so MCP tool scripts continue to work normally.

One line added to `MCPConnection.init`: `proc.environment = MCPProtocol.scrubbedEnvironment(from: ProcessInfo.processInfo.environment)` - applied before `proc.run()`.

## Test coverage

- Added `MCPClientTests`: `scrubbedEnvironment strips APFEL_TOKEN`
- Added `MCPClientTests`: `scrubbedEnvironment strips APFEL_MCP_TOKEN`
- Added `MCPClientTests`: `scrubbedEnvironment strips both token vars simultaneously`
- Added `MCPClientTests`: `scrubbedEnvironment preserves all non-sensitive vars`
- Added `MCPClientTests`: `scrubbedEnvironment handles empty environment`
- Added `MCPClientTests`: `sensitiveEnvironmentKeys contains both token vars`

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: `APFEL_TOKEN=secret apfel --serve --mcp mcp/calculator/server.py` then check whether the child process can see `APFEL_TOKEN` in its environment (it should not)

## What I verified (static only)

- Pure scrubbing logic is correct: strips only `APFEL_TOKEN` and `APFEL_MCP_TOKEN`, preserves everything else.
- No data races: `scrubbedEnvironment` is a pure function on value types, `sensitiveEnvironmentKeys` is a `let` constant.
- Diff limited to `Sources/Core/MCPProtocol.swift`, `Sources/MCPClient.swift`, `Tests/apfelTests/MCPClientTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 strict concurrency: no new `Sendable` requirements, no actor boundaries crossed.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward security fix. The issue was filed by Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_011u3E7T2bf8x8NLtBVD2H7i)_