### PR TITLE
fix(cli): route usage text to stderr on error exits (#250)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -572,8 +572,10 @@ private func shellPassthrough(_ executable: String, args: [String]) -> Int32 {
 // MARK: - Usage
 
 /// Print the help text. Styled with ANSI colors when on a TTY.
-func printUsage() {
-    print("""
+/// When `toStderr` is true, the output goes to stderr (for usage-error exits);
+/// when false (the default), it goes to stdout (for --help).
+func printUsage(toStderr: Bool = false) {
+    let text = """
     \(styled(appName, .cyan, .bold)) v\(version) — Apple Intelligence from the command line
 
     \(styled("USAGE:", .yellow, .bold))
@@ -676,5 +678,10 @@ func printUsage() {
       \(appName) --count-tokens -o json "hello" | jq .
       APFEL_SYSTEM_PROMPT="Be brief" \(appName) "Explain TCP"
       \(appName) --serve --port 3000 --host 0.0.0.0 --cors
-    """)
+    """
+    if toStderr {
+        printStderr(text)
+    } else {
+        print(text)
+    }
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -77,7 +77,7 @@ if rawArgs.isEmpty {
             printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
         }
     }
-    printUsage()
+    printUsage(toStderr: true)
     exit(exitUsageError)
 }
 

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -304,6 +304,14 @@ def test_help_exit_success():
     assert "USAGE:" in result.stdout
 
 
+def test_usage_error_writes_usage_to_stderr_not_stdout():
+    """Usage text on error exits (exit 2) must go to stderr, not stdout (#250)."""
+    result = run_cli([], input_text="", timeout=10)
+    assert result.returncode == 2
+    assert "USAGE:" not in result.stdout, "usage text must not pollute stdout on error exits"
+    assert "USAGE:" in result.stderr
+
+
 def test_version_exit_success():
     result = run_cli(["--version"])
     assert result.returncode == 0


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #250.

## Summary

`printUsage()` wrote to stdout unconditionally via `print()`. On usage-error exits (exit 2), this pollutes downstream pipes - `apfel --bogus 2>/dev/null | wc -c` gets ~4.8KB of usage text instead of empty output. The `--help` path (exit 0) correctly uses stdout per POSIX convention and is unchanged.

## Root cause

`Sources/CLI.swift:575` - `printUsage()` used `print()` (stdout) with no way to redirect. `Sources/main.swift:107` called it on the error path (no args, exit 2), sending usage text to stdout where it corrupts pipe output.

## The fix

Added a `toStderr: Bool = false` parameter to `printUsage()`. The usage string is now stored in a `let text` variable and routed through either `printStderr()` or `print()` based on the flag. The error path in `main.swift` passes `toStderr: true`; the `--help` path keeps the default (stdout).

## Test plan

- Added `test_usage_error_writes_usage_to_stderr_not_stdout` in `Tests/integration/cli_e2e_test.py` - verifies `USAGE:` appears in stderr (not stdout) when exit code is 2
- Existing `test_help_exit_success` continues to verify `USAGE:` on stdout for `--help` (exit 0)
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- `printUsage()` call sites: exactly two - error path (line 80, now `toStderr: true`) and help path (line 96, default stdout)
- `printStderr()` adds the same trailing newline as `print()`, so output is identical except for the file descriptor
- No other callers of `printUsage()` exist in the codebase
- Diff limited to `Sources/CLI.swift`, `Sources/main.swift`, `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies
- Swift 6 concurrency: no new shared state introduced

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by Arthur-Ficial from the v1.6.1 audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZz2j3qGSTNDhVHoR4VFFS)_