### PR TITLE
fix(cli): route usage text to stderr on usage-error exits (#250)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -572,8 +572,9 @@ private func shellPassthrough(_ executable: String, args: [String]) -> Int32 {
 // MARK: - Usage
 
 /// Print the help text. Styled with ANSI colors when on a TTY.
-func printUsage() {
-    print("""
+/// When `toStderr` is true, the output goes to stderr (for usage-error exits).
+func printUsage(toStderr useStderr: Bool = false) {
+    let text = """
     \(styled(appName, .cyan, .bold)) v\(version) — Apple Intelligence from the command line
 
     \(styled("USAGE:", .yellow, .bold))
@@ -676,5 +677,10 @@ func printUsage() {
       \(appName) --count-tokens -o json "hello" | jq .
       APFEL_SYSTEM_PROMPT="Be brief" \(appName) "Explain TCP"
       \(appName) --serve --port 3000 --host 0.0.0.0 --cors
-    """)
+    """
+    if useStderr {
+        printStderr(text)
+    } else {
+        print(text)
+    }
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -104,7 +104,7 @@ if rawArgs.isEmpty {
             printStderr("\(styled("apfel:", .yellow)) piped input was empty - if the command prints to stderr, try: command 2>&1 | apfel")
         }
     }
-    printUsage()
+    printUsage(toStderr: true)
     exit(exitUsageError)
 }
 

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -304,6 +304,14 @@ def test_help_exit_success():
     assert "USAGE:" in result.stdout
 
 
+def test_no_args_usage_error_writes_to_stderr():
+    """No-args usage-error (exit 2) must write usage text to stderr, not stdout (#250)."""
+    result = run_cli([], input_text="")
+    assert result.returncode == 2
+    assert "USAGE:" in result.stderr, "usage text should appear on stderr for error exits"
+    assert "USAGE:" not in result.stdout, "usage text must not pollute stdout on error exits"
+
+
 def test_version_exit_success():
     result = run_cli(["--version"])
     assert result.returncode == 0


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #250.

## Summary

Usage-error paths (exit 2) printed ~4.8 KB of usage text to **stdout**, polluting downstream pipes. `apfel --bogus 2>/dev/null | wc -c` would count the usage text as program output rather than discarding it with the error.

## Root cause

`printUsage()` in `Sources/CLI.swift:575` unconditionally used `print()` (stdout). The no-args error path at `Sources/main.swift:107` called `printUsage()` then `exit(exitUsageError)` - so usage text landed on stdout even on error exits. The `--help` path (exit 0) correctly uses stdout per POSIX convention, but the error path should use stderr.

## The fix

Added a `toStderr` parameter (default `false`) to `printUsage()`. The function now captures the usage text in a `let text` variable and routes it through `printStderr()` or `print()` depending on the flag. The single error-path call site in `main.swift:107` now passes `printUsage(toStderr: true)`. The `--help` path at `main.swift:127` is unchanged and continues writing to stdout.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## Test coverage

- Added `test_no_args_usage_error_writes_to_stderr` in `Tests/integration/cli_e2e_test.py` to lock the bug: asserts exit 2, `USAGE:` appears in stderr, `USAGE:` does not appear in stdout.
- Existing `test_help_exit_success` still covers the `--help` happy path (usage text on stdout, exit 0).

## What I verified (static only)

- The only `printUsage()` call on an error path is `main.swift:107` - all other `exit(exitUsageError)` sites already use `printError()` (stderr).
- The `--help` path at `main.swift:127` is unaffected (default `toStderr: false`).
- Swift 6 concurrency: no data races introduced - `printUsage` is a synchronous function with no shared mutable state.
- Diff limited to `Sources/CLI.swift`, `Sources/main.swift`, `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a one-line root cause.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1mqzsQgN8PXFqQ8teKxvT)_