### PR TITLE
fix(output): NO_COLOR="" (empty) no longer suppresses color (#258)

### DIFF
--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -12,8 +12,8 @@ import ApfelCLI
 // Marked `nonisolated(unsafe)` because Swift 6 strict concurrency treats global
 // mutable state as @MainActor-isolated. Safe here: single-threaded CLI, write-once.
 
-/// True if the NO_COLOR environment variable is set (https://no-color.org)
-let noColorEnv = ProcessInfo.processInfo.environment["NO_COLOR"] != nil
+/// True if the NO_COLOR environment variable is set to a non-empty value (https://no-color.org)
+let noColorEnv = ProcessInfo.processInfo.environment["NO_COLOR"].map { !$0.isEmpty } ?? false
 
 /// True if --no-color flag was passed
 nonisolated(unsafe) var noColorFlag = false

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -360,6 +360,15 @@ def test_no_color_disables_ansi_under_tty():
     assert not ANSI_RE.search(output), output
 
 
+def test_no_color_empty_preserves_ansi_under_tty():
+    """NO_COLOR="" (empty) must NOT suppress color per no-color.org spec."""
+    returncode, output = run_cli_tty(["--help"], env={"NO_COLOR": ""})
+    assert returncode == 0
+    assert ANSI_RE.search(output), (
+        "NO_COLOR='' (empty) should preserve ANSI color but it was suppressed"
+    )
+
+
 def test_quiet_json_prompt_output_is_machine_readable():
     require_model()
     result = run_cli(


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**\n\nFixes #258.\n\n## Summary\n\n`NO_COLOR=\"\"` (empty string, e.g. from `env -i NO_COLOR=` or a CI template) was disabling color output. The no-color.org spec and apfel's own man page (`man/apfel.1.in:338` - \"When set to any non-empty value\") say only a **non-empty** value should count.\n\n## Root cause\n\n`Sources/Output.swift:16` checked `ProcessInfo.processInfo.environment[\"NO_COLOR\"] != nil`, which returns `true` when `NO_COLOR` is present in the environment regardless of its value. An empty string is present but should not trigger the colour suppression.\n\n## The fix\n\nChanged the check from `!= nil` to `.map { !$0.isEmpty } ?? false`, so the variable must be both present and non-empty to suppress colour. This matches the no-color.org spec and the man page's documented behaviour.\n\n## Test coverage\n\n- Added `Tests/integration/cli_e2e_test.py:test_no_color_empty_preserves_ansi_under_tty` to lock the spec-compliant behaviour (empty NO_COLOR must preserve ANSI under a TTY).\n- Existing `test_no_color_disables_ansi_under_tty` still covers the happy path (non-empty NO_COLOR suppresses colour).\n- Existing `test_help_uses_ansi_under_tty` confirms baseline colour output.\n\n## Test plan\n- [ ] `swift build -c release`\n- [ ] `swift run apfel-tests`\n- [ ] `make install` and manual smoke test\n- [ ] `NO_COLOR=\"\" apfel --help` under a TTY shows coloured output\n- [ ] `NO_COLOR=1 apfel --help` under a TTY shows plain output\n\n## What I verified (static only)\n\n- Read `Sources/Output.swift` and traced both code paths (`noColorEnv` and `noColorFlag` via `styled()`).\n- Confirmed the man page (`man/apfel.1.in:338`) documents \"non-empty value\" semantics.\n- Confirmed the no-color.org spec requires non-empty.\n- Swift 6 concurrency: no change to isolation - `noColorEnv` remains a module-level `let`.\n- Diff limited to `Sources/Output.swift` and `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.\n\n## What I did NOT verify\n\n- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.\n\n## Anything that seemed suspicious\n\nNothing - straightforward spec-compliance bug filed by the audit routine.\n\n---\n\ncc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.\n\n_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwdEZj9EQackSLqfVuVUqL)_