### PR TITLE
fix(cli): route no-args pipe through parse() so APFEL_* env vars apply (#222)

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -71,38 +71,17 @@ func stdinPromptText(_ data: Data) throws -> String {
 
 let rawArgs = Array(CommandLine.arguments.dropFirst())
 
-// No-args + stdin-pipe fast path: `echo "prompt" | apfel` with no flags.
-// Must stay above the parse() call because it needs isatty + await singlePrompt
-// before any parsing happens.
-if rawArgs.isEmpty {
-    if isatty(STDIN_FILENO) == 0 {
-        let input: String
-        do {
-            input = try stdinPromptText(readStdinData())
-        } catch let error as CLIParseError {
-            printError(error.message)
-            exit(exitUsageError)
-        }
-        if !input.isEmpty {
-            do {
-                try await singlePrompt(input, systemPrompt: nil, stream: true)
-                exit(exitSuccess)
-            } catch {
-                let classified = ApfelError.classify(error)
-                printError("\(classified.cliLabel) \(classified.openAIMessage)")
-                exit(exitCode(for: classified))
-            }
-        }
-        if stdinIsPipe() {
-            printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
-        }
-    }
+// No args + interactive terminal: show usage and exit.
+if rawArgs.isEmpty && isatty(STDIN_FILENO) != 0 {
     printUsage()
     exit(exitUsageError)
 }
 
 // Pure, testable parsing. Errors land here as CLIParseError.
-let parsed: CLIArguments
+// FIX #222: the old no-args pipe fast path bypassed parse() entirely,
+// silently dropping every APFEL_* env var and skipping the model check.
+// Now all paths go through parse(), which applies env defaults.
+var parsed: CLIArguments
 do {
     parsed = try CLIArguments.parse(
         rawArgs,
@@ -137,6 +116,11 @@ if parsed.quiet { quietMode = true }
 if parsed.noColor { noColorFlag = true }
 if parsed.debug { ApfelDebugConfiguration.isEnabled = true }
 
+// No-args pipe: default to streaming to preserve `echo "text" | apfel` behavior (#222).
+if rawArgs.isEmpty && isatty(STDIN_FILENO) == 0 && parsed.mode == .single {
+    parsed.mode = .stream
+}
+
 // Build the prompt: positional args + piped stdin + attached files.
 var prompt = parsed.prompt
 var fileContents = parsed.fileContents
@@ -158,7 +142,7 @@ if parsed.mode.acceptsStdinInput && isatty(STDIN_FILENO) == 0 {
         } else {
             fileContents.append(stdinContent)
         }
-    } else if !prompt.isEmpty && !quietMode && stdinIsPipe() {
+    } else if !quietMode && stdinIsPipe() {
         printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
     }
 }

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -267,6 +267,27 @@ func runCLIArgumentsTests() {
         try assertEqual(args.systemPrompt, "Be brief")
     }
 
+    test("no-args parse still applies APFEL_SYSTEM_PROMPT env (#222)") {
+        let args = try CLIArguments.parse([], env: ["APFEL_SYSTEM_PROMPT": "Be brief"])
+        try assertEqual(args.systemPrompt, "Be brief")
+        try assertEqual(args.mode, .single)
+    }
+
+    test("no-args parse still applies all APFEL_* env vars (#222)") {
+        let args = try CLIArguments.parse([], env: [
+            "APFEL_SYSTEM_PROMPT": "Be brief",
+            "APFEL_TEMPERATURE": "0.5",
+            "APFEL_MAX_TOKENS": "200",
+            "APFEL_DEBUG": "1",
+            "APFEL_MCP": "calc.py",
+        ])
+        try assertEqual(args.systemPrompt, "Be brief")
+        try assertEqual(args.temperature, 0.5)
+        try assertEqual(args.maxTokens, 200)
+        try assertTrue(args.debug)
+        try assertEqual(args.mcpServerPaths, ["calc.py"])
+    }
+
     // ========================================================================
     // MARK: - Output flags
     // ========================================================================

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -776,6 +776,36 @@ def test_empty_file_redirect_no_hint(tmp_path):
     assert "piped input was empty" not in result.stderr
 
 
+# --- No-args pipe + env var tests (GH-222) ---
+
+
+def test_no_args_pipe_honors_system_prompt_env():
+    """echo 'text' | APFEL_SYSTEM_PROMPT='...' apfel must apply the env var (#222).
+    The old no-args fast path bypassed parse() entirely, dropping all APFEL_* vars."""
+    require_model()
+    result = run_cli(
+        [],
+        input_text="Reply with exactly the word BANANA and nothing else.",
+        env={"APFEL_SYSTEM_PROMPT": "You must reply with exactly the word BANANA and nothing else."},
+        timeout=60,
+    )
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}: {result.stderr}"
+
+
+def test_no_args_pipe_honors_debug_env():
+    """echo 'text' | APFEL_DEBUG=1 apfel must enable debug logging (#222)."""
+    require_model()
+    result = run_cli(
+        [],
+        input_text="hi",
+        env={"APFEL_DEBUG": "1"},
+        timeout=60,
+    )
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}: {result.stderr}"
+    assert "debug" in result.stderr.lower() or "prompt" in result.stderr.lower(), \
+        "APFEL_DEBUG=1 should produce debug output on stderr"
+
+
 # --- Release info tests ---
 
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #222.

## Summary

The no-args stdin-pipe fast path (`echo "text" | apfel` with zero CLI flags) bypassed `CLIArguments.parse()` entirely. It hardcoded `systemPrompt: nil` and `SessionOptions.defaults`, silently dropping every `APFEL_*` environment variable and skipping the model availability check.

## Root cause

`Sources/main.swift:77-102` had a fast path that fired when `rawArgs.isEmpty`. It read stdin and called `singlePrompt()` directly without ever calling `CLIArguments.parse()`, so `APFEL_SYSTEM_PROMPT`, `APFEL_TEMPERATURE`, `APFEL_MAX_TOKENS`, `APFEL_DEBUG`, `APFEL_MCP`, and all other env-var defaults were never applied. The misleading comment (\"Must stay above the parse() call\") suggested this was intentional, but `parse([], env:)` is pure and cheap - there was no reason to skip it.

## The fix

- Removed the 28-line fast path entirely.
- All code paths now go through `CLIArguments.parse(rawArgs, env:)`, which applies env defaults.
- When `rawArgs` is empty and stdin is piped, mode is overridden from `.single` to `.stream` to preserve the existing `echo \"text\" | apfel` streaming behavior.
- Relaxed the empty-pipe warning condition (`!prompt.isEmpty` guard removed) so `echo \"\" | apfel` still shows the \"piped input was empty\" hint - previously handled by the fast path.
- The model availability check now runs for the no-args pipe path (`.stream` is not excluded), fixing the secondary bug noted in #222.

## Test coverage

- Added `CLIArgumentsTests.swift`: two new unit tests verifying `parse([], env:)` correctly applies `APFEL_SYSTEM_PROMPT`, `APFEL_TEMPERATURE`, `APFEL_MAX_TOKENS`, `APFEL_DEBUG`, and `APFEL_MCP` with zero CLI args.
- Added `cli_e2e_test.py`: `test_no_args_pipe_honors_system_prompt_env` and `test_no_args_pipe_honors_debug_env` - integration tests that reproduce the exact bug scenario (require Apple Intelligence).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: `echo \"greet me\" | APFEL_SYSTEM_PROMPT=\"reply with exactly BANANA\" apfel` now outputs \"BANANA\" (was ignored before)
- [ ] Verify: `echo \"greet me\" | APFEL_SYSTEM_PROMPT=\"reply with exactly BANANA\" apfel --stream` still works (unchanged path)
- [ ] Verify: `echo \"\" | apfel` still shows \"piped input was empty\" hint with exit 2
- [ ] Verify: `apfel` (no args, interactive) still shows usage with exit 2

## What I verified (static only)

- Swift 6 concurrency: no data races introduced. `parsed` changed from `let` to `var` but is only mutated once (mode override) before any async work.
- Diff limited to `Sources/main.swift`, `Tests/apfelTests/CLIArgumentsTests.swift`, `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Existing integration test `test_empty_pipe_no_args_shows_stderr_hint` should still pass (checks stderr for \"piped input was empty\" and exit code 2 - both preserved).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. Issue filed by @Arthur-Ficial from an internal audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._"

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoUBc7Daex91ZPw3QCpysh)_