### PR TITLE
fix(test): drop flaky speedup_ratio > 1.0 assertions (#264)

### DIFF
--- a/Tests/integration/performance_test.py
+++ b/Tests/integration/performance_test.py
@@ -20,31 +20,24 @@ def test_benchmark_reports_real_speedups():
     payload = json.loads(result.stdout)
     benchmarks = {entry["name"]: entry for entry in payload["benchmarks"]}
 
-    # Optimizations with a large, reliably measurable algorithmic win
-    # (binary-search trims, schema-convert caching, capture short-circuits).
+    # Algorithmic wins (binary-search trims, schema-convert caching, capture
+    # short-circuits) and the message_text_content single-pass refactor all
+    # produce genuine speedups, but wall-clock ratios are noisy run-to-run on
+    # loaded machines - scheduler jitter, thermal throttling, and GC pauses can
+    # push any single measurement below 1.0. Assert output correctness and that
+    # both paths executed; the speedup ratio is informational, not a release gate.
     for name in [
         "trim_newest_first",
         "trim_oldest_first",
         "tool_schema_convert",
         "request_body_capture_disabled",
         "stream_debug_capture_disabled",
+        "message_text_content",
     ]:
         entry = benchmarks[name]
         assert entry["validated"] is True, entry
         assert entry["baseline_avg_ms"] is not None, entry
-        assert entry["speedup_ratio"] is not None, entry
-        assert entry["speedup_ratio"] > 1.0, entry
-
-    # message_text_content is a single-pass correctness/clarity refactor: it
-    # drops one extra pass over `parts` (the image scan), but both paths still
-    # build and join the same intermediate string array, so that shared cost
-    # dominates and the speedup ratio sits at ~1.0 -- below reliable wall-clock
-    # resolution and noisy run-to-run. We assert output correctness and that the
-    # benchmark executed, but not a speedup ratio it cannot stably deliver.
-    text = benchmarks["message_text_content"]
-    assert text["validated"] is True, text
-    assert text["baseline_avg_ms"] is not None, text
-    assert text["current_avg_ms"] >= 0, text
+        assert entry["current_avg_ms"] >= 0, entry
 
     for name in [
         "context_manager_make_session",


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #264.

## Summary

Five benchmarks in `performance_test.py` asserted `speedup_ratio > 1.0`, but wall-clock noise on loaded release machines (scheduler jitter, thermal throttling, GC pauses) can push any single measurement below 1.0 - aborting `make release` mid-flight on scheduler noise rather than a real regression.

This is the same flake class already fixed for `message_text_content` in commit `02592b7` (CHANGELOG 1.6.1). The fix unifies all 6 baseline-vs-optimized benchmarks (`trim_newest_first`, `trim_oldest_first`, `tool_schema_convert`, `request_body_capture_disabled`, `stream_debug_capture_disabled`, `message_text_content`) into a single loop that asserts:
- `validated is True` - output correctness (baseline and optimized produce identical results)
- `baseline_avg_ms is not None` - the baseline path executed
- `current_avg_ms >= 0` - the optimized path executed

The speedup ratio remains in the JSON output for informational purposes but no longer gates the release.

## Root cause

`Tests/integration/performance_test.py:36` - `assert entry["speedup_ratio"] > 1.0` for benchmarks whose algorithmic wins are genuine but whose wall-clock measurements are noisy at low iteration counts (especially the trim benchmarks at 14 iterations).

## Test coverage

- This is a test-only change - the fix is to the test assertions themselves.
- The `validated` field already locks output correctness (binary-search trims produce identical results to linear-scan baselines, cached schema matches uncached, etc.).
- The remaining throughput-only benchmarks (`context_manager_make_session`, `request_pipeline_noninference`, `request_decode`, `tool_call_detect`, `response_encode`) are unchanged.

## What I verified (static only)

- Diff limited to `Tests/integration/performance_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- The pattern matches the existing `message_text_content` de-flake from `02592b7`.
- All 6 baseline-vs-optimized benchmarks still assert correctness via `validated`.
- No code copied from the issue body.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. The change is test-only and follows an established pattern, but confirmation that `--benchmark -o json` still produces the expected fields is needed locally.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Run `apfel --benchmark -o json` and verify all benchmarks report `validated: true`
- [ ] Run `make release` (dry) on a loaded machine to confirm no flake

## Anything that seemed suspicious

Nothing - straightforward test fix. Issue filed by Arthur-Ficial from a read-only audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAVdNKePFnRVgpG2nzt95)_