### PR TITLE
fix(token-count): name the real chars/4 fallback reason (macOS < 26.4 vs Apple Intelligence) (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `--count-tokens` chars/4 fallback warning now names the actual reason instead of always blaming Apple Intelligence. On a Mac running macOS older than 26.4 the `tokenCount(for:)` API does not exist at runtime even though generation works fine, so the old message ("Apple Intelligence unavailable") was false and misleading - it made real doc output look like a broken machine. The reason decision is a pure, unit-tested `TokenCountFallback` in ApfelCore: `osTooOld` (names the required 26.4 and the actual OS version) wins over `modelUnavailable`. Covered by unit tests and a model-free cli_e2e test that asserts the warning against the host OS version (#315).
+
 ## [1.7.0] - 2026-07-02
 
 ### Added

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -90,7 +90,8 @@ func countTokens(
     let mcpTools = await mcpManager?.allTools() ?? []
     let outputReserve = options.contextConfig.outputReserve
     let contextSize = await TokenCounter.shared.contextSize
-    let approximate = !(await TokenCounter.shared.isTokenCountingAvailable)
+    let tokenCountFallback = await TokenCounter.shared.tokenCountFallback
+    let approximate = tokenCountFallback != nil
 
     let inputEntries: [Transcript.Entry]
     let noToolEntries: [Transcript.Entry]?
@@ -169,8 +170,8 @@ func countTokens(
         approximate: approximate
     )
 
-    if approximate && !quietMode {
-        printStderr("\(styledErr("apfel:", .yellow)) token count is approximate (Apple Intelligence unavailable; using chars/4 fallback)")
+    if let tokenCountFallback, !quietMode {
+        printStderr("\(styledErr("apfel:", .yellow)) \(tokenCountFallback.message)")
     }
 
     switch outputFormat {

--- a/Sources/Core/TokenCountFallback.swift
+++ b/Sources/Core/TokenCountFallback.swift
@@ -1,0 +1,42 @@
+// ============================================================================
+// TokenCountFallback.swift — Why token counting fell back to chars/4 (ApfelCore)
+// ============================================================================
+
+import Foundation
+
+/// Why the real `tokenCount(for:)` API was not used and token counts fell
+/// back to the chars/4 approximation. Pure: callers supply the runtime facts
+/// (OS capability and model availability), this type only decides and phrases
+/// the reason. `nil` from `reason` means the real API is usable.
+public enum TokenCountFallback: Sendable, Equatable {
+    /// The running macOS is older than 26.4, which introduced
+    /// `SystemLanguageModel.tokenCount(for:)`. The model itself may be
+    /// fully available for generation (#315).
+    case osTooOld(currentOS: String)
+    /// The on-device model reports unavailable (Apple Intelligence disabled,
+    /// device not eligible, model not ready).
+    case modelUnavailable
+
+    /// Decide the fallback reason from runtime facts. The OS check wins over
+    /// model availability: on an old OS the real API does not exist at all,
+    /// regardless of model state.
+    public static func reason(
+        modelAvailable: Bool,
+        osSupportsTokenCounting: Bool,
+        currentOS: String
+    ) -> TokenCountFallback? {
+        if !osSupportsTokenCounting { return .osTooOld(currentOS: currentOS) }
+        if !modelAvailable { return .modelUnavailable }
+        return nil
+    }
+
+    /// Human-readable explanation for the stderr warning.
+    public var message: String {
+        switch self {
+        case .osTooOld(let currentOS):
+            return "token count is approximate (the on-device tokenizer API requires macOS 26.4+; this Mac runs macOS \(currentOS); using chars/4 fallback)"
+        case .modelUnavailable:
+            return "token count is approximate (Apple Intelligence unavailable; using chars/4 fallback)"
+        }
+    }
+}

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -48,9 +48,25 @@ actor TokenCounter {
     /// Whether the real tokenCount API is usable (model available AND macOS 26.4+).
     /// When false, token counts fall back to chars/4 approximation.
     var isTokenCountingAvailable: Bool {
-        guard isAvailable else { return false }
-        if #available(macOS 26.4, *) { return true }
-        return false
+        tokenCountFallback == nil
+    }
+
+    /// Why token counting falls back to chars/4, or nil when the real API is
+    /// usable. Distinguishes "this macOS predates the tokenizer API" from
+    /// "Apple Intelligence is unavailable" so the warning names the actual
+    /// cause (#315: generation can work fine while the OS lacks tokenCount).
+    var tokenCountFallback: TokenCountFallback? {
+        let osSupportsTokenCounting: Bool
+        if #available(macOS 26.4, *) {
+            osSupportsTokenCounting = true
+        } else {
+            osSupportsTokenCounting = false
+        }
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return TokenCountFallback.reason(
+            modelAvailable: isAvailable,
+            osSupportsTokenCounting: osSupportsTokenCounting,
+            currentOS: "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)")
     }
 
     /// Warm up the model so the first real request does not pay the

--- a/Tests/apfelTests/TokenCountFallbackTests.swift
+++ b/Tests/apfelTests/TokenCountFallbackTests.swift
@@ -1,0 +1,47 @@
+// ============================================================================
+// TokenCountFallbackTests.swift — Why token counting fell back to chars/4 (ApfelCore)
+// ============================================================================
+
+import Foundation
+import ApfelCore
+
+func runTokenCountFallbackTests() {
+
+    test("no fallback when OS supports token counting and model is available") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: true, osSupportsTokenCounting: true, currentOS: "26.4.0")
+        try assertTrue(reason == nil)
+    }
+
+    test("OS too old wins even when the model is available (#315)") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: true, osSupportsTokenCounting: false, currentOS: "26.3.1")
+        try assertEqual(reason, .osTooOld(currentOS: "26.3.1"))
+    }
+
+    test("OS too old wins when both the OS is old and the model is unavailable") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: false, osSupportsTokenCounting: false, currentOS: "26.1.0")
+        try assertEqual(reason, .osTooOld(currentOS: "26.1.0"))
+    }
+
+    test("model unavailable when OS is new enough but the model is off") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: false, osSupportsTokenCounting: true, currentOS: "26.4.0")
+        try assertEqual(reason, .modelUnavailable)
+    }
+
+    test("osTooOld message names the required version, the actual OS, and the fallback") {
+        let msg = TokenCountFallback.osTooOld(currentOS: "26.3.1").message
+        try assertTrue(msg.contains("macOS 26.4"))
+        try assertTrue(msg.contains("26.3.1"))
+        try assertTrue(msg.contains("chars/4"))
+        try assertTrue(!msg.contains("Apple Intelligence unavailable"))
+    }
+
+    test("modelUnavailable message names Apple Intelligence and the fallback") {
+        let msg = TokenCountFallback.modelUnavailable.message
+        try assertTrue(msg.contains("Apple Intelligence unavailable"))
+        try assertTrue(msg.contains("chars/4"))
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -100,6 +100,7 @@ suite("StreamingToolCallGateTests") { runStreamingToolCallGateTests() }
 suite("ToolResolutionTests") { runToolResolutionTests() }
 suite("BodyLimitsTests") { runBodyLimitsTests() }
 suite("TokenBudgetTests") { runTokenBudgetTests() }
+suite("TokenCountFallbackTests") { runTokenCountFallbackTests() }
 suite("CLIServerParityTests") { runCLIServerParityTests() }
 suite("TraceBufferTests") { runTraceBufferTests() }
 suite("StreamTaskBoxTests") { runStreamTaskBoxTests() }

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -395,6 +395,38 @@ def test_count_tokens_json_shape():
     assert isinstance(data["fits"], bool)
 
 
+def test_count_tokens_fallback_warning_names_real_reason():
+    """#315: when --count-tokens falls back to chars/4, the stderr warning
+    must name the actual cause. On macOS < 26.4 the tokenizer API does not
+    exist at runtime, so the warning must say so - not falsely claim
+    "Apple Intelligence unavailable" while generation works fine.
+    Model-free: asserts against the host OS version, not model output."""
+    import platform
+    result = run_cli(["--count-tokens", "-o", "json", "hello"], timeout=30)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    data = json.loads(result.stdout.strip())
+    mac_ver = tuple(int(x) for x in platform.mac_ver()[0].split(".")[:2])
+    if mac_ver < (26, 4):
+        assert data["approximate"] is True
+        assert "token count is approximate" in result.stderr
+        assert "macOS 26.4" in result.stderr, (
+            f"warning must name the OS requirement (#315): {result.stderr!r}"
+        )
+        assert "Apple Intelligence unavailable" not in result.stderr, (
+            f"warning must not blame Apple Intelligence for a missing OS API "
+            f"(#315): {result.stderr!r}"
+        )
+    elif "token count is approximate" in result.stderr:
+        # OS supports the API: the only truthful fallback reason left is
+        # genuine model unavailability.
+        assert data["approximate"] is True
+        assert "Apple Intelligence unavailable" in result.stderr, (
+            f"unexpected fallback reason on macOS >= 26.4: {result.stderr!r}"
+        )
+    else:
+        assert data["approximate"] is False
+
+
 def test_count_tokens_strict_exit_over_budget():
     """--strict exits 4 when input exceeds the token budget.
     50 000 x's ≈ 6 200 real tokens (measured: 20 000 x's → 2 508 tokens),


### PR DESCRIPTION
Fixes #315.

## Root cause (verified by instrumentation, not guessed)

The mystery in #315 - generation works in the same run, yet `--count-tokens` claims "Apple Intelligence unavailable" - has nothing to do with `model.isAvailable`. A standalone FoundationModels probe on the machine that generates `docs/EXAMPLES.md` (Arthur Mac, macOS **26.3.1**, SDK 26.4) shows:

```
isAvailable: true
availability: available
generation worked: Apple.
```

while `apfel --count-tokens -o json "hello"` on the same machine returns `"approximate": true`. The gate that fails is not `isAvailable` - it is `#available(macOS 26.4, *)`: `tokenCount(for:)` requires macOS 26.4 **at runtime**, and the machine runs 26.3.1. The model is fully available, generation works, but the tokenizer API simply does not exist on that OS. The chars/4 fallback is therefore *correct behavior* - the bug is that the warning names the wrong reason ("Apple Intelligence unavailable"), which sent the issue (and PR #316's diagnosis of transient `isAvailable` flapping) down the wrong path.

This also means #316 would not change the doc output at all on these machines, and on 26.4+ it would make the JSON `approximate: false` even when `count()` silently falls back - a lying flag. I recommend closing #316 in favor of this PR.

## The fix

- New pure `TokenCountFallback` in ApfelCore (`Sources/Core/TokenCountFallback.swift`): decides and phrases the fallback reason from runtime facts. `osTooOld(currentOS:)` wins over `modelUnavailable` (on an old OS the API does not exist regardless of model state).
- `TokenCounter.tokenCountFallback` supplies the facts (`#available(macOS 26.4, *)`, `model.isAvailable`, `ProcessInfo` OS version); `isTokenCountingAvailable` is now derived from it (unchanged semantics: JSON `approximate` stays true in both fallback cases).
- `CLI.swift` prints the reason's message instead of the hardcoded string.

New warning on macOS < 26.4:

```
apfel: token count is approximate (the on-device tokenizer API requires macOS 26.4+; this Mac runs macOS 26.3.1; using chars/4 fallback)
```

The "Apple Intelligence unavailable" wording is kept for the case where that is actually true.

## TDD

Red first: `TokenCountFallbackTests` (6 unit tests) failed to compile against main, then went green with the implementation. New model-free integration test `test_count_tokens_fallback_warning_names_real_reason` asserts the warning against the host OS version - on < 26.4 it must name the OS requirement and must NOT blame Apple Intelligence.

## Test plan (executed on Arthur Mac, Apple Intelligence available)

- [x] `swift build -c release` clean
- [x] `swift run apfel-tests` - all 896 unit tests pass (890 + 6 new)
- [x] `pytest -k count_tokens` - 5 passed including the new #315 test
- [x] Manual smoke: warning now truthfully reports `macOS 26.3.1` as the reason
- [x] `make test` full suite (unit + integration)

## docs/EXAMPLES.md regeneration

Deliberately not in this PR: regenerating on a 26.3 machine would still (correctly) show the fallback path, now with the truthful message. Once the doc machine is on macOS 26.4+ the examples will show real `tokenCount(for:)` output. Regeneration is a one-command follow-up (`bash scripts/generate-examples.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)