### PR TITLE
fix(chat): context-rotation failure now exits with correct code (#252)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -239,6 +239,7 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
     let genOpts = makeGenerationOptions(options)
     let lineEditor = ChatLineEditor(outputFormat: outputFormat)
     var turn = 0
+    var chatFatalError: Error?
 
     printHeader()
     if !quietMode {
@@ -320,6 +321,7 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
                 } catch {
                     let classified = ApfelError.classify(error)
                     printError("\(classified.cliLabel) \(classified.openAIMessage)")
+                    chatFatalError = error
                     break
                 }
             }
@@ -336,6 +338,10 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
         } else {
             print(bye)
         }
+    }
+
+    if let error = chatFatalError {
+        throw error
     }
 }
 

--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -873,3 +873,27 @@ def test_chat_hint_message_shown():
     clean = strip_ansi(output)
     assert "quit" in clean.lower() and "exit" in clean.lower(), \
         f"Quit hint not shown: {clean[:300]}"
+
+
+def test_chat_context_rotation_failure_exits_nonzero():
+    """Context rotation failure (strict strategy, overflow) must exit 4, not 0.
+
+    Regression test for #252: the inner catch in the chat loop used `break`
+    which returned from chat() normally, so the process exited 0 even though
+    single-prompt mode maps the same contextOverflow error to exit 4.
+    """
+    require_model()
+    long_text = "word " * 2500
+    returncode, output = run_chat_tty(
+        ["--chat", "--context-strategy", "strict"],
+        steps=[
+            (b"you", (long_text + "\n").encode()),
+            (b"you", (long_text + "\n").encode()),
+            (b"you", (long_text + "\n").encode()),
+        ],
+        timeout=120,
+    )
+    assert returncode == 4, (
+        f"Expected exit 4 (contextOverflow) from context rotation failure, "
+        f"got {returncode}. Output tail: {strip_ansi(output)[-500:]}"
+    )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #252.

## Summary

When context rotation throws in chat mode (e.g. `--context-strategy strict` with a transcript exceeding the 4096-token budget), the inner catch block used `break` to exit the chat loop. This returned from `chat()` normally, so the process exited 0. Single-prompt mode maps the same `contextOverflow` error to exit 4 via `main.swift`'s top-level catch block - chat mode was the only path that silently swallowed the error.

## Root cause

`Sources/CLI.swift:320-324` - the inner catch for context rotation failure did `break`, which exits the while loop. `chat()` then returns normally (no throw), control reaches the end of `main.swift`'s `do` block, and the process exits 0. A wrapper script checking `$?` would see success despite the session dying from an unrecoverable error.

## The fix

Three lines in `CLI.swift`:
1. Added `var chatFatalError: Error?` before the while loop
2. In the inner catch, store `chatFatalError = error` before `break`
3. After the goodbye message, `throw` the stored error if present

This preserves the existing behaviour (error message prints immediately, "Goodbye." still displays) while letting the error propagate to `main.swift`'s catch block, which maps `contextOverflow` to exit 4 via `exitCode(for:)`.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Run `test_chat_context_rotation_failure_exits_nonzero` locally with Apple Intelligence: `python3 -m pytest Tests/integration/test_chat.py::test_chat_context_rotation_failure_exits_nonzero -v`
- [ ] Verify: `apfel --chat --context-strategy strict`, send enough text to overflow, confirm exit code is 4

## Test coverage

- Added `Tests/integration/test_chat.py::test_chat_context_rotation_failure_exits_nonzero` - starts chat with `--context-strategy strict`, sends enough text to overflow the 4096-token window, asserts exit code is 4.
- Existing `ExitCodeMapTests` already lock `contextOverflow -> exit 4`.

## What I verified (static only)

- The fix is three lines in a single function, operating on a local variable.
- Control flow traced: `chatFatalError = error` -> `break` -> goodbye prints -> `throw error` -> `main.swift` catch -> `exit(exitCode(for: classified))`.
- `contextOverflow` maps to exit 4 (verified in `ExitCodeMapTests`).
- Swift 6 concurrency: no data races introduced (`chatFatalError` is local to `chat()`, single-threaded access).
- Diff limited to `Sources/CLI.swift` and `Tests/integration/test_chat.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward control-flow bug. The issue was filed by Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_017sdsMcVBcmN8kjM9dzNs6d)_