### PR TITLE
fix(mcp): reject malformed tool-call arguments instead of silently using {} (#241)

### DIFF
--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -39,8 +39,12 @@ public enum MCPProtocol {
     ///   - id: The JSON-RPC request identifier.
     ///   - name: The tool name to invoke.
     ///   - arguments: JSON text describing the tool-call arguments.
-    public static func toolsCallRequest(id: Int, name: String, arguments: String) -> String {
-        let argsObj = (try? JSONSerialization.jsonObject(with: Data(arguments.utf8))) ?? [:]
+    public static func toolsCallRequest(id: Int, name: String, arguments: String) throws -> String {
+        guard let argsObj = try? JSONSerialization.jsonObject(with: Data(arguments.utf8)) else {
+            throw MCPError.invalidResponse(
+                "Invalid JSON in tool-call arguments for '\(name)': \(String(arguments.prefix(200)))"
+            )
+        }
         return jsonRPC(id: id, method: "tools/call", params: [
             "name": name,
             "arguments": argsObj

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -90,7 +90,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: String = MCPProtocol.initializeRequest(id: 1)
         let _: String = MCPProtocol.initializedNotification()
         let _: String = MCPProtocol.toolsListRequest(id: 2)
-        let _: String = MCPProtocol.toolsCallRequest(id: 3, name: "f", arguments: "{}")
+        let _: String = try MCPProtocol.toolsCallRequest(id: 3, name: "f", arguments: "{}")
 
         let info = try MCPProtocol.parseInitializeResponse(
             #"{"result":{"serverInfo":{"name":"s","version":"1"}}}"#

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -28,7 +28,7 @@ func runMCPClientTests() {
     }
 
     test("formatToolsCall produces valid JSON-RPC") {
-        let msg = MCPProtocol.toolsCallRequest(id: 3, name: "multiply", arguments: "{\"a\":247,\"b\":83}")
+        let msg = try MCPProtocol.toolsCallRequest(id: 3, name: "multiply", arguments: "{\"a\":247,\"b\":83}")
         let data = msg.data(using: .utf8)!
         let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         try assertEqual(obj["method"] as! String, "tools/call")
@@ -38,17 +38,35 @@ func runMCPClientTests() {
         try assertEqual(args["a"] as! Int, 247)
     }
 
-    test("formatToolsCall falls back to empty object when arguments are invalid JSON") {
-        let msg = MCPProtocol.toolsCallRequest(id: 3, name: "multiply", arguments: "{not json}")
-        let data = msg.data(using: .utf8)!
-        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-        let params = obj["params"] as! [String: Any]
-        let args = params["arguments"] as! [String: Any]
-        try assertEqual(args.count, 0)
+    test("toolsCallRequest throws on malformed JSON arguments") {
+        do {
+            _ = try MCPProtocol.toolsCallRequest(id: 3, name: "multiply", arguments: "{not json}")
+            try assertTrue(false, "should have thrown")
+        } catch let e as MCPError {
+            if case .invalidResponse(let msg) = e {
+                try assertTrue(msg.contains("Invalid JSON"), "error should mention invalid JSON")
+                try assertTrue(msg.contains("multiply"), "error should include the tool name")
+            } else {
+                try assertTrue(false, "expected .invalidResponse, got \(e)")
+            }
+        }
+    }
+
+    test("toolsCallRequest throws on truncated JSON arguments") {
+        do {
+            _ = try MCPProtocol.toolsCallRequest(id: 3, name: "calc", arguments: "{\"lat\": 48.2, \"lon\":")
+            try assertTrue(false, "should have thrown")
+        } catch let e as MCPError {
+            if case .invalidResponse(let msg) = e {
+                try assertTrue(msg.contains("Invalid JSON"), "error should mention invalid JSON")
+            } else {
+                try assertTrue(false, "expected .invalidResponse, got \(e)")
+            }
+        }
     }
 
     test("formatToolsCall preserves JSON array arguments") {
-        let msg = MCPProtocol.toolsCallRequest(id: 3, name: "sum", arguments: "[1,2,3]")
+        let msg = try MCPProtocol.toolsCallRequest(id: 3, name: "sum", arguments: "[1,2,3]")
         let data = msg.data(using: .utf8)!
         let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         let params = obj["params"] as! [String: Any]


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #241.

## Summary

`MCPProtocol.toolsCallRequest` silently replaced unparseable JSON arguments with an empty dictionary (`[:]`), so a tool with all-optional parameters would "succeed" with defaults and the user would get a confidently wrong answer with no trace of the malformed input.

Now the function throws `MCPError.invalidResponse` on parse failure, including the tool name and a prefix of the malformed input for debugging. The error propagates through the existing `callTool` paths and surfaces as a classified `ApfelError.toolExecution` - loud failure instead of silent corruption.

## Root cause

`Sources/Core/MCPProtocol.swift:43` - `(try? JSONSerialization.jsonObject(with: Data(arguments.utf8))) ?? [:]`. The `try?` swallows the parse error and `?? [:]` replaces it with an empty dictionary. The on-device 3B model routinely deviates from the exact prompt format (the codebase already defends against unclosed brackets, preambles, string-vs-object `function`), so truncated or malformed arguments are a real-world occurrence.

## The fix

Changed `toolsCallRequest` from a non-throwing to a throwing function. On JSON parse failure, it now throws `MCPError.invalidResponse("Invalid JSON in tool-call arguments for '<name>': <truncated args>")`. Both callers in `MCPClient.swift` (local and remote connections) are already inside `try`/`try await` expressions, so the error propagates naturally with no caller changes needed.

## Test coverage

- Replaced `MCPClientTests`: `toolsCallRequest throws on malformed JSON arguments` - asserts the throw, checks error message contains "Invalid JSON" and the tool name.
- Added `MCPClientTests`: `toolsCallRequest throws on truncated JSON arguments` - covers the realistic scenario of mid-stream truncation (`{"lat": 48.2, "lon":`).
- Existing `formatToolsCall produces valid JSON-RPC` and `formatToolsCall preserves JSON array arguments` still pass (valid JSON still works).
- Updated `ApfelCorePublicAPIUsageTests` to use `try` for the now-throwing call.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Both `MCPClient.swift` callers (line 83 local, line 198 remote) are already inside `try` expressions - no source changes needed there.
- `ApfelError.classify` maps any `MCPError` to `.toolExecution` via `.description` (line 20-22 of `ApfelError.swift`) - no change needed.
- The `MCPError.description` exhaustive switch already covers `.invalidResponse` - no new case added.
- Swift 6 concurrency: no data races introduced (pure static function, no shared state).
- Diff limited to `Sources/Core/MCPProtocol.swift`, `Tests/apfelTests/MCPClientTests.swift`, `Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug from the v1.6.1 audit. The issue was filed by Arthur-Ficial. No code was copied from the issue body; the fix was written from scratch after reading the source.

## Note on error propagation

Today, `detectAndExecuteMCPTools` in `Session.swift` only catches `MCPError.toolNotFound` gracefully (feeding it back to the model). All other `MCPError` variants - including this new `.invalidResponse` throw - propagate up and surface as HTTP 500 / CLI runtime error. This is deliberately better than silent wrong answers. The broader improvement of feeding tool execution errors back to the model for retry is tracked by #220.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPqHWtBfxsaZ3NA2xAFtjD)_