### PR TITLE
fix(output): check stderr TTY status for stderr-destined styling (#249)

### DIFF
--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -40,7 +40,17 @@ enum ANSIColor: String, Sendable {
 /// Apply ANSI color codes to text. Returns plain text if stdout is not a TTY,
 /// NO_COLOR is set, or --no-color was passed.
 func styled(_ text: String, _ colors: ANSIColor...) -> String {
-    let isTerminal = isatty(STDOUT_FILENO) != 0
+    applyStyle(text, colors: colors, fd: STDOUT_FILENO)
+}
+
+/// Apply ANSI color codes to text destined for stderr. Returns plain text if
+/// stderr is not a TTY, NO_COLOR is set, or --no-color was passed.
+func styledErr(_ text: String, _ colors: ANSIColor...) -> String {
+    applyStyle(text, colors: colors, fd: STDERR_FILENO)
+}
+
+private func applyStyle(_ text: String, colors: [ANSIColor], fd: Int32) -> String {
+    let isTerminal = isatty(fd) != 0
     guard isTerminal, !noColorEnv, !noColorFlag else { return text }
     let prefix = colors.map(\.rawValue).joined()
     return "\(prefix)\(text)\(ANSIColor.reset.rawValue)"
@@ -57,7 +67,7 @@ func printStderr(_ message: String) {
 
 /// Print a styled error message to stderr. Format: "error: <message>"
 func printError(_ message: String) {
-    stderr.write(Data("\(styled("error:", .red, .bold)) \(message)\n".utf8))
+    stderr.write(Data("\(styledErr("error:", .red, .bold)) \(message)\n".utf8))
 }
 
 // MARK: - Debug Output
@@ -65,11 +75,11 @@ func printError(_ message: String) {
 /// Print a debug message to stderr. Zero-cost when debug logging is disabled.
 func debugLog(_ message: @autoclosure () -> String) {
     guard ApfelDebugConfiguration.isEnabled else { return }
-    printStderr("\(styled("debug:", .dim)) \(message())")
+    printStderr("\(styledErr("debug:", .dim)) \(message())")
 }
 
 /// Print a categorized debug message to stderr. Zero-cost when debug logging is disabled.
 func debugLog(_ category: String, _ message: @autoclosure () -> String) {
     guard ApfelDebugConfiguration.isEnabled else { return }
-    printStderr("\(styled("debug[\(category)]:", .dim)) \(message())")
+    printStderr("\(styledErr("debug[\(category)]:", .dim)) \(message())")
 }

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -360,6 +360,40 @@ def test_no_color_disables_ansi_under_tty():
     assert not ANSI_RE.search(output), output
 
 
+def test_stderr_no_ansi_when_only_stdout_is_tty():
+    """Bug #249: styled() checked stdout's TTY status for stderr-destined output.
+    With stdout on a TTY and stderr piped, error messages should NOT have ANSI."""
+    merged_env = os.environ.copy()
+    for key in ["NO_COLOR", "APFEL_SYSTEM_PROMPT", "APFEL_HOST", "APFEL_PORT",
+                "APFEL_TEMPERATURE", "APFEL_MAX_TOKENS"]:
+        merged_env.pop(key, None)
+    master_fd, slave_fd = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [str(BINARY), "--bogus-flag-that-does-not-exist"],
+            stdin=subprocess.PIPE,
+            stdout=slave_fd,
+            stderr=subprocess.PIPE,
+            env=merged_env,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        slave_fd = -1
+        _, stderr_bytes = proc.communicate(timeout=10)
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+        assert proc.returncode != 0, "bad flag should fail"
+        assert "error:" in stderr_text.lower() or "unknown" in stderr_text.lower(), (
+            f"expected error message on stderr, got: {stderr_text!r}"
+        )
+        assert not ANSI_RE.search(stderr_text), (
+            f"stderr should not contain ANSI when stderr is a pipe (stdout is TTY): {stderr_text!r}"
+        )
+    finally:
+        if slave_fd != -1:
+            os.close(slave_fd)
+        os.close(master_fd)
+
+
 def test_quiet_json_prompt_output_is_machine_readable():
     require_model()
     result = run_cli(


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #249.

## Summary

`styled()` checked `isatty(STDOUT_FILENO)` for all ANSI color decisions, but `printError()`, `debugLog()`, and other stderr writers used it too. This caused two symmetric bugs:

1. `apfel --bogus-flag 2>err.log` in a terminal wrote `\x1b[31m\x1b[1merror:\x1b[0m ...` into the log file (ANSI garbage) because stdout was a TTY.
2. `apfel ... | cat` with stderr on a TTY printed uncolored error messages because stdout was a pipe.

Added `styledErr()` checking `isatty(STDERR_FILENO)` and routed `printError` and both `debugLog` overloads through it. The existing `styled()` function is unchanged for stdout-destined output.

## Root cause

`Sources/Output.swift:43` - `let isTerminal = isatty(STDOUT_FILENO) != 0` was used by `styled()`, which was called by `printError()` (line 60), `debugLog()` (lines 68, 74), and many direct `printStderr(styled(...))` call sites across the codebase. The file descriptor check was always against stdout, regardless of where the styled text would actually be written.

## The fix

Three changes in `Sources/Output.swift`:

1. Extracted the shared logic into `private func applyStyle(_:colors:fd:)` that takes a file descriptor parameter.
2. `styled()` now delegates to `applyStyle` with `STDOUT_FILENO` (behavior unchanged).
3. Added `styledErr()` delegating to `applyStyle` with `STDERR_FILENO`.
4. `printError()` and both `debugLog()` overloads now use `styledErr()` instead of `styled()`.

## Follow-up needed

This PR fixes the core API functions (`printError`, `debugLog`). There are additional direct `printStderr(styled(...))` call sites that still use `styled()` instead of `styledErr()`:

- `Sources/Server.swift` - banner lines, error messages (~20 calls)
- `Sources/main.swift:104,169` - empty pipe warnings
- `Sources/CLI.swift:74,173,189` - truncation/count warnings
- `Sources/Session.swift:304,306` - tool logging
- `Sources/MCPClient.swift:443,456` - MCP listing/collision warnings
- `Sources/Logging.swift:66` - event logging

These need the same `styled()` -> `styledErr()` change but span 6+ files, which exceeds the routine's 3-file scope limit. A follow-up PR should sweep these.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify: `apfel --bogus-flag 2>err.log` - err.log should have no ANSI escape codes
- [ ] Verify: `apfel --bogus-flag` in a terminal - stderr should still show colored `error:` prefix
- [ ] Verify: `apfel ... | cat` - stderr errors should still be colored (stderr is a TTY)

## Test coverage

- Added `cli_e2e_test.py::test_stderr_no_ansi_when_only_stdout_is_tty` - runs apfel with an invalid flag, stdout on a PTY (TTY), stderr on a pipe. Asserts the error message is present on stderr and contains NO ANSI escape codes. This is the exact scenario from the bug report.
- Existing `test_help_uses_ansi_under_tty` still covers stdout color output.
- Existing `test_no_color_disables_ansi_under_tty` still covers NO_COLOR suppression.

## What I verified (static only)

- `styled()` behavior is unchanged - it still checks `STDOUT_FILENO` and all stdout-destined call sites (`print(styled(...))` in CLI.swift for help, model-info, chat UI, demos, update) are unaffected.
- `styledErr()` is a new function with no existing callers to break.
- `applyStyle` is private and only called by the two public functions.
- Swift 6 concurrency: no data races introduced. `applyStyle` is a pure function with no shared mutable state beyond the existing `noColorEnv`/`noColorFlag` globals (read-only after startup).
- Diff limited to `Sources/Output.swift` and `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward fd-mismatch bug filed by Arthur-Ficial from the v1.6.1 audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXNTZSzAaAmXBBzjETA3RD)_