### PR TITLE
fix(test): rotate seeds on guardrail refusal in sqrt test (#320)

### DIFF
--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -70,6 +70,35 @@ def assert_no_raw_tool_calls(content):
             f"Response leaked raw tool_calls JSON: {content[:200]}"
 
 
+GUARDRAIL_RETRY_SEEDS = [42, 7, 123, 0, 99]
+
+
+def _is_guardrail_refusal(data):
+    """True when the on-device model guardrail-refused instead of answering."""
+    choice = data.get("choices", [{}])[0]
+    return choice.get("finish_reason") == "content_filter"
+
+
+def _post_with_seed_rotation(url, body, *, timeout=TIMEOUT):
+    """POST body with each seed in GUARDRAIL_RETRY_SEEDS until one is not refused.
+
+    Returns (data, seed) on the first non-refusal.  Raises AssertionError if
+    every seed triggers a guardrail refusal.
+    """
+    refusals = []
+    for seed in GUARDRAIL_RETRY_SEEDS:
+        payload = {**body, "seed": seed}
+        resp = httpx.post(url, json=payload, timeout=timeout)
+        data = resp.json()
+        if not _is_guardrail_refusal(data):
+            return data, seed
+        refusals.append(seed)
+    pytest.fail(
+        f"All seeds {refusals} triggered a guardrail refusal for: "
+        f"{body['messages'][-1]['content']!r}"
+    )
+
+
 def find_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -730,15 +759,20 @@ def test_mcp_multiply_returns_correct_result(multiply_247x83_response):
 
 
 def test_mcp_sqrt_returns_correct_result():
-    """Sqrt tool: sqrt(144) = 12."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
-        ],
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    data = resp.json()
+    """Sqrt tool: sqrt(144) = 12.
+
+    Some seeds trigger a guardrail refusal on macOS 26.5.2 even for benign
+    math prompts (#320).  Rotate through seeds until one is not refused.
+    """
+    data, _seed = _post_with_seed_rotation(
+        f"{API_URL}/chat/completions",
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
+            ],
+        },
+    )
     content = data["choices"][0]["message"]["content"] or ""
     assert data["choices"][0]["finish_reason"] == "stop"
     assert_no_raw_tool_calls(content)
@@ -958,3 +992,25 @@ def test_temperature_zero_with_mcp():
     assert data["choices"][0]["finish_reason"] == "stop"
     content = data["choices"][0]["message"]["content"]
     assert content is not None
+
+
+# ============================================================================
+# Guardrail seed-rotation helpers (pure logic, no model needed) (#320)
+# ============================================================================
+
+def test_is_guardrail_refusal_detects_content_filter():
+    """_is_guardrail_refusal returns True for content_filter finish_reason."""
+    data = {"choices": [{"finish_reason": "content_filter", "message": {"refusal": "no"}}]}
+    assert _is_guardrail_refusal(data) is True
+
+
+def test_is_guardrail_refusal_false_for_stop():
+    """_is_guardrail_refusal returns False for normal stop."""
+    data = {"choices": [{"finish_reason": "stop", "message": {"content": "12"}}]}
+    assert _is_guardrail_refusal(data) is False
+
+
+def test_is_guardrail_refusal_false_for_empty():
+    """_is_guardrail_refusal returns False for empty/malformed data."""
+    assert _is_guardrail_refusal({}) is False
+    assert _is_guardrail_refusal({"choices": []}) is False


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #320.

## Summary

macOS 26.5.2 deterministically guardrail-refuses the sqrt(144) prompt when `seed: 42` is pinned. apfel itself is correct - the server log shows `mcp tool: sqrt({"value": 144}) = 12` executed on every request - but the model's follow-up answer after the tool result round-trip triggers a `content_filter` refusal on certain seed values.

### Root cause

The test `test_mcp_sqrt_returns_correct_result` hardcoded `"seed": 42`. On macOS 26.5.2, this particular seed value causes the on-device model to guardrail-refuse an otherwise benign math prompt. The property under test is "the tool result reaches the final answer", not "seed 42 never trips a guardrail".

### The fix

Added `_post_with_seed_rotation()` helper that tries seeds `[42, 7, 123, 0, 99]` in order and asserts on the first non-refusal response. Guardrail refusals are detected via `finish_reason == "content_filter"` (the wire format apfel already emits for on-device model refusals). If every seed refuses, `pytest.fail()` fires with the full seed list and prompt for clear diagnostics.

The helper is reusable - other tests that hit the same macOS model-drift class of failure can adopt it with a one-line change.

### Test coverage

- `test_mcp_sqrt_returns_correct_result` updated to use seed rotation instead of hardcoded seed 42.
- Added `test_is_guardrail_refusal_detects_content_filter` - verifies detection of `content_filter` finish_reason.
- Added `test_is_guardrail_refusal_false_for_stop` - verifies normal responses are not flagged.
- Added `test_is_guardrail_refusal_false_for_empty` - verifies graceful handling of empty/malformed data.

### What I verified (static only)

- `_is_guardrail_refusal` checks `finish_reason == "content_filter"` which matches the wire format in `Sources/Handlers.swift` (`refusalNonStreamingResponse` sets `FinishReason.contentFilter.openAIValue`).
- The seed list `[42, 7, 123, 0, 99]` starts with 42 so existing behaviour is preserved when seed 42 works.
- `_post_with_seed_rotation` does not swallow non-refusal errors - only `content_filter` is retried.
- Diff limited to `Tests/integration/mcp_server_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: not applicable (Python test-only change).

### What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

### Anything that seemed suspicious

Nothing - straightforward test-only bug with a clear root cause (model behaviour drift from an OS update).

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full unit + integration with Apple Intelligence) to confirm the sqrt test passes with seed rotation on macOS 26.5.2

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_017yMdR4L42tvJuJH3AgbwR1)_