### PR TITLE
fix(token-counter): decouple isTokenCountingAvailable from model.isAvailable (#315)

### DIFF
--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -13,21 +13,17 @@ actor TokenCounter {
     private let model = SystemLanguageModel.default
 
     /// Count tokens in text using the real FoundationModels API.
-    /// Falls back to chars/4 approximation on error or when the model is unavailable.
+    /// Falls back to chars/4 approximation on error.
     func count(_ text: String) async -> Int {
         guard !text.isEmpty else { return 0 }
-        guard isAvailable else {
-            return max(1, text.count / 4)
-        }
         if #available(macOS 26.4, *) {
             do {
                 return try await model.tokenCount(for: text)
             } catch {
                 return max(1, text.count / 4)
             }
-        } else {
-            return max(1, text.count / 4)
         }
+        return max(1, text.count / 4)
     }
 
     /// Real context window size from the model.
@@ -45,10 +41,9 @@ actor TokenCounter {
         model.isAvailable
     }
 
-    /// Whether the real tokenCount API is usable (model available AND macOS 26.4+).
-    /// When false, token counts fall back to chars/4 approximation.
+    /// Whether the platform supports real token counting (macOS 26.4+).
+    /// Individual count calls still fall back to chars/4 if tokenCount throws.
     var isTokenCountingAvailable: Bool {
-        guard isAvailable else { return false }
         if #available(macOS 26.4, *) { return true }
         return false
     }
@@ -108,18 +103,14 @@ actor TokenCounter {
     /// More accurate than counting individual text strings.
     func count(entries: [Transcript.Entry]) async -> Int {
         guard !entries.isEmpty else { return 0 }
-        guard isAvailable else {
-            return fallbackCount(entries: entries)
-        }
         if #available(macOS 26.4, *) {
             do {
                 return try await model.tokenCount(for: entries)
             } catch {
                 return fallbackCount(entries: entries)
             }
-        } else {
-            return fallbackCount(entries: entries)
         }
+        return fallbackCount(entries: entries)
     }
 
     private func fallbackCount(entries: [Transcript.Entry]) -> Int {

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -605,6 +605,20 @@ def test_count_tokens_json_trailing_newline():
 
 
 @pytest.mark.model
+def test_count_tokens_real_not_approximate():
+    """When the model is available, --count-tokens uses the real tokenCount API,
+    not the chars/4 fallback (#315)."""
+    require_model()
+    result = run_cli(["--count-tokens", "-o", "json", "hello world"], timeout=30)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    data = json.loads(result.stdout.strip())
+    assert data["approximate"] is False, (
+        f"expected approximate=false with model available, "
+        f"got approximate={data['approximate']!r} (#315)"
+    )
+
+
+@pytest.mark.model
 def test_stream_returns_content():
     require_model()
     result = run_cli(["--stream", "Reply with the single word OK."], timeout=90)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #315.

## Summary

`TokenCounter.isTokenCountingAvailable` gated on `model.isAvailable`, which can transiently return `false` even when the `tokenCount(for:)` API works fine. This caused `--count-tokens` to always take the chars/4 fallback path and print the "Apple Intelligence unavailable" warning on machines where generation worked moments earlier in the same script run.

The fix removes the `isAvailable` dependency from three places in `TokenCounter.swift`:

- **`isTokenCountingAvailable`** - now checks only `#available(macOS 26.4, *)` (platform capability), not runtime model state. The property answers "can this platform do real token counting?", which is a static fact.
- **`count(_ text:)`** - no longer guards on `isAvailable` before trying the real API. On macOS 26.4+, always attempts `model.tokenCount(for:)` first; the existing `try/catch` handles actual failures gracefully by falling back to chars/4.
- **`count(entries:)`** - same pattern as above.

The `isAvailable` property itself is unchanged and still used by its other consumers (`/health` endpoint, benchmarks, `prewarm()`, the model-availability gate in `main.swift`).

## Root cause

`TokenCounter` stores its own `SystemLanguageModel.default` instance. The `isAvailable` property on this instance can transiently return `false` under conditions where the model is actually functional (likely thermal/contention after heavy OCR processing, or cold-start timing). The `--count-tokens` path checked `isAvailable` upfront and committed entirely to the approximate path, never even attempting the real `tokenCount(for:)` API. Since `countTokens` in `CLI.swift` was already designed to be model-free (it is exempted from the availability gate in `main.swift`), the `isAvailable` guard was an unnecessary fragility.

## The fix

Decouple `isTokenCountingAvailable` from `isAvailable` so it reflects platform capability only. Remove the `isAvailable` guards from `count()` and `count(entries:)` so they always try the real API first on macOS 26.4+, falling back to chars/4 via the existing try/catch on actual failure. This is both simpler and more resilient than the upfront check.

## Test plan

- Added `test_count_tokens_real_not_approximate` (`@pytest.mark.model`) to lock `approximate=false` when Apple Intelligence is available.
- Existing model-free tests (`test_count_tokens_json_shape`, `test_count_tokens_strict_exit_over_budget`, `test_count_tokens_json_trailing_newline`) still cover the shape and behavior of the fallback path.
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `apfel --count-tokens -o json "hello"` shows `"approximate": false`
- [ ] `apfel -f Tests/integration/fixtures/lesbar/irs_w9.pdf --count-tokens "Summarize this form."` no longer prints the chars/4 warning
- [ ] `scripts/generate-examples.sh` produces `--count-tokens` examples without the fallback warning

## What I verified (static only)

- Diff limited to `Sources/TokenCounter.swift` and `Tests/integration/cli_e2e_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced (removed guards only, no new shared state).
- `isAvailable` remains available for its other consumers (health, benchmarks, prewarm, main.swift gate).
- The existing try/catch in `count()` and `count(entries:)` handles actual API failures gracefully.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by @franzenzenhofer with clear reproduction evidence from `docs/EXAMPLES.md`.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_016s9UEMQcnhRbKa2r2NtyhK)_