### PR TITLE
fix(chat): call setlocale(LC_CTYPE) at startup for libedit multibyte support (#256)

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -36,6 +36,12 @@ func exitCode(for error: ApfelError) -> Int32 {
     ApfelExitCodes.code(for: error)
 }
 
+// MARK: - Locale
+
+// Inherit the user's LC_CTYPE so libedit handles multibyte characters
+// (backspace over ü, arrow-left over emoji) correctly (#256).
+setlocale(LC_CTYPE, "")
+
 // MARK: - Signal Handling
 
 apfel_install_sigint_exit_handler(isatty(STDOUT_FILENO) != 0 ? 1 : 0)

--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -303,6 +303,35 @@ def test_chat_eof_exits_cleanly():
     assert returncode in (0, 1, -9), f"Unexpected exit code: {returncode}"
 
 
+def test_chat_multibyte_backspace_deletes_whole_character():
+    """Backspace over a multibyte character must delete the whole character, not one byte (#256).
+
+    Without setlocale(LC_CTYPE, ""), libedit runs in the "C" locale and treats
+    each byte independently. Backspace over 'u-umlaut' (2 UTF-8 bytes: 0xC3 0xBC)
+    deletes only 0xBC, leaving a dangling 0xC3 in the buffer. The subsequent
+    'quit' then reads as '\\xC3quit' which is not recognized as the exit command.
+
+    With the fix, backspace deletes both bytes, leaving a clean 'quit' that
+    exits normally.
+    """
+    require_model()
+    returncode, output = run_chat_tty(
+        ["--chat"],
+        steps=[
+            # Wait for the prompt, type u-umlaut + DEL (backspace) + "quit"
+            (b"you>", b"\xc3\xbc\x7fquit\n", 0.2),
+        ],
+        env={"LANG": "en_US.UTF-8"},
+        stop_when=lambda out: b"Goodbye" in out,
+        timeout=30,
+    )
+    clean = strip_ansi(output)
+    assert "Goodbye" in clean, (
+        "Backspace did not delete the whole multibyte character - "
+        "setlocale(LC_CTYPE) may be missing"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Category 2: Chat + MCP (5 tests)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #256.

## Summary

`apfel` never called `setlocale`, so the C runtime ran in the `"C"` locale regardless of the user's `LANG=...UTF-8` setting. libedit's multibyte handling (`mbrtowc`) depends on `LC_CTYPE`, so editing non-ASCII characters in `--chat` mode (backspace over `ü`, arrow-left over emoji) operated on single bytes instead of whole characters - one backspace over `é` leaves a dangling `0xC3` byte and misdraws the line.

The fix adds `setlocale(LC_CTYPE, "")` once at startup in `main.swift`, before the signal handler and any readline code. This tells the C library to inherit the user's locale from the environment.

## Root cause

`Sources/main.swift` - no `setlocale` call anywhere in the codebase (`grep -rn setlocale Sources/` returns zero hits). The `ChatLineEditor` wraps libedit's `readline()` via `apfel_readline_interruptible` in the `CReadline` shim, and libedit's `ct_encode`/`mbrtowc` character-width logic reads `LC_CTYPE` at runtime. With the default `"C"` locale, every byte is one character.

## The fix

Added `setlocale(LC_CTYPE, "")` in `Sources/main.swift` before the signal handler installation. The empty string `""` tells the C runtime to read `LC_CTYPE` from the user's environment (`LANG`, `LC_ALL`, `LC_CTYPE`). Using `LC_CTYPE` rather than `LC_ALL` is intentional - it's the minimum scope needed for libedit's multibyte support.

## Test coverage

- Added `test_chat_multibyte_backspace_deletes_whole_character` in `Tests/integration/test_chat.py` to lock the bug in place. The test types `ü` (0xC3 0xBC) followed by DEL (backspace), then `quit`. Without the fix, backspace deletes only one byte (0xBC), leaving `\xC3quit` which is not recognized as the exit command. With the fix, backspace deletes the whole 2-byte character, leaving clean `quit` that exits normally.
- Existing `test_chat_quit_exits_cleanly` still covers the ASCII happy path.

## What I verified (static only)

- `grep -rn setlocale Sources/` confirmed zero existing calls.
- `Sources/CReadline/shim.h` links `edit` (libedit) and wraps `readline()`.
- `Sources/ChatLineEditor.swift:53` calls `apfel_readline_interruptible` which calls `readline(prompt)`.
- Swift 6 concurrency: no data races introduced (single `setlocale` call at startup, before any concurrent code).
- Diff limited to `Sources/main.swift` and `Tests/integration/test_chat.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or build the binary. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by Arthur-Ficial from an audit. The suggested fix matches the standard POSIX pattern for locale initialization.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/test_chat.py::test_chat_multibyte_backspace_deletes_whole_character -v`
- [ ] Manual: `apfel --chat`, type `ü`, press backspace, verify the whole character is deleted

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CndocvQaY4B5y6KfsxexxX)_