### PR TITLE
fix(mcp): truncate oversized tool results before re-prompting (#221)

### DIFF
--- a/Sources/Core/ToolResultTruncator.swift
+++ b/Sources/Core/ToolResultTruncator.swift
@@ -1,0 +1,27 @@
+// ============================================================================
+// ToolResultTruncator.swift — Truncate oversized MCP tool results
+// Part of ApfelCore — pure data types, no FoundationModels dependency
+// ============================================================================
+
+public enum ToolResultTruncator: Sendable {
+
+    /// Truncate a tool result string to fit within a character budget.
+    ///
+    /// When the text exceeds `maxCharacters`, returns the first 2/3 of the
+    /// budget as a head, a human-readable marker noting the truncation, and
+    /// the last 1/3 of the budget as a tail. This preserves both the
+    /// beginning (usually the most relevant data) and the end (often
+    /// contains closing structure) of the result.
+    ///
+    /// When the text fits, it is returned unchanged.
+    public static func truncate(_ text: String, maxCharacters: Int) -> String {
+        guard text.count > maxCharacters else { return text }
+        let marker = "\n\n[tool output truncated: showing \(maxCharacters) of \(text.count) characters]\n\n"
+        let available = max(0, maxCharacters - marker.count)
+        let headSize = available * 2 / 3
+        let tailSize = available - headSize
+        let head = String(text.prefix(headSize))
+        let tail = tailSize > 0 ? String(text.suffix(tailSize)) : ""
+        return head + marker + tail
+    }
+}

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -365,7 +365,16 @@ func executeMCPToolCallsForCLI(
 
     var aggregatedLog = executed.toolLog
     let plainSession = makeSession(systemPrompt: systemPrompt)
-    var toolResult = executed.resultParts.joined(separator: "\n")
+
+    let templateText = "The user asked: \n\nThe tool returned: \n\nAnswer the user's question using this result."
+    let inputBudgetChars = await TokenCounter.shared.inputBudget() * 4
+    let promptOverheadChars = templateText.count + userPrompt.count
+    let toolResultBudget = max(1000, inputBudgetChars - promptOverheadChars)
+
+    var toolResult = ToolResultTruncator.truncate(
+        executed.resultParts.joined(separator: "\n"),
+        maxCharacters: toolResultBudget
+    )
     var finalContent = try await plainSession.respond(
         to: "The user asked: \(userPrompt)\n\nThe tool returned: \(toolResult)\n\nAnswer the user's question using this result.",
         options: options
@@ -383,7 +392,10 @@ func executeMCPToolCallsForCLI(
           let followUp = try await detectAndExecuteMCPTools(in: finalContent, mcpManager: mcpManager) {
         reprompts += 1
         aggregatedLog.append(contentsOf: followUp.toolLog)
-        toolResult = followUp.resultParts.joined(separator: "\n")
+        toolResult = ToolResultTruncator.truncate(
+            followUp.resultParts.joined(separator: "\n"),
+            maxCharacters: toolResultBudget
+        )
         finalContent = try await plainSession.respond(
             to: "The user asked: \(userPrompt)\n\nThe tool returned: \(toolResult)\n\nAnswer the user's question using this result.",
             options: options
@@ -450,10 +462,14 @@ func executeMCPToolCallsForServer(
         return nil
     }
 
+    let perResultBudget = await TokenCounter.shared.inputBudget() * 2
+    let truncatedToolResults = executed.toolLog.map {
+        ($0.name, ToolResultTruncator.truncate($0.result, maxCharacters: perResultBudget))
+    }
     let followUpMessages = appendExecutedToolResults(
         to: messages,
         toolCalls: executed.toolCalls,
-        toolResults: executed.toolLog.map { ($0.name, $0.result) }
+        toolResults: truncatedToolResults
     )
     let (followUpSession, followUpPrompt, _) = try await ContextManager.makeSession(
         messages: followUpMessages,

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -450,6 +450,15 @@ func runApfelCorePublicAPIUsageTests() {
         try assertEqual(errs.count, 3)
     }
 
+    // MARK: - ToolResultTruncator
+
+    test("ToolResultTruncator public surface compiles") {
+        let _: String = ToolResultTruncator.truncate("hello", maxCharacters: 100)
+        let long = String(repeating: "x", count: 200)
+        let truncated = ToolResultTruncator.truncate(long, maxCharacters: 50)
+        try assertTrue(truncated.contains("[tool output truncated:"))
+    }
+
     // MARK: - ToolCallHandler
 
     test("ToolCallHandler public surface compiles") {

--- a/Tests/apfelTests/ToolResultTruncatorTests.swift
+++ b/Tests/apfelTests/ToolResultTruncatorTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import ApfelCore
+
+func runToolResultTruncatorTests() {
+
+    test("short result is returned unchanged") {
+        let input = "The answer is 42."
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 100)
+        try assertEqual(result, input)
+    }
+
+    test("result exactly at budget is returned unchanged") {
+        let input = String(repeating: "x", count: 100)
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 100)
+        try assertEqual(result, input)
+    }
+
+    test("result exceeding budget is truncated with marker") {
+        let input = String(repeating: "A", count: 300)
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 100)
+        try assertTrue(result.count < input.count, "truncated result should be shorter than input")
+        try assertTrue(result.contains("[tool output truncated:"), "should contain truncation marker")
+        try assertTrue(result.contains("of 300 characters]"), "marker should report original length")
+    }
+
+    test("truncated result contains head and tail of original") {
+        var input = ""
+        for i in 0..<100 {
+            input += "LINE\(i)\n"
+        }
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 200)
+        try assertTrue(result.hasPrefix("LINE0\n"), "should start with beginning of original")
+        try assertTrue(result.hasSuffix("LINE99\n"), "should end with end of original")
+    }
+
+    test("empty string is returned unchanged") {
+        let result = ToolResultTruncator.truncate("", maxCharacters: 100)
+        try assertEqual(result, "")
+    }
+
+    test("single character within budget is returned unchanged") {
+        let result = ToolResultTruncator.truncate("x", maxCharacters: 100)
+        try assertEqual(result, "x")
+    }
+
+    test("truncation marker includes character counts") {
+        let input = String(repeating: "z", count: 10000)
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 500)
+        try assertTrue(result.contains("of 10000 characters]"), "marker should show original length")
+    }
+
+    test("head portion is larger than tail portion") {
+        let input = String(repeating: "H", count: 50) + String(repeating: "T", count: 950)
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 200)
+        let markerRange = result.range(of: "[tool output truncated:")!
+        let head = String(result[result.startIndex..<markerRange.lowerBound])
+        let tail = String(result[result.range(of: "characters]")!.upperBound...])
+        try assertTrue(head.count > tail.count, "head should be larger than tail (2:1 ratio)")
+    }
+
+    test("very large input is correctly truncated") {
+        let input = String(repeating: "x", count: 100_000)
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 8000)
+        try assertTrue(result.count <= 8200, "result should be roughly within budget plus marker")
+        try assertTrue(result.contains("[tool output truncated:"), "should contain marker")
+        try assertTrue(result.contains("of 100000 characters]"), "marker should show 100000")
+    }
+
+    test("budget of 1 still produces valid output") {
+        let input = "Hello, world!"
+        let result = ToolResultTruncator.truncate(input, maxCharacters: 1)
+        try assertTrue(result.contains("[tool output truncated:"), "should truncate")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -114,6 +114,7 @@ suite("DemoInstallerTests") { runDemoInstallerTests() }
 suite("FileFramingTests") { runFileFramingTests() }
 suite("RedTDDTests") { runRedTDDTests() }
 suite("AsyncSemaphoreTests") { runAsyncSemaphoreTests() }
+suite("ToolResultTruncatorTests") { runToolResultTruncatorTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #221.

## Summary

Tool results from MCP servers were fed back to the model verbatim with no size check. On the 4096-token context window this causes two distinct failures:

- **CLI mode**: `plainSession.respond()` throws "Input exceeds the 4096-token context window" *after* the tool already ran - wasted work and a confusing error.
- **Server mode**: `ContextManager.makeSession()` drops the oversized tool-result message atomically during trimming, but the synthetic prompt still says "Respond based on the tool result above" - the model confidently hallucinates an answer with no trace of the real data.

Now both paths truncate tool results to fit within the input budget before building the re-prompt. Truncation preserves the head (2/3) and tail (1/3) of the original text with a visible marker noting what was cut.

## Root cause

- `Sources/Session.swift:368` (CLI path) - `executed.resultParts.joined(separator: "\n")` fed directly into the re-prompt string with no size check.
- `Sources/Session.swift:456` (server path) - full tool result appended as a `role:"tool"` message. ContextManager's newest-first trimming treats it as one atomic entry, so a result bigger than the budget makes `keepCount = 0` and drops it entirely while the synthetic prompt still references it.

## The fix

Two changes:

1. **`ToolResultTruncator`** (new, in `ApfelCore`) - pure utility that truncates a string to a character budget with head/tail preservation and a human-readable marker: `[tool output truncated: showing N of M characters]`. No FoundationModels dependency, fully unit-testable.

2. **`Session.swift`** - both `executeMCPToolCallsForCLI` and `executeMCPToolCallsForServer` now truncate tool results before re-prompting:
   - CLI path: budget computed dynamically from `TokenCounter.shared.inputBudget()` minus the prompt template and user prompt overhead (chars/4 approximation).
   - Server path: each tool result capped at `inputBudget * 2` characters (half the input budget using chars/4), leaving room for conversation history and the synthetic prompt.
   - The re-prompt loop in CLI mode also truncates on each iteration.

## Test coverage

- Added `ToolResultTruncatorTests` (10 tests): short input unchanged, exact budget unchanged, oversized truncated with marker, head/tail preservation, empty string, character counts in marker, head-larger-than-tail ratio, very large input, budget-of-1 edge case.
- Updated `ApfelCorePublicAPIUsageTests`: public API surface includes `ToolResultTruncator.truncate(_:maxCharacters:)`.
- Registered new suite in `Tests/apfelTests/main.swift`.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: start `apfel --serve --mcp` with an MCP tool that returns a very large result (e.g. a file-reader tool reading a 50KB file), confirm the model receives a truncated result and responds coherently instead of erroring or hallucinating

## What I verified (static only)

- Traced both re-prompt paths (CLI line 369-401, server line 462-473) to confirm truncation happens before `respond()` / `appendExecutedToolResults`.
- CLI budget computation: `inputBudget() * 4` converts tokens to chars, subtracts template + user prompt overhead, floors at 1000 chars.
- Server budget: `inputBudget() * 2` chars per tool result (half the input budget) leaves room for history and prompt.
- Re-prompt loop (CLI lines 391-403) also uses the same `toolResultBudget`, so chained tool calls are equally protected.
- `ToolResultTruncator.truncate` is a pure function on value types - no concurrency concerns.
- Swift 6 concurrency: no data races introduced. `TokenCounter.shared` is an actor, called with `await` in an existing async context.
- Diff limited to `Sources/Core/ToolResultTruncator.swift`, `Sources/Session.swift`, and three test files - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial from a code audit. No code was copied from the issue body; the fix was written from scratch after reading the source.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_017NgiNUaXUdY5WBkDrawAzm)_