### PR TITLE
fix(cli): derive Homebrew prefix from binary path (#260)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -493,8 +493,14 @@ func performUpdate() {
         return
     }
 
+    guard let prefix = brewPrefix(fromBinaryPath: resolved) else {
+        print("Could not determine Homebrew prefix. Try: brew upgrade apfel")
+        return
+    }
+    let brewBin = "\(prefix)/bin/brew"
+
     // Check for updates via brew
-    let outdatedJSON = shellOutput("/opt/homebrew/bin/brew", args: ["info", "--json=v2", "apfel"])
+    let outdatedJSON = shellOutput(brewBin, args: ["info", "--json=v2", "apfel"])
     guard let data = outdatedJSON.data(using: .utf8),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
           let formulae = json["formulae"] as? [[String: Any]],
@@ -528,9 +534,10 @@ func performUpdate() {
     }
 
     print(styled("Running: brew upgrade apfel", .dim))
-    let result = shellPassthrough("/opt/homebrew/bin/brew", args: ["upgrade", "apfel"])
+    let result = shellPassthrough(brewBin, args: ["upgrade", "apfel"])
     if result == 0 {
-        let newVersion = shellOutput("/opt/homebrew/bin/apfel", args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let apfelBin = "\(prefix)/bin/apfel"
+        let newVersion = shellOutput(apfelBin, args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
         print(styled("Updated to \(newVersion)", .green))
     } else {
         printError("brew upgrade failed (exit \(result)). Try manually: brew upgrade apfel")

--- a/Sources/CLI/InstallMethod.swift
+++ b/Sources/CLI/InstallMethod.swift
@@ -41,3 +41,17 @@ public func detectInstallMethod(
 
     return .source
 }
+
+/// Extract the Homebrew prefix from a resolved binary path.
+///
+/// Works for both Cellar paths (`<prefix>/Cellar/apfel/…`) and opt symlink
+/// paths (`<prefix>/opt/apfel/…`). Returns `nil` for non-Homebrew paths.
+public func brewPrefix(fromBinaryPath path: String) -> String? {
+    if let range = path.range(of: "/Cellar/apfel/") {
+        return String(path[path.startIndex..<range.lowerBound])
+    }
+    if let range = path.range(of: "/opt/apfel/") {
+        return String(path[path.startIndex..<range.lowerBound])
+    }
+    return nil
+}

--- a/Tests/apfelTests/InstallMethodTests.swift
+++ b/Tests/apfelTests/InstallMethodTests.swift
@@ -84,6 +84,38 @@ func runInstallMethodTests() {
         let result = detectInstallMethod(binaryPath: tmp.appendingPathComponent("bin/apfel").path)
         try assertEqual(result, .source)
     }
+
+    // MARK: - brewPrefix(fromBinaryPath:)
+
+    test("brewPrefix: default Apple Silicon Cellar path") {
+        let path = "/opt/homebrew/Cellar/apfel/1.6.1/bin/apfel"
+        try assertEqual(brewPrefix(fromBinaryPath: path), "/opt/homebrew")
+    }
+
+    test("brewPrefix: Intel Homebrew Cellar path") {
+        let path = "/usr/local/homebrew/Cellar/apfel/1.3.5/bin/apfel"
+        try assertEqual(brewPrefix(fromBinaryPath: path), "/usr/local/homebrew")
+    }
+
+    test("brewPrefix: custom home-directory Homebrew Cellar path") {
+        let path = "/Users/dev/homebrew/Cellar/apfel/2.0.0/bin/apfel"
+        try assertEqual(brewPrefix(fromBinaryPath: path), "/Users/dev/homebrew")
+    }
+
+    test("brewPrefix: opt symlink path") {
+        let path = "/opt/homebrew/opt/apfel/bin/apfel"
+        try assertEqual(brewPrefix(fromBinaryPath: path), "/opt/homebrew")
+    }
+
+    test("brewPrefix: non-homebrew path returns nil") {
+        let path = "/usr/local/bin/apfel"
+        try assertEqual(brewPrefix(fromBinaryPath: path), nil)
+    }
+
+    test("brewPrefix: source build path returns nil") {
+        let path = "/Users/dev/projects/apfel/.build/release/apfel"
+        try assertEqual(brewPrefix(fromBinaryPath: path), nil)
+    }
 }
 
 private func makeTempPrefix() -> URL {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #260.

## Summary

`performUpdate()` hardcoded `/opt/homebrew/bin/{brew,apfel}` in three places. On a non-default Homebrew prefix (e.g. `~/homebrew` on Apple Silicon or `/usr/local/homebrew` on Intel), `detectInstallMethod` correctly returns `.homebrew` but the update then runs a binary that doesn't exist - "Could not check for updates." with an empty post-upgrade version string.

### Root cause

`Sources/CLI.swift:497,531,533` - three hardcoded `/opt/homebrew/bin/` paths used for `brew info`, `brew upgrade`, and `apfel --version` after upgrade.

### The fix

Added `brewPrefix(fromBinaryPath:)` to `Sources/CLI/InstallMethod.swift`. It extracts the Homebrew prefix by finding `/Cellar/apfel/` or `/opt/apfel/` in the resolved binary path and returning everything before it. `performUpdate()` now derives `brewBin` and `apfelBin` from this prefix instead of hardcoding.

### Test coverage

- Added 6 tests in `Tests/apfelTests/InstallMethodTests.swift` for `brewPrefix(fromBinaryPath:)`:
  - Default Apple Silicon Cellar path
  - Intel Homebrew Cellar path
  - Custom home-directory Cellar path
  - Opt symlink path
  - Non-homebrew path returns nil
  - Source build path returns nil
- Existing `detectInstallMethod` tests still cover the detection side.

### What I verified (static only)

- All three hardcoded paths replaced with the dynamic prefix.
- `brewPrefix` returns `nil` for non-Homebrew paths; `performUpdate` handles nil with a user-friendly message.
- Swift 6 concurrency: no data races introduced (pure functions, no shared state).
- Diff limited to `Sources/CLI.swift`, `Sources/CLI/InstallMethod.swift`, `Tests/apfelTests/InstallMethodTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

### What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

### Anything that seemed suspicious

Nothing - straightforward bug filed by Arthur-Ficial from an internal audit.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJmM9bofx5dDStnTUswUPQ)_