### PR TITLE
fix(chat): propagate context-rotation error to exit code (#252)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -239,6 +239,7 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
     let genOpts = makeGenerationOptions(options)
     let lineEditor = ChatLineEditor(outputFormat: outputFormat)
     var turn = 0
+    var chatFatalError: Error? = nil
 
     printHeader()
     if !quietMode {
@@ -318,8 +319,7 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
                         print(styled("  [context rotated — \(options.contextConfig.strategy.rawValue)]", .dim))
                     }
                 } catch {
-                    let classified = ApfelError.classify(error)
-                    printError("\(classified.cliLabel) \(classified.openAIMessage)")
+                    chatFatalError = error
                     break
                 }
             }
@@ -327,6 +327,10 @@ func chat(systemPrompt: String?, options: SessionOptions = .defaults, mcpManager
             let classified = ApfelError.classify(error)
             printError("\(classified.cliLabel) \(classified.openAIMessage)")
         }
+    }
+
+    if let fatal = chatFatalError {
+        throw fatal
     }
 
     if !quietMode {

--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -873,3 +873,22 @@ def test_chat_hint_message_shown():
     clean = strip_ansi(output)
     assert "quit" in clean.lower() and "exit" in clean.lower(), \
         f"Quit hint not shown: {clean[:300]}"
+
+
+def test_chat_context_overflow_strict_exits_nonzero():
+    """#252: context-rotation failure in chat mode must exit with code 4
+    (contextOverflow), not 0. With --context-strategy strict and a huge
+    output reserve the input budget is tiny, so even one turn overflows."""
+    require_model()
+    returncode, output = run_chat_tty(
+        ["--chat", "--context-strategy", "strict",
+         "--context-output-reserve", "4090"],
+        steps=[
+            (b"quit", b"Say hello.\n", 0.5),
+        ],
+        timeout=30,
+    )
+    assert returncode == 4, (
+        f"Expected exit code 4 (contextOverflow), got {returncode}. "
+        f"Output: {strip_ansi(output)[:500]}"
+    )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #252.

## Root cause

When `truncateTranscript` throws in chat mode (e.g. `--context-strategy strict` with history exceeding the token budget), the inner catch block at `Sources/CLI.swift:320-323` ran `break`, which exited the `while true` loop and returned from `chat()` normally. The caller in `main.swift` saw a clean return and exited 0. Single-prompt mode correctly maps the same `ApfelError.contextOverflow` to exit code 4 via `exitCode(for:)`, but chat mode silently swallowed it.

## The fix

Store the error in a `chatFatalError` variable and `break` as before (to exit the chat loop), then rethrow it after the loop - before the "Goodbye." message. This lets the error propagate to `main.swift`'s outer catch block, which classifies it and calls `exit(exitCode(for: classified))`. The error message is printed exactly once (by `main.swift`), and "Goodbye." is skipped on error exit since the session died abnormally.

## Test coverage

- Added `Tests/integration/test_chat.py:test_chat_context_overflow_strict_exits_nonzero` to lock the bug in place. It starts chat with `--context-strategy strict --context-output-reserve 4090` (budget of 6 tokens), sends one prompt, and asserts exit code 4.
- Existing `ExitCodeMapTests.swift` already covers `contextOverflow -> exit 4`.
- Existing `ApfelErrorTests.swift` already covers error classification.

## What I verified (static only)

- The inner catch block no longer prints the error itself (no double-print) - `main.swift`'s catch handles it.
- The `chatFatalError` variable is `Error?` (nullable), so the happy path (no context overflow) is unaffected.
- The thrown error is `ApfelError.contextOverflow`, which `ApfelError.classify()` returns as-is (line 19: `if let already = error as? ApfelError { return already }`).
- MCP shutdown is handled by `main.swift`'s catch block (`await shutdownMCP()` at line 339).
- Swift 6 concurrency: no data races introduced - `chatFatalError` is a local variable within `chat()`.
- Diff limited to `Sources/CLI.swift` and `Tests/integration/test_chat.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by @Arthur-Ficial from a read-only audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj2L9uLhyc2HYyGYPuHpSq)_