### PR TITLE
fix(test): fail release qualification when integration tests skip (#227)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ test: build
 		curl -sf http://localhost:11435/health >/dev/null 2>&1 && \
 		READY=1 && break; sleep 1; done; \
 	if [ "$$READY" -ne 1 ]; then echo "FATAL: servers did not start"; exit 1; fi; \
-	python3 -m pytest Tests/integration/ -v --tb=short; \
+	APFEL_REQUIRE_FULL=1 python3 -m pytest Tests/integration/ -v --tb=short; \
 	STATUS=$$?; \
 	kill $$(cat /tmp/apfel-test-server.pid) $$(cat /tmp/apfel-test-mcp.pid) 2>/dev/null || true; \
 	rm -f /tmp/apfel-test-server.pid /tmp/apfel-test-mcp.pid; \

--- a/Tests/integration/conftest.py
+++ b/Tests/integration/conftest.py
@@ -109,3 +109,21 @@ def guard_server_11435():
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Fail the run when tests were skipped and APFEL_REQUIRE_FULL=1."""
+    if os.environ.get("APFEL_REQUIRE_FULL") != "1":
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is None:
+        return
+    skipped = len(reporter.stats.get("skipped", []))
+    if skipped > 0:
+        session.exitstatus = 1
+        reporter.write_line(
+            f"\nFATAL: {skipped} test(s) skipped with APFEL_REQUIRE_FULL=1. "
+            "Skips are not allowed during release qualification.",
+            red=True,
+            bold=True,
+        )

--- a/Tests/integration/test_skip_enforcement.py
+++ b/Tests/integration/test_skip_enforcement.py
@@ -1,0 +1,119 @@
+"""
+Tests for the APFEL_REQUIRE_FULL skip-enforcement hook (#227).
+
+Release qualification must never silently pass when tests are skipped.
+The conftest.py pytest_sessionfinish hook enforces this when
+APFEL_REQUIRE_FULL=1 is set. These tests verify the hook's behavior
+by running pytest in a subprocess with controlled skip scenarios.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+import tempfile
+
+import pytest
+
+
+CONFTEST_PATH = os.path.join(os.path.dirname(__file__), "conftest.py")
+
+HOOK_SOURCE = textwrap.dedent("""\
+    import os
+
+    def pytest_sessionfinish(session, exitstatus):
+        if os.environ.get("APFEL_REQUIRE_FULL") != "1":
+            return
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is None:
+            return
+        skipped = len(reporter.stats.get("skipped", []))
+        if skipped > 0:
+            session.exitstatus = 1
+""")
+
+SKIP_TEST = textwrap.dedent("""\
+    import pytest
+    def test_intentional_skip():
+        pytest.skip("controlled skip for enforcement test")
+""")
+
+PASS_TEST = textwrap.dedent("""\
+    def test_passes():
+        assert True
+""")
+
+
+def _run_pytest_in_tmpdir(conftest_src, test_src, env_override=None, timeout=30):
+    """Run pytest in a temp dir with the given conftest and test source."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "conftest.py"), "w") as f:
+            f.write(conftest_src)
+        with open(os.path.join(tmpdir, "test_target.py"), "w") as f:
+            f.write(test_src)
+
+        env = os.environ.copy()
+        env.pop("APFEL_REQUIRE_FULL", None)
+        if env_override:
+            env.update(env_override)
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "pytest",
+                os.path.join(tmpdir, "test_target.py"),
+                "-v", "--no-header",
+                "-p", "no:cacheprovider",
+                "--override-ini=addopts=",
+                "--rootdir", tmpdir,
+                "-c", os.devnull,
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=tmpdir,
+            timeout=timeout,
+        )
+        return result
+
+
+def test_conftest_has_sessionfinish_hook():
+    """The real conftest.py must define pytest_sessionfinish for skip enforcement."""
+    with open(CONFTEST_PATH) as f:
+        source = f.read()
+    assert "def pytest_sessionfinish" in source, (
+        "conftest.py must define pytest_sessionfinish hook for skip enforcement"
+    )
+    assert "APFEL_REQUIRE_FULL" in source, (
+        "pytest_sessionfinish must check APFEL_REQUIRE_FULL env var"
+    )
+
+
+def test_enforcement_fails_on_skip_with_env_set():
+    """With APFEL_REQUIRE_FULL=1, a skipped test must cause nonzero exit."""
+    result = _run_pytest_in_tmpdir(
+        HOOK_SOURCE, SKIP_TEST, env_override={"APFEL_REQUIRE_FULL": "1"}
+    )
+    assert result.returncode != 0, (
+        f"Expected nonzero exit when APFEL_REQUIRE_FULL=1 and a test skipped.\n"
+        f"stdout:\n{result.stdout[-500:]}\nstderr:\n{result.stderr[-500:]}"
+    )
+
+
+def test_enforcement_allows_skip_without_env():
+    """Without APFEL_REQUIRE_FULL, a skipped test exits 0 (default pytest)."""
+    result = _run_pytest_in_tmpdir(HOOK_SOURCE, SKIP_TEST)
+    assert result.returncode == 0, (
+        f"Expected exit 0 without APFEL_REQUIRE_FULL.\n"
+        f"stdout:\n{result.stdout[-500:]}\nstderr:\n{result.stderr[-500:]}"
+    )
+
+
+def test_enforcement_passes_when_no_skips():
+    """With APFEL_REQUIRE_FULL=1 but no skips, exit must be 0."""
+    result = _run_pytest_in_tmpdir(
+        HOOK_SOURCE, PASS_TEST, env_override={"APFEL_REQUIRE_FULL": "1"}
+    )
+    assert result.returncode == 0, (
+        f"Expected exit 0 with APFEL_REQUIRE_FULL=1 but no skips.\n"
+        f"stdout:\n{result.stdout[-500:]}\nstderr:\n{result.stderr[-500:]}"
+    )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #227.

## Root cause

pytest exits 0 when all tests are skipped. The session-scoped autouse fixtures in `conftest.py` (lines 79, 101) call `pytest.skip()` when servers fail to start, and the `mcp_remote_test.py` fixtures do the same at lines 102, 124, 190, 214, 245. Since neither `make test`, `release-preflight.sh`, nor `publish-release.sh` check for skipped test counts, a startup-breaking regression turns the entire suite green-by-skip and `make release` publishes an unqualified build.

## The fix

Added a `pytest_sessionfinish` hook in `Tests/integration/conftest.py` that checks for skipped tests when `APFEL_REQUIRE_FULL=1` is set. If any test was skipped, it sets `session.exitstatus = 1` and prints a clear FATAL message. The `make test` target now exports `APFEL_REQUIRE_FULL=1` before running pytest, so the enforcement is active during development builds.

The existing `pytest.skip()` calls are preserved - during casual development (running individual test files without the env var), skips still work as before. The hook only bites during `make test` and release qualification, where silent skips are dangerous.

## Test coverage

- Added `Tests/integration/test_skip_enforcement.py` with 4 tests:
  - `test_conftest_has_sessionfinish_hook` - verifies the hook exists in the real conftest.py
  - `test_enforcement_fails_on_skip_with_env_set` - subprocess pytest with `APFEL_REQUIRE_FULL=1` and a skip returns nonzero
  - `test_enforcement_allows_skip_without_env` - subprocess pytest without the env var and a skip returns 0
  - `test_enforcement_passes_when_no_skips` - subprocess pytest with `APFEL_REQUIRE_FULL=1` and no skips returns 0

## What I verified (static only)

- All 4 new tests pass on the cloud runner (`pytest --noconftest`)
- The hook logic uses the standard `terminalreporter` plugin to count skips
- The `APFEL_REQUIRE_FULL` env var is opt-in, so existing dev workflows are unaffected
- Diff limited to `Tests/integration/conftest.py`, `Tests/integration/test_skip_enforcement.py`, and `Makefile`
- No touches to release infrastructure, guardrails, CI, or dependencies
- Swift 6 concurrency: not applicable (Python-only change)

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or the full integration suite. The hook and tests are pure Python and don't touch the Swift codebase, but the Makefile change should be verified end-to-end.

## Follow-up needed (forbidden files)

The issue also suggests setting `APFEL_REQUIRE_FULL=1` in `scripts/release-preflight.sh` (line 118) and `scripts/publish-release.sh` (line 86). These are release infrastructure files I cannot modify from a routine. Franz should add:
```
APFEL_REQUIRE_FULL=1 python3 -m pytest Tests/integration/ -v --tb=short
```
to both scripts to close the gap completely.

## Anything that seemed suspicious

Nothing - straightforward test infrastructure bug filed by Arthur-Ficial from an audit.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5n9RTTnT6P7hmeCxJuDmN)_