### PR TITLE
fix(output): NO_COLOR="" (empty) no longer disables color (#258)

### DIFF
--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -12,8 +12,8 @@ import ApfelCLI
 // Marked `nonisolated(unsafe)` because Swift 6 strict concurrency treats global
 // mutable state as @MainActor-isolated. Safe here: single-threaded CLI, write-once.
 
-/// True if the NO_COLOR environment variable is set (https://no-color.org)
-let noColorEnv = ProcessInfo.processInfo.environment["NO_COLOR"] != nil
+/// True if the NO_COLOR environment variable is set to a non-empty value (https://no-color.org)
+let noColorEnv = ProcessInfo.processInfo.environment["NO_COLOR"].map { !$0.isEmpty } ?? false
 
 /// True if --no-color flag was passed
 nonisolated(unsafe) var noColorFlag = false

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -360,6 +360,13 @@ def test_no_color_disables_ansi_under_tty():
     assert not ANSI_RE.search(output), output
 
 
+def test_empty_no_color_preserves_ansi_under_tty():
+    """NO_COLOR="" (empty string) must NOT disable color per no-color.org and the man page (#258)."""
+    returncode, output = run_cli_tty(["--help"], env={"NO_COLOR": ""})
+    assert returncode == 0
+    assert ANSI_RE.search(output), f"Expected ANSI codes with NO_COLOR='', got: {output[:200]}"
+
+
 def test_quiet_json_prompt_output_is_machine_readable():
     require_model()
     result = run_cli(


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #258.

## Summary

### Root cause

`Sources/Output.swift:16` checked `ProcessInfo.processInfo.environment["NO_COLOR"] != nil`, treating any value - including an empty string - as active. The man page says "When set to any non-empty value" and [no-color.org](https://no-color.org) distinguishes presence from non-empty. Running `NO_COLOR= apfel --help` in a TTY incorrectly stripped all ANSI color codes.

### The fix

Changed the check from `!= nil` to `.map { !$0.isEmpty } ?? false`. Now `NO_COLOR=""` is ignored (color preserved) while `NO_COLOR=1` or any non-empty value still disables color. One-line change, no behavioral difference for the common case (`NO_COLOR=1`).

## Test coverage

- Added `cli_e2e_test.py::test_empty_no_color_preserves_ansi_under_tty` - runs `--help` under a pseudo-TTY with `NO_COLOR=""` and asserts ANSI escape codes are present.
- Existing `test_no_color_disables_ansi_under_tty` (uses `NO_COLOR=1`) remains unchanged as a regression guard.
- Existing `test_help_uses_ansi_under_tty` covers the baseline (no `NO_COLOR` at all).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: `NO_COLOR="" apfel --help` under a TTY shows colored output
- [ ] Verify: `NO_COLOR=1 apfel --help` under a TTY still shows plain output

## What I verified (static only)

- The fix is a single expression change on a global `let` constant.
- `Optional.map` returns `nil` when the key is absent, so `?? false` kicks in - same as the old `!= nil` returning `false`.
- When the key is present with a non-empty value, `.map { !$0.isEmpty }` returns `true` - same as before.
- Only new case: present with empty value now returns `false` instead of `true`.
- Swift 6 concurrency: no change - `noColorEnv` is already a `let` constant, no data races.
- Diff limited to `Sources/Output.swift` and `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward spec-compliance fix. The issue was filed by @Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMNn5Nt9aKaESNSrgHZUxu)_