### PR TITLE
fix(mcp): correlate JSON-RPC response IDs to skip server notifications (#217)

### DIFF
--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -129,6 +129,19 @@ public enum MCPProtocol {
         return ToolCallResult(text: text, isError: isError)
     }
 
+    // MARK: - ID correlation
+
+    /// Returns true if `json` is a JSON-RPC response whose `id` matches `requestId`.
+    /// Notifications (no `id`) and mismatched IDs return false.
+    public static func isResponse(_ json: String, forRequestId id: Int) -> Bool {
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let responseId = obj["id"] as? Int else {
+            return false
+        }
+        return responseId == id
+    }
+
     // MARK: - Private helpers
 
     private static func jsonRPC(id: Int? = nil, method: String, params: [String: Any]? = nil) -> String {

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -53,8 +53,10 @@ final class MCPConnection: @unchecked Sendable {
 
         do {
             // Initialize handshake
+            let initId = allocId()
             let initResp = try sendAndReceive(
-                MCPProtocol.initializeRequest(id: allocId()),
+                MCPProtocol.initializeRequest(id: initId),
+                requestId: initId,
                 timeoutMilliseconds: timeoutMilliseconds,
                 operationDescription: "initialize"
             )
@@ -62,8 +64,10 @@ final class MCPConnection: @unchecked Sendable {
             send(MCPProtocol.initializedNotification())
 
             // Discover tools
+            let toolsId = allocId()
             let toolsResp = try sendAndReceive(
-                MCPProtocol.toolsListRequest(id: allocId()),
+                MCPProtocol.toolsListRequest(id: toolsId),
+                requestId: toolsId,
                 timeoutMilliseconds: timeoutMilliseconds,
                 operationDescription: "tools/list"
             )
@@ -79,8 +83,10 @@ final class MCPConnection: @unchecked Sendable {
     func callTool(name: String, arguments: String) throws -> String {
         let resp: String
         do {
+            let callId = allocId()
             resp = try sendAndReceive(
-                MCPProtocol.toolsCallRequest(id: allocId(), name: name, arguments: arguments),
+                MCPProtocol.toolsCallRequest(id: callId, name: name, arguments: arguments),
+                requestId: callId,
                 timeoutMilliseconds: timeoutMilliseconds,
                 operationDescription: "tool '\(name)'"
             )
@@ -122,14 +128,25 @@ final class MCPConnection: @unchecked Sendable {
 
     private func sendAndReceive(
         _ message: String,
+        requestId: Int,
         timeoutMilliseconds: Int,
         operationDescription: String
     ) throws -> String {
         send(message)
-        return try lineReader.readLine(
-            timeoutMilliseconds: timeoutMilliseconds,
-            operationDescription: operationDescription
-        )
+        let deadline = Date().addingTimeInterval(Double(timeoutMilliseconds) / 1000.0)
+        while true {
+            let remaining = Int(deadline.timeIntervalSinceNow * 1000.0)
+            if remaining <= 0 {
+                throw MCPError.timedOut("\(operationDescription.capitalized) timed out after \(timeoutMilliseconds / 1000)s")
+            }
+            let line = try lineReader.readLine(
+                timeoutMilliseconds: remaining,
+                operationDescription: operationDescription
+            )
+            if MCPProtocol.isResponse(line, forRequestId: requestId) {
+                return line
+            }
+        }
     }
 }
 

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -91,6 +91,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: String = MCPProtocol.initializedNotification()
         let _: String = MCPProtocol.toolsListRequest(id: 2)
         let _: String = MCPProtocol.toolsCallRequest(id: 3, name: "f", arguments: "{}")
+        let _: Bool = MCPProtocol.isResponse(#"{"id":1}"#, forRequestId: 1)
 
         let info = try MCPProtocol.parseInitializeResponse(
             #"{"result":{"serverInfo":{"name":"s","version":"1"}}}"#

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -299,6 +299,36 @@ func runMCPClientTests() {
         try assertTrue(formatInstructions.contains("tool_calls"), "format must contain call format")
     }
 
+    // MARK: - JSON-RPC response ID correlation (#217)
+
+    test("isResponse matches response with correct id") {
+        let json = #"{"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text","text":"42"}]}}"#
+        try assertTrue(MCPProtocol.isResponse(json, forRequestId: 7))
+    }
+
+    test("isResponse rejects notification without id") {
+        let json = #"{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"hello"}}"#
+        try assertTrue(!MCPProtocol.isResponse(json, forRequestId: 1))
+    }
+
+    test("isResponse rejects response with mismatched id") {
+        let json = #"{"jsonrpc":"2.0","id":5,"result":{"content":[{"type":"text","text":"42"}]}}"#
+        try assertTrue(!MCPProtocol.isResponse(json, forRequestId: 3))
+    }
+
+    test("isResponse rejects invalid JSON") {
+        try assertTrue(!MCPProtocol.isResponse("{not json}", forRequestId: 1))
+    }
+
+    test("isResponse rejects empty string") {
+        try assertTrue(!MCPProtocol.isResponse("", forRequestId: 1))
+    }
+
+    test("isResponse matches JSON-RPC error response with correct id") {
+        let json = #"{"jsonrpc":"2.0","id":4,"error":{"code":-32602,"message":"Unknown tool"}}"#
+        try assertTrue(MCPProtocol.isResponse(json, forRequestId: 4))
+    }
+
     test("Tool call detection works on object-argument format from #144 report") {
         // The #144 reporter showed the model producing arguments as a JSON object
         // (not an escaped string). Detection must handle both forms.


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #217.

## Summary

`sendAndReceive` now loops until a response whose JSON-RPC `id` matches the request arrives, skipping server notifications (messages without an `id` field). Previously, any interleaved notification - such as FastMCP's `ctx.info()` logging, `notifications/tools/list_changed`, or `ping` - would be parsed as the tool response, causing a "Missing content" error. Worse, the real response would stay buffered, so every subsequent call would be off-by-one forever.

### Root cause

`MCPConnection.sendAndReceive` (`Sources/MCPClient.swift:123-133`) did `send(message); return try lineReader.readLine(...)` with no loop and no id check. `MCPProtocol.parseToolCallResponse` also never inspected `obj["id"]`. MCP servers legitimately emit notifications interleaved with responses - one notification desynchronises the connection permanently.

### The fix

Two changes:

1. **`MCPProtocol.isResponse(_:forRequestId:)`** - new public predicate in ApfelCore that checks whether a JSON line is a JSON-RPC response with a matching `id`. Notifications (no `id`) and mismatched IDs return false. Pure function, fully testable.

2. **`MCPConnection.sendAndReceive`** - now accepts a `requestId` parameter, computes a deadline from the original timeout, and loops `readLine()` (sharing that deadline) until `MCPProtocol.isResponse` returns true. All three callers (`init` handshake, tools/list, callTool) capture the `allocId()` result and pass it to both the request formatter and `sendAndReceive`.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: start `apfel --serve --mcp` with a FastMCP server that calls `ctx.info()` during tool execution, confirm the tool result is returned correctly instead of erroring on the log notification

## Test coverage

- Added `MCPClientTests`: `isResponse matches response with correct id`
- Added `MCPClientTests`: `isResponse rejects notification without id`
- Added `MCPClientTests`: `isResponse rejects response with mismatched id`
- Added `MCPClientTests`: `isResponse rejects invalid JSON`
- Added `MCPClientTests`: `isResponse rejects empty string`
- Added `MCPClientTests`: `isResponse matches JSON-RPC error response with correct id`
- Updated `ApfelCorePublicAPIUsageTests`: public API surface includes the new method

## What I verified (static only)

- All three `sendAndReceive` call sites updated to pass the request ID
- The timeout deadline is shared across loop iterations - a flood of notifications will still time out correctly
- `BufferedLineReader.readLine` already stashes leftover bytes from partial reads, so skipped notifications don't lose data
- `readLine` throws `MCPError.timedOut` on deadline expiry, which `callTool` already handles (shutdown + re-throw)
- No data races: `sendAndReceive` is called under the existing serial access pattern (NSLock on allocId, synchronous stdio)
- Swift 6 concurrency: no changes to Sendable conformance or actor boundaries
- Diff limited to `Sources/Core/MCPProtocol.swift`, `Sources/MCPClient.swift`, and two test files - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward protocol bug. The issue was filed by Arthur-Ficial from a systematic audit. No code was copied from the issue body; the fix was written from scratch.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjJE6U13S8yXcW86mzu4PL)_