### PR TITLE
fix(args): demos subcommand handles --help and rejects unknown flags (#248)

### DIFF
--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -237,8 +237,17 @@ extension CLIArguments {
         // works as a normal prompt because it is not the literal first arg here.
         if args.first == "demos" {
             result.mode = .demos
-            if args.count > 1, !args[1].hasPrefix("-") {
-                result.demosTarget = args[1]
+            for j in 1..<args.count {
+                switch args[j] {
+                case "-h", "--help":
+                    result.mode = .help
+                    return result
+                default:
+                    if args[j].hasPrefix("-") {
+                        throw CLIErrors.unknownOption(args[j])
+                    }
+                    result.demosTarget = args[j]
+                }
             }
             return result
         }

--- a/Tests/apfelTests/CLIArgumentsTests.swift
+++ b/Tests/apfelTests/CLIArgumentsTests.swift
@@ -158,6 +158,27 @@ func runCLIArgumentsTests() {
         try assertEqual(args.demosTarget, "./my-demos")
     }
 
+    test("demos --help sets help mode (#248)") {
+        let args = try CLIArguments.parse(["demos", "--help"])
+        try assertEqual(args.mode, .help)
+    }
+
+    test("demos -h sets help mode (#248)") {
+        let args = try CLIArguments.parse(["demos", "-h"])
+        try assertEqual(args.mode, .help)
+    }
+
+    test("demos with unknown flag throws (#248)") {
+        var threw = false
+        do {
+            _ = try CLIArguments.parse(["demos", "--output", "json"])
+        } catch let e as CLIParseError {
+            try assertTrue(e.message.contains("unknown option"))
+            threw = true
+        }
+        try assertTrue(threw)
+    }
+
     test("quoted prompt 'demos' is NOT the subcommand when it is the prompt value") {
         // A real prompt that happens to equal "demos" still triggers the
         // subcommand (bare first token); users wanting it as a prompt can phrase


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #248.

## Summary

The `demos` subcommand early-return path at `Sources/CLI/CLIArguments.swift:238` bypassed the main parser loop entirely, returning immediately after setting `.demos` mode. This meant `-h`/`--help` after `demos` was either silently discarded or treated as a dash-prefixed non-target, and the command proceeded to write 9 files to disk. Any other flag (`-q`, `-o json`, unknown flags) was also silently ignored.

## Root cause

`CLIArguments.parse()` checked `args.first == "demos"` and returned early with only a single lookahead for a non-dash target directory. It never inspected the remaining args for help flags or unknown options. The `--demos` flag path (line 335) does not have this problem because it goes through the normal parser loop where `-h`/`--help` is handled before `--demos` is reached.

## The fix

Replaced the single-lookahead with a loop over all remaining args after `demos`:
- `-h`/`--help` sets `.help` mode and returns (shows help instead of writing files)
- Unknown dash-prefixed tokens throw `CLIErrors.unknownOption` (consistent with the main parser's behaviour)
- Non-dash tokens set `demosTarget` as before

## Test coverage

- Added `CLIArgumentsTests`: `"demos --help sets help mode (#248)"` - the core bug fix
- Added `CLIArgumentsTests`: `"demos -h sets help mode (#248)"` - short form
- Added `CLIArgumentsTests`: `"demos with unknown flag throws (#248)"` - verifies `CLIParseError` with "unknown option" message
- Existing `"demos subcommand sets demos mode"` and `"demos subcommand with dir captures the target"` still pass unchanged

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: `apfel demos --help` shows help text (was: wrote 9 files)
- [ ] Verify: `apfel demos -h` shows help text
- [ ] Verify: `apfel demos --output json` prints "unknown option" error (was: silently ignored)
- [ ] Verify: `apfel demos ./my-dir` still works as before

## What I verified (static only)

- Traced all code paths through the new loop for: `["demos"]`, `["demos", "./dir"]`, `["demos", "--help"]`, `["demos", "-h"]`, `["demos", "--output", "json"]`, `["demos", "--unknown"]`.
- All four existing `demos` tests pass unchanged (the new loop preserves the target-capture and bare-demos behaviour).
- The `--demos` flag path (line 335) is unaffected - it goes through the main parser.
- Swift 6 concurrency: no data races introduced - pure parsing function, no shared state.
- Diff limited to `Sources/CLI/CLIArguments.swift` and `Tests/apfelTests/CLIArgumentsTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward parser bug with a clear root cause. The issue was filed by @Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvX31sznd7S6RvWaizWMcV)_