### PR TITLE
fix(test): de-flake benchmark speedup assertions (#264)

### DIFF
--- a/Tests/integration/performance_test.py
+++ b/Tests/integration/performance_test.py
@@ -20,8 +20,12 @@ def test_benchmark_reports_real_speedups():
     payload = json.loads(result.stdout)
     benchmarks = {entry["name"]: entry for entry in payload["benchmarks"]}
 
-    # Optimizations with a large, reliably measurable algorithmic win
-    # (binary-search trims, schema-convert caching, capture short-circuits).
+    # Optimizations with a large algorithmic win (binary-search trims,
+    # schema-convert caching, capture short-circuits).  Expected speedups are
+    # 3-10x, but wall-clock ratios dip below 1.0 on loaded machines due to
+    # scheduler noise - the same flake class that already hit message_text_content
+    # (de-flaked in v1.6.1).  Gate on output correctness (validated) and a
+    # generous 0.5 floor that catches catastrophic regressions without flaking.
     for name in [
         "trim_newest_first",
         "trim_oldest_first",
@@ -33,7 +37,11 @@ def test_benchmark_reports_real_speedups():
         assert entry["validated"] is True, entry
         assert entry["baseline_avg_ms"] is not None, entry
         assert entry["speedup_ratio"] is not None, entry
-        assert entry["speedup_ratio"] > 1.0, entry
+        assert entry["speedup_ratio"] > 0.5, (
+            f"{name}: speedup_ratio {entry['speedup_ratio']:.3f} below 0.5 "
+            f"(baseline {entry['baseline_avg_ms']:.3f} ms, "
+            f"current {entry['current_avg_ms']:.3f} ms)"
+        )
 
     # message_text_content is a single-pass correctness/clarity refactor: it
     # drops one extra pass over `parts` (the image scan), but both paths still


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #264.

## Root cause

The five algorithmic-win benchmarks (`trim_newest_first`, `trim_oldest_first`, `tool_schema_convert`, `request_body_capture_disabled`, `stream_debug_capture_disabled`) assert `speedup_ratio > 1.0` against wall-clock measurements. On a loaded release machine, scheduler noise can push the measured ratio below 1.0 even when the optimisation is present and working correctly. This is the same flake class that already hit `message_text_content` (de-flaked in v1.6.1, commit `02592b7`). Because `make release` runs these tests after bumping `.version` but before tagging, a flake here aborts the release mid-flight and leaves the repo in a broken state.

## The fix

Lower the speedup ratio threshold from `> 1.0` to `> 0.5`. These are genuine algorithmic wins (binary-search vs linear-scan, cache hit vs recompute, short-circuit vs materialise) with expected speedups of 3-10x. A threshold of 0.5 means "current path is at most 2x slower than baseline" - a result that is essentially impossible from scheduler noise alone, but would catch a catastrophic regression where the optimisation was inverted or severely degraded. Output correctness remains gated on the `validated` field. The assertion error message now surfaces the actual ratio and timings for easier diagnosis.

## Test coverage

- This IS the test fix. The bug is in `Tests/integration/performance_test.py` itself - the assertion threshold is the source of the flake.
- The `validated is True` assertion still guards output correctness for all five benchmarks.
- The `message_text_content` de-flake pattern (lines 46-55) is unchanged and serves as the precedent for this approach.

## What I verified (static only)

- Read `Sources/Benchmark.swift` end-to-end to confirm the speedup_ratio calculation (`baseline_avg_ms / current_avg_ms`) and iteration counts.
- Confirmed the five benchmarks measure genuinely different code paths (legacy vs optimised), not the same function twice.
- Verified the `message_text_content` de-flake in CHANGELOG 1.6.1 as precedent.
- Diff limited to `Tests/integration/performance_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: N/A (Python test file only).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run the benchmark binary. The threshold of 0.5 is based on analysis of the algorithmic wins (3-10x expected) and noise characteristics - Franz should confirm it matches observed ratios on his release machine.

## Anything that seemed suspicious

Nothing - straightforward test-flake fix. The issue was filed by @Arthur-Ficial from a read-only audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbqyLa8QZ8fmNibxLgd4Cz)_