### PR TITLE
fix(output): check stderr TTY status for stderr-destined styling (#249)

### DIFF
--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -46,6 +46,16 @@ func styled(_ text: String, _ colors: ANSIColor...) -> String {
     return "\(prefix)\(text)\(ANSIColor.reset.rawValue)"
 }
 
+/// Apply ANSI color codes to text destined for stderr. Checks stderr's TTY
+/// status instead of stdout's, so redirecting stderr strips escape codes even
+/// when stdout is still attached to a terminal.
+func styledErr(_ text: String, _ colors: ANSIColor...) -> String {
+    let isTerminal = isatty(STDERR_FILENO) != 0
+    guard isTerminal, !noColorEnv, !noColorFlag else { return text }
+    let prefix = colors.map(\.rawValue).joined()
+    return "\(prefix)\(text)\(ANSIColor.reset.rawValue)"
+}
+
 // MARK: - Output Helpers
 
 let stderr = FileHandle.standardError
@@ -57,7 +67,7 @@ func printStderr(_ message: String) {
 
 /// Print a styled error message to stderr. Format: "error: <message>"
 func printError(_ message: String) {
-    stderr.write(Data("\(styled("error:", .red, .bold)) \(message)\n".utf8))
+    stderr.write(Data("\(styledErr("error:", .red, .bold)) \(message)\n".utf8))
 }
 
 // MARK: - Debug Output
@@ -65,11 +75,11 @@ func printError(_ message: String) {
 /// Print a debug message to stderr. Zero-cost when debug logging is disabled.
 func debugLog(_ message: @autoclosure () -> String) {
     guard ApfelDebugConfiguration.isEnabled else { return }
-    printStderr("\(styled("debug:", .dim)) \(message())")
+    printStderr("\(styledErr("debug:", .dim)) \(message())")
 }
 
 /// Print a categorized debug message to stderr. Zero-cost when debug logging is disabled.
 func debugLog(_ category: String, _ message: @autoclosure () -> String) {
     guard ApfelDebugConfiguration.isEnabled else { return }
-    printStderr("\(styled("debug[\(category)]:", .dim)) \(message())")
+    printStderr("\(styledErr("debug[\(category)]:", .dim)) \(message())")
 }

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -301,9 +301,9 @@ func printToolLog(_ toolLog: [ToolLogEntry]) {
     guard !quietMode else { return }
     for log in toolLog {
         if log.isError {
-            printStderr("\(styled("tool:", .red)) \(log.name) failed: \(log.result)")
+            printStderr("\(styledErr("tool:", .red)) \(log.name) failed: \(log.result)")
         } else {
-            printStderr("\(styled("tool:", .cyan)) \(log.name)(\(log.args)) = \(log.result)")
+            printStderr("\(styledErr("tool:", .cyan)) \(log.name)(\(log.args)) = \(log.result)")
         }
     }
 }

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -360,6 +360,35 @@ def test_no_color_disables_ansi_under_tty():
     assert not ANSI_RE.search(output), output
 
 
+def test_stderr_no_ansi_when_stderr_not_tty():
+    """stderr must not contain ANSI codes when redirected, even if stdout is a TTY. (#249)"""
+    merged_env = os.environ.copy()
+    merged_env.pop("NO_COLOR", None)
+    merged_env.pop("APFEL_SYSTEM_PROMPT", None)
+
+    master_fd, slave_fd = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [str(BINARY), "--definitely-not-a-real-flag"],
+            stdin=subprocess.PIPE,
+            stdout=slave_fd,
+            stderr=subprocess.PIPE,
+            env=merged_env,
+        )
+    finally:
+        os.close(slave_fd)
+
+    _, stderr_bytes = proc.communicate(timeout=10)
+    os.close(master_fd)
+
+    assert proc.returncode == 2
+    stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+    assert "unknown option" in stderr_text
+    assert not ANSI_RE.search(stderr_text), (
+        f"ANSI escape codes leaked into redirected stderr: {stderr_text!r}"
+    )
+
+
 def test_quiet_json_prompt_output_is_machine_readable():
     require_model()
     result = run_cli(


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #249.

## Summary

`styled()` in `Output.swift` gates colorization on `isatty(STDOUT_FILENO)`, but `printError`, `debugLog`, and `printToolLog` all write to stderr. When stdout is a terminal but stderr is redirected (e.g. `apfel --bogus-flag 2>err.log`), ANSI escape codes leak into the log file. Conversely, when stdout is piped but stderr is a TTY, error messages lose color unnecessarily.

Added `styledErr()` that checks `isatty(STDERR_FILENO)` and routed the core stderr helpers through it.

## Root cause

`Sources/Output.swift:43` - `let isTerminal = isatty(STDOUT_FILENO) != 0` is used by `styled()`, which is called from `printError` (line 60), `debugLog` (lines 68, 74), and `printToolLog` in `Session.swift` (lines 304, 306). These all write to stderr, but the color decision is based on stdout's TTY status.

## The fix

Added `styledErr()` - identical to `styled()` but checks `isatty(STDERR_FILENO)` instead of `STDOUT_FILENO`. Updated the three core stderr helpers (`printError`, `debugLog`, `printToolLog`) to use it. This ensures error messages, debug output, and tool logs respect stderr's own TTY status.

## Test coverage

- Added `test_stderr_no_ansi_when_stderr_not_tty` in `Tests/integration/cli_e2e_test.py` - creates a PTY for stdout but pipes stderr, then asserts no ANSI codes leak into the captured stderr. Model-free, runnable on CI.
- Existing `test_help_uses_ansi_under_tty` and `test_no_color_disables_ansi_under_tty` still cover the stdout color path.

## What I verified (static only)

- `styledErr()` mirrors `styled()` exactly, differing only in the `isatty` file descriptor.
- `printError`, `debugLog` (both overloads), and `printToolLog` are the only helper functions that combine `styled()` with stderr writes.
- Swift 6 concurrency: no data races introduced - `styledErr` reads the same globals as `styled` with identical access patterns.
- Diff limited to `Sources/Output.swift`, `Sources/Session.swift`, `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Remaining call sites (follow-up)

Several direct `printStderr(styled(...))` calls still use stdout-based `styled()`. These are lower-impact (informational messages, server banner, chat UI chrome) and can be swept in a follow-up:
- `main.swift:104,169` - piped-input-empty warning
- `CLI.swift:74,173,189,248,255,335,347` - chat warnings and UI elements
- `Server.swift:233-285` - server startup banner
- `MCPClient.swift:443,456` - MCP connection messages
- `Logging.swift:66` - event logging bullet

## Anything that seemed suspicious

Nothing - straightforward bug with a mechanical fix.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `apfel --bogus-flag 2>err.log && hexdump -C err.log | grep 1b` - should show no ANSI escapes
- [ ] `python3 -m pytest Tests/integration/cli_e2e_test.py::test_stderr_no_ansi_when_stderr_not_tty -v`

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhsomtB1dnhkSRz1vThEdh)_