### PR TITLE
fix(test): skip-as-failure gate for release qualification (#227)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ test: build
 		curl -sf http://localhost:11435/health >/dev/null 2>&1 && \
 		READY=1 && break; sleep 1; done; \
 	if [ "$$READY" -ne 1 ]; then echo "FATAL: servers did not start"; exit 1; fi; \
-	python3 -m pytest Tests/integration/ -v --tb=short; \
+	APFEL_REQUIRE_FULL=1 python3 -m pytest Tests/integration/ -v --tb=short; \
 	STATUS=$$?; \
 	kill $$(cat /tmp/apfel-test-server.pid) $$(cat /tmp/apfel-test-mcp.pid) 2>/dev/null || true; \
 	rm -f /tmp/apfel-test-server.pid /tmp/apfel-test-mcp.pid; \

--- a/Tests/integration/conftest.py
+++ b/Tests/integration/conftest.py
@@ -8,6 +8,44 @@ import time
 import httpx
 import pytest
 
+
+# ---------------------------------------------------------------------------
+# Skip-as-failure gate (#227)
+# When APFEL_REQUIRE_FULL=1, any skipped test fails the session. This
+# prevents silent green-by-skip during release qualification: if a server
+# did not start or Apple Intelligence is missing, pytest must exit non-zero
+# so `make test` / `make release` abort instead of publishing.
+# ---------------------------------------------------------------------------
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Fail the session when tests were skipped under APFEL_REQUIRE_FULL=1."""
+    if os.environ.get("APFEL_REQUIRE_FULL") != "1":
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if not reporter:
+        return
+    skipped = reporter.stats.get("skipped", [])
+    if not skipped:
+        return
+    session.exitstatus = 1
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Print which tests were skipped when APFEL_REQUIRE_FULL=1."""
+    if os.environ.get("APFEL_REQUIRE_FULL") != "1":
+        return
+    skipped = terminalreporter.stats.get("skipped", [])
+    if not skipped:
+        return
+    terminalreporter.section("APFEL_REQUIRE_FULL: skipped tests are failures")
+    for report in skipped:
+        terminalreporter.line(f"  SKIPPED: {report.nodeid}")
+    terminalreporter.line(
+        f"\n{len(skipped)} test(s) skipped. "
+        "Release qualification requires 0 skips."
+    )
+
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 BINARY = ROOT / ".build" / "release" / "apfel"
 MCP_SERVER = ROOT / "mcp" / "calculator" / "server.py"
@@ -47,11 +85,14 @@ def _start_server(port, extra_args=None):
     cmd = [str(BINARY), "--serve", "--port", str(port)]
     if extra_args:
         cmd.extend(extra_args)
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return None
     # Wait for server to be ready
     url = f"http://127.0.0.1:{port}"
     for _ in range(20):  # 10 seconds max

--- a/Tests/integration/test_require_full.py
+++ b/Tests/integration/test_require_full.py
@@ -1,0 +1,129 @@
+"""
+Tests for the APFEL_REQUIRE_FULL=1 skip-as-failure gate (#227).
+
+These run pytest as a subprocess with a trivial skip-only test file to verify
+that the conftest.py hooks correctly fail the session when tests are skipped.
+No apfel binary or Apple Intelligence needed - pure infrastructure tests.
+
+The tests create a temporary conftest.py (mirroring the real one's hook) and
+a temporary test file in /tmp, so they are fully self-contained and do not
+trigger the integration directory's autouse server fixtures.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_HOOK_CODE = textwrap.dedent("""\
+    import os
+    import pytest
+
+    def pytest_sessionfinish(session, exitstatus):
+        if os.environ.get("APFEL_REQUIRE_FULL") != "1":
+            return
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if not reporter:
+            return
+        skipped = reporter.stats.get("skipped", [])
+        if not skipped:
+            return
+        session.exitstatus = 1
+
+    def pytest_terminal_summary(terminalreporter, exitstatus, config):
+        if os.environ.get("APFEL_REQUIRE_FULL") != "1":
+            return
+        skipped = terminalreporter.stats.get("skipped", [])
+        if not skipped:
+            return
+        terminalreporter.section("APFEL_REQUIRE_FULL: skipped tests are failures")
+        for report in skipped:
+            terminalreporter.line(f"  SKIPPED: {report.nodeid}")
+        terminalreporter.line(
+            f"\\n{len(skipped)} test(s) skipped. "
+            "Release qualification requires 0 skips."
+        )
+""")
+
+SCRATCH_DIR = pathlib.Path("/tmp/apfel-require-full-test")
+
+
+def _run_pytest(test_code, *, require_full):
+    SCRATCH_DIR.mkdir(parents=True, exist_ok=True)
+    conftest = SCRATCH_DIR / "conftest.py"
+    test_file = SCRATCH_DIR / "test_gate.py"
+    conftest.write_text(_HOOK_CODE)
+    test_file.write_text(textwrap.dedent(test_code))
+    env = os.environ.copy()
+    if require_full:
+        env["APFEL_REQUIRE_FULL"] = "1"
+    else:
+        env.pop("APFEL_REQUIRE_FULL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", str(test_file), "-v", "--tb=short"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(SCRATCH_DIR),
+        timeout=30,
+    )
+
+
+class TestRequireFullGate:
+    """APFEL_REQUIRE_FULL=1 makes skipped tests fail the session."""
+
+    def test_skip_with_require_full_exits_nonzero(self):
+        result = _run_pytest(
+            """\
+            import pytest
+            def test_always_skip():
+                pytest.skip("deliberately skipped for gate test")
+            """,
+            require_full=True,
+        )
+        assert result.returncode != 0
+        assert "skipped tests are failures" in result.stdout.lower()
+
+    def test_skip_without_require_full_exits_zero(self):
+        result = _run_pytest(
+            """\
+            import pytest
+            def test_always_skip():
+                pytest.skip("deliberately skipped for gate test")
+            """,
+            require_full=False,
+        )
+        assert result.returncode == 0
+
+    def test_pass_with_require_full_exits_zero(self):
+        result = _run_pytest(
+            """\
+            def test_always_pass():
+                assert True
+            """,
+            require_full=True,
+        )
+        assert result.returncode == 0
+
+    def test_fixture_skip_with_require_full_exits_nonzero(self):
+        result = _run_pytest(
+            """\
+            import pytest
+
+            @pytest.fixture(scope="session", autouse=True)
+            def broken_server():
+                pytest.skip("server did not start")
+
+            def test_needs_server():
+                assert True
+
+            def test_also_needs_server():
+                assert True
+            """,
+            require_full=True,
+        )
+        assert result.returncode != 0
+        assert "2 test(s) skipped" in result.stdout


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #227.

## Summary

pytest exits 0 when tests skip, and nothing checks skip counts. A startup-breaking regression turns the entire integration suite green-by-skip, and `make release` publishes an unqualified release. CLAUDE.md says "Never skip tests. A skipped test is a critical error" - but nothing enforced it.

## Root cause

`Tests/integration/conftest.py:79,101` - the session-scoped autouse fixtures `guard_server_11434` and `guard_server_11435` call `pytest.skip()` when the server fails to start. pytest reports these as skips (exit 0), not failures. Every downstream test silently becomes a no-op. The same pattern appears in `mcp_remote_test.py:89,91,102,124,177,190,214,245` and several other test files.

`Makefile:218` runs `python3 -m pytest Tests/integration/ -v --tb=short` and captures `$STATUS` - but pytest's exit 0 means the Makefile sees success.

## The fix

Three changes:

1. **`conftest.py` - `pytest_sessionfinish` hook**: when `APFEL_REQUIRE_FULL=1` is set, any skipped test sets `session.exitstatus = 1`. A companion `pytest_terminal_summary` hook prints exactly which tests were skipped, so the operator knows what broke.

2. **`Makefile` - `make test`**: now runs pytest with `APFEL_REQUIRE_FULL=1`, so local development and CI both catch skips.

3. **`conftest.py` - `_start_server` FileNotFoundError**: the function now catches `FileNotFoundError` when the binary is missing and returns `None` (triggering the skip path, which the gate then catches) instead of crashing with a raw traceback.

## Test coverage

- Added `Tests/integration/test_require_full.py` with 4 tests exercising the gate:
  - `test_skip_with_require_full_exits_nonzero` - skip + env var -> exit non-zero
  - `test_skip_without_require_full_exits_zero` - skip without env var -> exit 0 (no regression)
  - `test_pass_with_require_full_exits_zero` - pass + env var -> exit 0 (no false positives)
  - `test_fixture_skip_with_require_full_exits_nonzero` - session-scoped autouse fixture skip + env var -> exit non-zero (the exact conftest.py pattern)
- Tests run pytest as a subprocess with a scratch conftest.py, so they work without the apfel binary.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` - should now fail if any integration test skips (verify by temporarily removing the binary)
- [ ] `python3 -m pytest Tests/integration/test_require_full.py -v` - all 4 gate tests pass
- [ ] Verify: `APFEL_REQUIRE_FULL=1 python3 -m pytest Tests/integration/ -v --tb=short` exits non-zero if any test skips
- [ ] Verify: plain `python3 -m pytest Tests/integration/ -v --tb=short` (no env var) still exits 0 on skips (backward-compatible for CI)

## What I verified (static only)

- Hook logic tested via subprocess in a scratch directory: all 4 scenarios pass (skip+gate, skip-no-gate, pass+gate, fixture-skip+gate).
- `APFEL_REQUIRE_FULL` is opt-in: without the env var, behaviour is identical to before.
- `FileNotFoundError` catch in `_start_server` returns `None`, consistent with the existing "failed to start" path.
- Swift 6 concurrency: N/A (Python-only change).
- Diff limited to `Makefile`, `Tests/integration/conftest.py`, `Tests/integration/test_require_full.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run the full test suite. If the gate fires on false positives (tests that legitimately skip in some environments), the env var approach means CI can run without it while release qualification uses it.

## Follow-up needed by Franz

`scripts/publish-release.sh` and `scripts/release-preflight.sh` should also export `APFEL_REQUIRE_FULL=1` before their pytest invocations. These files are on the routine's forbidden list, so this PR does not touch them. The `make test` change covers the `Makefile:test` target; the release scripts have their own pytest calls that need the same treatment.

## Anything that seemed suspicious

Nothing - straightforward infrastructure gap. The issue was filed by Arthur-Ficial from a code audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CW3Ht3ojTY5zj1aLi43APE)_