### PR TITLE
fix(test): noise-tolerant speedup floor for benchmark assertions (#264)

### DIFF
--- a/Tests/integration/performance_test.py
+++ b/Tests/integration/performance_test.py
@@ -6,6 +6,13 @@ import subprocess
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 BINARY = ROOT / ".build" / "release" / "apfel"
 
+# Wall-clock ratios fluctuate under scheduler noise. Real algorithmic wins
+# (binary-search trims 3-30x, schema-cache 380x+, short-circuits) stay far
+# above this floor; a ratio below it means the optimised path is genuinely
+# slower than baseline, not just jittered. Output correctness is verified
+# separately via the 'validated' flag.
+SPEEDUP_FLOOR = 0.8
+
 
 def test_benchmark_reports_real_speedups():
     result = subprocess.run(
@@ -33,7 +40,7 @@ def test_benchmark_reports_real_speedups():
         assert entry["validated"] is True, entry
         assert entry["baseline_avg_ms"] is not None, entry
         assert entry["speedup_ratio"] is not None, entry
-        assert entry["speedup_ratio"] > 1.0, entry
+        assert entry["speedup_ratio"] > SPEEDUP_FLOOR, entry
 
     # message_text_content is a single-pass correctness/clarity refactor: it
     # drops one extra pass over `parts` (the image scan), but both paths still


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #264.

## Root cause

The five benchmarks with `speedup_ratio` assertions (`trim_newest_first`, `trim_oldest_first`, `tool_schema_convert`, `request_body_capture_disabled`, `stream_debug_capture_disabled`) all gate on `> 1.0`. Wall-clock timing is inherently noisy - the trim benchmarks run only 14 iterations, making them especially vulnerable to scheduler jitter. On a loaded release machine, a context switch during the optimised timing window inflates the average and pushes the measured ratio below 1.0, aborting `make release` mid-flight after the version bump but before the tag.

## The fix

Introduces a `SPEEDUP_FLOOR = 0.8` constant and replaces the hardcoded `> 1.0` threshold. The real algorithmic wins (binary-search trims at 3-30x, schema-cache at 380x+, capture short-circuits) stay far above this floor under any reasonable load. A ratio below 0.8 means the "optimised" path is genuinely and categorically slower than baseline - not just jittered. Output correctness continues to be verified separately via the `validated` flag on every benchmark.

This follows the same de-flake pattern applied to `message_text_content` in commit `02592b7`, but retains a floor assertion (rather than dropping it entirely) because these five benchmarks have large, reliable algorithmic wins that warrant a regression guard.

## Test coverage

- The fix IS to the test infrastructure itself. `Tests/integration/performance_test.py` is the test file being hardened against flaky failures.
- The `validated is True` assertion continues to guard output correctness for all five benchmarks.
- The `baseline_avg_ms is not None` and `speedup_ratio is not None` assertions continue to verify the benchmark ran both paths.

## What I verified (static only)

- Read `Sources/Benchmark.swift` end to end: confirmed iteration counts (14 for trims, 500-2000 for others), `measure()` helper uses `DispatchTime.now().uptimeNanoseconds` with only 2 warmup iterations.
- Confirmed `speedup_ratio = baseline.avgMilliseconds / optimized.avgMilliseconds` at lines 139, 183, 225, 277, 296, 329.
- Confirmed commit `02592b7` used the same de-flake pattern for `message_text_content`.
- Diff limited to `Tests/integration/performance_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: not applicable (Python test file).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. The 0.8 floor value is based on static analysis of the expected speedup magnitudes - Franz should confirm it holds on a loaded machine by running `apfel --benchmark -o json` several times under load.

## Future improvement

The issue also suggests asserting algorithmic properties (e.g. comparison counts for binary-search trims) instead of wall-clock ratios. That would require changes to `Sources/Benchmark.swift` to instrument the trim and cache paths with operation counters. Worth considering as a follow-up if the noise floor approach proves insufficient.

## Anything that seemed suspicious

Nothing - straightforward test infrastructure fix.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CH5i1Kw1dQcKKpSNDepogZ)_