### PR TITLE
fix(chat): call setlocale(LC_CTYPE) so libedit handles multibyte chars (#256)

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -36,6 +36,11 @@ func exitCode(for error: ApfelError) -> Int32 {
     ApfelExitCodes.code(for: error)
 }
 
+// MARK: - Locale
+// Inherit the user's LC_CTYPE so libedit handles multibyte characters
+// (backspace, arrow keys over UTF-8) correctly (#256).
+setlocale(LC_CTYPE, "")
+
 // MARK: - Signal Handling
 
 apfel_install_sigint_exit_handler(isatty(STDOUT_FILENO) != 0 ? 1 : 0)

--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -873,3 +873,29 @@ def test_chat_hint_message_shown():
     clean = strip_ansi(output)
     assert "quit" in clean.lower() and "exit" in clean.lower(), \
         f"Quit hint not shown: {clean[:300]}"
+
+
+# ---------------------------------------------------------------------------
+# Category 9: Locale / Multibyte Input (#256)
+# ---------------------------------------------------------------------------
+
+def test_chat_utf8_input_echoed_correctly():
+    """Non-ASCII UTF-8 input must be echoed without byte-level garbling (#256).
+
+    Without setlocale(LC_CTYPE, ""), libedit operates byte-wise and the pty
+    echo of multibyte characters can produce dangling bytes or mojibake.
+    """
+    require_model()
+    returncode, output = run_chat_tty(
+        ["--chat"],
+        steps=[
+            (b"quit", "hello café\n".encode("utf-8")),
+            (b"quit", b"quit\n", 3),
+        ],
+        stop_when=lambda out: b"Goodbye" in out,
+        timeout=30,
+        env={"LANG": "en_US.UTF-8", "LC_CTYPE": "en_US.UTF-8"},
+    )
+    clean = strip_ansi(output)
+    assert "café" in clean, \
+        f"UTF-8 input garbled in echo: {clean[:400]}"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #256.

## Summary

apfel never calls `setlocale`, so it runs in the `"C"` locale regardless of the user's `LANG=...UTF-8`. libedit's multibyte handling (`ct_encode`/`mbrtowc`) depends on `LC_CTYPE`, so in `apfel --chat`, editing a line with non-ASCII characters (backspace over `é`, arrow-left over emoji, Ctrl-W on `café`) operates on single bytes - one backspace over `é` leaves a dangling `0xC3` byte and misdraws the line.

The fix is a single `setlocale(LC_CTYPE, "")` call at startup in `main.swift`, before any readline/libedit use. This inherits the user's locale from their environment, which is the standard approach for any program using libedit or readline.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `apfel --chat` with `LANG=en_US.UTF-8`, type `café`, backspace once - should delete `é` as a single character, not leave a dangling byte
- [ ] `python3 -m pytest Tests/integration/test_chat.py::test_chat_utf8_input_echoed_correctly -v`

## Root cause

`Sources/main.swift` - no `setlocale` call anywhere in the codebase. `grep -rn setlocale Sources/` returns zero hits. The CReadline module links libedit, and `ChatLineEditor.swift:52-58` wraps `readline()`. Without the locale set, libedit's `mbrtowc` sees every byte as a single-byte character.

## The fix

Added `setlocale(LC_CTYPE, "")` in `main.swift` at line 40, right before the signal handler setup and well before any `ChatLineEditor` construction. Using `LC_CTYPE` specifically (not `LC_ALL`) to only affect character classification without changing number/date formatting.

## Test coverage

- Added `Tests/integration/test_chat.py::test_chat_utf8_input_echoed_correctly` to lock the bug in place - sends `hello café` via pty with `LANG=en_US.UTF-8` and verifies the echo contains `café` without garbling.
- Existing chat startup/exit tests still cover the happy path.

## What I verified (static only)

- `setlocale` and `LC_CTYPE` are available via Foundation's Darwin import (confirmed by `#if canImport(Darwin)` usage elsewhere in `Sources/Core/BufferedLineReader.swift`).
- The call placement is before signal handling (line 41) and before any readline use (chat dispatch at line 303).
- No other files touched. Diff limited to `Sources/main.swift` and `Tests/integration/test_chat.py`.
- Swift 6 concurrency: `setlocale` is a process-wide C call at top-level init, no concurrency implications.
- No touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by the project's own audit routine. The fix is a standard C library initialization call.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9tkvLDT2A1zFVkS7gzEqP)_