### PR TITLE
fix(cli): derive brew prefix from binary path instead of hardcoding /opt/homebrew (#260)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -494,7 +494,8 @@ func performUpdate() {
     }
 
     // Check for updates via brew
-    let outdatedJSON = shellOutput("/opt/homebrew/bin/brew", args: ["info", "--json=v2", "apfel"])
+    let prefix = brewPrefix(from: resolved)
+    let outdatedJSON = shellOutput("\(prefix)/bin/brew", args: ["info", "--json=v2", "apfel"])
     guard let data = outdatedJSON.data(using: .utf8),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
           let formulae = json["formulae"] as? [[String: Any]],
@@ -528,9 +529,9 @@ func performUpdate() {
     }
 
     print(styled("Running: brew upgrade apfel", .dim))
-    let result = shellPassthrough("/opt/homebrew/bin/brew", args: ["upgrade", "apfel"])
+    let result = shellPassthrough("\(prefix)/bin/brew", args: ["upgrade", "apfel"])
     if result == 0 {
-        let newVersion = shellOutput("/opt/homebrew/bin/apfel", args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let newVersion = shellOutput("\(prefix)/bin/apfel", args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
         print(styled("Updated to \(newVersion)", .green))
     } else {
         printError("brew upgrade failed (exit \(result)). Try manually: brew upgrade apfel")

--- a/Sources/CLI/InstallMethod.swift
+++ b/Sources/CLI/InstallMethod.swift
@@ -41,3 +41,20 @@ public func detectInstallMethod(
 
     return .source
 }
+
+/// Derive the Homebrew prefix from a resolved binary path.
+///
+/// For a Cellar path like `/opt/homebrew/Cellar/apfel/1.3.5/bin/apfel`,
+/// returns `/opt/homebrew`. For an opt symlink path like
+/// `/usr/local/homebrew/opt/apfel/bin/apfel`, returns `/usr/local/homebrew`.
+/// Falls back to `/opt/homebrew` if neither pattern matches (caller should
+/// only invoke this after `detectInstallMethod` returned `.homebrew`).
+public func brewPrefix(from binaryPath: String) -> String {
+    if let range = binaryPath.range(of: "/Cellar/apfel/") {
+        return String(binaryPath[..<range.lowerBound])
+    }
+    if let range = binaryPath.range(of: "/opt/apfel/") {
+        return String(binaryPath[..<range.lowerBound])
+    }
+    return "/opt/homebrew"
+}

--- a/Tests/apfelTests/InstallMethodTests.swift
+++ b/Tests/apfelTests/InstallMethodTests.swift
@@ -84,6 +84,43 @@ func runInstallMethodTests() {
         let result = detectInstallMethod(binaryPath: tmp.appendingPathComponent("bin/apfel").path)
         try assertEqual(result, .source)
     }
+
+    // MARK: - brewPrefix(from:) tests
+
+    test("brewPrefix: Apple Silicon Cellar path") {
+        let path = "/opt/homebrew/Cellar/apfel/1.3.5/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/opt/homebrew")
+    }
+
+    test("brewPrefix: Intel Cellar path") {
+        let path = "/usr/local/homebrew/Cellar/apfel/1.3.5/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/usr/local/homebrew")
+    }
+
+    test("brewPrefix: custom prefix Cellar path") {
+        let path = "/Users/me/homebrew/Cellar/apfel/1.6.1/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/Users/me/homebrew")
+    }
+
+    test("brewPrefix: Apple Silicon opt symlink path") {
+        let path = "/opt/homebrew/opt/apfel/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/opt/homebrew")
+    }
+
+    test("brewPrefix: Intel opt symlink path") {
+        let path = "/usr/local/homebrew/opt/apfel/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/usr/local/homebrew")
+    }
+
+    test("brewPrefix: custom prefix opt symlink path") {
+        let path = "/Users/me/homebrew/opt/apfel/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/Users/me/homebrew")
+    }
+
+    test("brewPrefix: non-homebrew path returns default fallback") {
+        let path = "/usr/local/bin/apfel"
+        try assertEqual(brewPrefix(from: path), "/opt/homebrew")
+    }
 }
 
 private func makeTempPrefix() -> URL {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #260.

## Summary

`performUpdate()` hardcoded `/opt/homebrew/bin/{brew,apfel}` at three call sites (lines 497, 531, 533). On Intel Macs (`/usr/local/homebrew`) or custom Homebrew prefixes (e.g. `~/homebrew`), `detectInstallMethod` correctly returns `.homebrew` from the resolved binary path, but the subsequent shell calls target the wrong prefix - so `brew info` fails silently and the user sees "Could not check for updates."

## Root cause

`Sources/CLI.swift` used literal `/opt/homebrew/bin/brew` and `/opt/homebrew/bin/apfel` strings instead of deriving the prefix from the already-resolved binary path that `detectInstallMethod` successfully parsed.

## The fix

Added `brewPrefix(from:)` to `Sources/CLI/InstallMethod.swift` alongside the existing `detectInstallMethod`. It extracts the Homebrew prefix by matching `/Cellar/apfel/` or `/opt/apfel/` in the resolved path and returning everything before the match. Falls back to `/opt/homebrew` if neither pattern matches (should be unreachable when called after `.homebrew` detection).

Updated all three hardcoded paths in `performUpdate()` to use `brewPrefix(from: resolved)`.

## Test coverage

- Added 7 tests to `Tests/apfelTests/InstallMethodTests.swift`:
  - `brewPrefix: Apple Silicon Cellar path`
  - `brewPrefix: Intel Cellar path`
  - `brewPrefix: custom prefix Cellar path`
  - `brewPrefix: Apple Silicon opt symlink path`
  - `brewPrefix: Intel opt symlink path`
  - `brewPrefix: custom prefix opt symlink path`
  - `brewPrefix: non-homebrew path returns default fallback`
- Existing `detectInstallMethod` tests still cover the detection layer.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Diff is 3 files, 58 insertions, 3 deletions - minimal and focused.
- No touches to `.version`, `BuildInfo.swift`, CI workflows, release scripts, or `Package.swift`.
- No new dependencies.
- Swift 6 concurrency: `brewPrefix` is a pure function with no shared state.
- Pattern matching logic checked against Apple Silicon, Intel, and custom prefix paths.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by Arthur-Ficial from an internal audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_018FjVNV39togsSuSqYPrhU4)_