### PR TITLE
fix(test,tokens): libedit erase style (#318) + token counter false-approximate (#315)

### DIFF
--- a/Tests/integration/test_chat.py
+++ b/Tests/integration/test_chat.py
@@ -337,10 +337,12 @@ def test_chat_multibyte_backspace_is_character_wise():
     """#256: with setlocale(LC_CTYPE,"") libedit edits non-ASCII by character.
 
     Type "cafe-acute" (the 'e' is U+00E9, 2 UTF-8 bytes) then one backspace then
-    'X'. Locale-aware libedit deletes the whole 2-byte character with a single
-    backspace/erase, so the erased region leaves no dangling UTF-8 lead byte. In
-    the "C" locale the backspace would delete a single byte and leave a stray
-    0xC3, corrupting the line.
+    'X'. Locale-aware libedit deletes the whole 2-byte character in one operation,
+    so the erased region leaves no dangling UTF-8 lead byte. In the "C" locale the
+    backspace would delete a single byte and leave a stray 0xC3, corrupting the
+    line. The exact erase echo varies by macOS version (bare \\x08 pre-26.3.1,
+    BS-SP-BS on 26.3.1+), so we check for at least one \\x08 and rely on the
+    no-dangling-lead-byte assertion as the primary correctness signal.
     """
     require_model()
     with warnings.catch_warnings():
@@ -386,8 +388,10 @@ def test_chat_multibyte_backspace_is_character_wise():
     echo = bytes(echo)
     # The 2-byte character was echoed once when typed.
     assert b"\xc3\xa9" in echo, f"multibyte char not echoed: {echo!r}"
-    # A single backspace deleted the whole character (character-wise, not byte-wise).
-    assert echo.count(b"\x08") == 1, f"expected one backspace erase, got: {echo!r}"
+    # At least one backspace proves an erase happened. The exact count varies by
+    # macOS version: pre-26.3.1 libedit emits a bare \x08, 26.3.1+ emits
+    # BS-SP-BS (\x08 \x08) to visually clear the cell. Both are character-wise.
+    assert echo.count(b"\x08") >= 1, f"expected at least one backspace byte, got: {echo!r}"
     # No dangling UTF-8 lead byte after the erase (the byte-wise-deletion signature).
     after_erase = echo.rsplit(b"\x08", 1)[1]
     assert b"\xc3" not in after_erase, f"dangling lead byte after erase: {echo!r}"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #318.
Fixes #315.

## Summary

Two independent bug fixes, one commit each.

### Commit 1: fix(test) - #318 multibyte backspace test

macOS 26.3.1 changed libedit's backspace echo for multibyte characters from a bare `\x08` to the standard BS-SP-BS erase sequence (`\x08 \x20 \x08`). The `test_chat_multibyte_backspace_is_character_wise` test asserted exactly 1 `\x08` byte, which now fails because the erase sequence contains 2.

**Root cause:** The test assertion was too strict - tied to a specific libedit erase style that changed in macOS 26.3.1.

**Fix:** Changed the `\x08` count assertion from `== 1` to `>= 1`. The primary correctness signal - the no-dangling-UTF-8-lead-byte assertion - is unchanged and catches byte-wise vs character-wise deletion regardless of erase style.

### Commit 2: fix(tokens) - #315 false "approximate" warning

`TokenCounter.isTokenCountingAvailable` gated on `model.isAvailable`, which can transiently report `false` on a cold `SystemLanguageModel.default` instance even when Apple Intelligence is working. This caused `--count-tokens` to always fall back to chars/4 approximation and print a misleading "approximate" warning.

**Root cause:** `isTokenCountingAvailable` and both `count()` methods checked `model.isAvailable` as a prerequisite, but `SystemLanguageModel.default.isAvailable` can return `false` transiently (cold start, load contention, or a difference between `.default` and `SystemLanguageModel(guardrails:)` instances). Since `model.tokenCount(for:)` is already wrapped in try/catch, the guard was redundant - a genuinely unavailable model falls back gracefully via the catch block.

**Fix:** Removed the `isAvailable` guard from `isTokenCountingAvailable`, `count(_ text:)`, and `count(entries:)` on macOS 26.4+. The try/catch around `model.tokenCount(for:)` handles genuine failures. On pre-26.4, behavior is unchanged (always falls back to chars/4).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make preflight` - the #318 test was blocking preflight on macOS 26.3.1
- [ ] `apfel --count-tokens "Hello world"` - should show real token count, no "approximate" warning
- [ ] Regenerate `docs/EXAMPLES.md` via `scripts/generate-examples.sh` to verify `--count-tokens` examples no longer show the fallback warning

## Test coverage

- Modified `Tests/integration/test_chat.py::test_chat_multibyte_backspace_is_character_wise` to accept both libedit erase styles.
- Added `Tests/integration/cli_e2e_test.py::test_count_tokens_no_false_approximate_warning` (model-dependent) to verify `--count-tokens` does not produce a false "approximate" warning when the model is available.

## What I verified (static only)

- The `rsplit(b"\x08", 1)[1]` on line 392 still works correctly with both old and new erase sequences.
- `LanguageModelSession` constructors are non-throwing, so the CLI.swift code path that constructs sessions when `isTokenCountingAvailable` returns true is safe even if the model is transiently unavailable.
- The try/catch in `count()` and `count(entries:)` handles `tokenCount(for:)` failures and falls back to chars/4.
- Diff limited to `Tests/integration/test_chat.py`, `Sources/TokenCounter.swift`, `Tests/integration/cli_e2e_test.py` - no release infrastructure, no dependencies, no CI changes.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If either fix does not actually resolve the reported behavior, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - both are straightforward bugs. #318 is a test too tightly coupled to a specific macOS libedit version. #315 is a premature availability check that became a false negative under real-world conditions.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._