### PR TITLE
fix(mcp): feed isError tool results back to the model (#220)

### DIFF
--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -337,10 +337,15 @@ func detectAndExecuteMCPTools(
             resultParts.append("\(call.name): \(result)")
             toolLog.append((name: call.name, args: call.argumentsString, result: result, isError: false))
         } catch {
-            if case .toolNotFound = error as? MCPError {
-                let msg = "\(error)"
-                resultParts.append("\(call.name): error - \(msg)")
-                toolLog.append((name: call.name, args: call.argumentsString, result: msg, isError: true))
+            if let mcpErr = error as? MCPError {
+                switch mcpErr {
+                case .toolNotFound, .serverError:
+                    let msg = "\(error)"
+                    resultParts.append("\(call.name): error - \(msg)")
+                    toolLog.append((name: call.name, args: call.argumentsString, result: msg, isError: true))
+                default:
+                    throw error
+                }
             } else {
                 throw error
             }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -299,6 +299,33 @@ func runMCPClientTests() {
         try assertTrue(formatInstructions.contains("tool_calls"), "format must contain call format")
     }
 
+    // MARK: - isError tool results (#220)
+    // MCP tools that return isError:true should be recoverable, not fatal.
+    // The error text should be fed back to the model so it can respond.
+
+    test("MCPError.serverError from isError tool result is recoverable, not fatal (#220)") {
+        let json = """
+        {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"Error: division by zero"}],"isError":true}}
+        """
+        let result = try MCPProtocol.parseToolCallResponse(json)
+        try assertTrue(result.isError, "isError must be true")
+        try assertEqual(result.text, "Error: division by zero")
+        // The error text is valid content that should be fed back to the model,
+        // not converted to a thrown MCPError.serverError that kills the request.
+        // detectAndExecuteMCPTools must catch .serverError and record it in
+        // resultParts/toolLog, same as it does for .toolNotFound.
+        try assertTrue(!result.text.isEmpty, "error text must be non-empty for model feedback")
+    }
+
+    test("JSON-RPC level error is also recoverable (#220)") {
+        let json = """
+        {"jsonrpc":"2.0","id":5,"error":{"code":-32602,"message":"Unknown tool: fake"}}
+        """
+        let result = try MCPProtocol.parseToolCallResponse(json)
+        try assertTrue(result.isError)
+        try assertTrue(result.text.contains("Unknown tool"))
+    }
+
     test("Tool call detection works on object-argument format from #144 report") {
         // The #144 reporter showed the model producing arguments as a JSON object
         // (not an escaped string). Detection must handle both forms.

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -332,8 +332,8 @@ def test_client_tools_not_auto_executed():
         f"Expected 'tool_calls' for client tools but got '{data['choices'][0]['finish_reason']}'"
 
 
-def test_mcp_tool_error_returns_structured_error():
-    """MCP tool failures must be surfaced honestly, not rewritten by the model."""
+def test_mcp_tool_error_fed_back_to_model():
+    """MCP isError results are fed back to the model, not thrown as HTTP 500 (#220)."""
     resp = httpx.post(f"{API_URL}/chat/completions", json={
         "model": MODEL,
         "messages": [
@@ -341,12 +341,11 @@ def test_mcp_tool_error_returns_structured_error():
         ],
         "seed": 42,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 500
+    assert resp.status_code == 200, f"Expected 200 (error fed to model), got {resp.status_code}: {resp.text}"
     data = resp.json()
-    assert data["error"]["type"] == "server_error"
-    message = data["error"]["message"].lower()
-    assert "divide" in message
-    assert "division by zero" in message
+    content = data["choices"][0]["message"]["content"].lower()
+    assert any(w in content for w in ["error", "zero", "undefined", "cannot", "divide", "impossible"]), \
+        f"Expected model to acknowledge the tool error, got: {content}"
 
 
 def test_mcp_tool_timeout_returns_structured_error():


### PR DESCRIPTION
## Summary

**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #220.

### Root cause

`MCPConnection.callTool` (and `RemoteMCPConnection.callTool`) throw `MCPError.serverError` when the MCP server returns `isError: true` in a tool result - for example, `divide(10, 0)` returning "Error: division by zero". In `detectAndExecuteMCPTools` (`Session.swift:339`), only `.toolNotFound` was caught and recorded in `resultParts`/`toolLog` for re-prompting. Every other `MCPError` - including `.serverError` - fell through to the `throw error` re-throw, which `ApfelError.classify` maps to `.toolExecution` (HTTP 500 in server mode, runtime error in CLI mode).

Per the MCP spec, execution errors "should be reported inside the result object... so the LLM can see it and act." Today, the model never sees them.

### The fix

Widen the catch in `detectAndExecuteMCPTools` to also handle `MCPError.serverError`, recording it in `resultParts` and `toolLog` with `isError: true` - the same pattern already used for `.toolNotFound`. The error text is then fed back to the model via the re-prompt path, so the model can acknowledge it gracefully (e.g. "Cannot divide by zero") instead of the request crashing with HTTP 500.

Transport-level errors (`.processError`, `.timedOut`, `.invalidResponse`) still throw - those indicate broken connections, not recoverable tool failures.

### Test coverage

- Added `MCPClientTests.swift`: "MCPError.serverError from isError tool result is recoverable, not fatal (#220)" - verifies `parseToolCallResponse` returns error text suitable for model feedback.
- Added `MCPClientTests.swift`: "JSON-RPC level error is also recoverable (#220)" - verifies JSON-RPC error responses are also handled.
- Updated `mcp_server_test.py`: `test_mcp_tool_error_fed_back_to_model` - changed from asserting HTTP 500 to asserting HTTP 200 with the model acknowledging the tool error.
- Existing `parseToolCallResponse detects errors` test still covers the protocol parsing happy path.

### What I verified (static only)

- Traced the full error propagation path: `MCPProtocol.parseToolCallResponse` -> `MCPConnection.callTool` -> `MCPManager.execute` -> `detectAndExecuteMCPTools` -> `executeMCPToolCallsForServer`/`executeMCPToolCallsForCLI`.
- Confirmed `.serverError` is the only `MCPError` case produced by `isError: true` results (both local and remote connections).
- Confirmed transport errors (`.processError`, `.timedOut`, `.invalidResponse`) are NOT caught by the new code - they still throw as before.
- Swift 6 concurrency: no data races introduced. The change is purely in the catch block's pattern matching.
- Diff limited to `Sources/Session.swift`, `Tests/apfelTests/MCPClientTests.swift`, `Tests/integration/mcp_server_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

### What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- The updated integration test (`test_mcp_tool_error_fed_back_to_model`) checks that the model responds with HTTP 200 and mentions the error. The exact model response is non-deterministic; the assertion checks for any of several reasonable keywords.

### Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial from a systematic audit.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full integration suite including updated `test_mcp_tool_error_fed_back_to_model`)

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01M63B8dzsXcRugFoD7yRFyT)_