### PR TITLE
fix(chat): call setlocale(LC_CTYPE) so libedit handles multibyte input (#256)

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -9,6 +9,11 @@ import ApfelCore
 import ApfelCLI
 import CReadline
 
+// MARK: - Locale
+// Honour the user's LC_CTYPE so libedit handles multibyte characters
+// (backspace, arrow keys, Ctrl-W) correctly in --chat (#256).
+setlocale(LC_CTYPE, "")
+
 // MARK: - Configuration
 
 let version = buildVersion

--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -873,3 +873,25 @@ def test_chat_hint_message_shown():
     clean = strip_ansi(output)
     assert "quit" in clean.lower() and "exit" in clean.lower(), \
         f"Quit hint not shown: {clean[:300]}"
+
+
+def test_chat_utf8_input_echoed_correctly():
+    """Non-ASCII UTF-8 input must be echoed intact by libedit (#256).
+
+    Without setlocale(LC_CTYPE, ""), libedit treats input as single-byte,
+    so multibyte characters get garbled on echo. This test types a non-ASCII
+    word, waits for libedit to echo it back in the PTY, then quits.
+    """
+    require_model()
+    returncode, output = run_chat_tty(
+        ["--chat"],
+        steps=[
+            (b"quit", "café\n".encode("utf-8")),
+            (b"caf", b"quit\n"),
+        ],
+        stop_when=lambda out: b"Goodbye" in out,
+        timeout=30,
+    )
+    clean = strip_ansi(output)
+    assert "café" in clean, \
+        f"UTF-8 input not echoed correctly (setlocale missing?): {clean[:400]}"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #256.

## Root cause

apfel never calls `setlocale`, so the process runs in the `"C"` locale regardless of the user's `LANG`/`LC_CTYPE` environment variables. libedit's multibyte character handling (`mbrtowc`, `ct_encode`) depends on `LC_CTYPE` being set correctly. In `apfel --chat`, editing a line containing non-ASCII characters (e.g. `ü`, `é`, emoji) with backspace, arrow keys, or Ctrl-W operates on single bytes instead of characters - one backspace over `é` (two UTF-8 bytes) removes only one byte, leaving a dangling `0xC3` and misdrawing the line.

## The fix

A single `setlocale(LC_CTYPE, "")` call at the top of `main.swift`, before any readline usage. This is the standard C pattern: passing `""` tells `setlocale` to read `LANG`/`LC_CTYPE` from the environment and configure multibyte handling accordingly. libedit then uses `mbrtowc` to measure character widths correctly.

## Test coverage

- Added `Tests/integration/test_chat.py:test_chat_utf8_input_echoed_correctly` to verify that non-ASCII UTF-8 input (`café`) is echoed intact by libedit in a PTY session.
- Existing chat startup/exit tests still cover the happy path.

## What I verified (static only)

- `grep -rn setlocale Sources/` confirms no prior `setlocale` call existed.
- `setlocale(LC_CTYPE, "")` is available via `Foundation` -> `Darwin` -> `<locale.h>` - no new imports needed.
- `CReadline/shim.h` includes `<stdlib.h>` and links `libedit` - the fix is on the Swift side, no C changes required.
- Swift 6 concurrency: `setlocale` is a top-level call before any async work, no data races introduced.
- Diff limited to `Sources/main.swift` and `Tests/integration/test_chat.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed from our own audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEVw3uCCf5WZovAzDpHLeW)_