### PR TITLE
fix(error,health): remove hardcoded 4096 from contextOverflow + deduplicate /health languages (#330, #329)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -138,7 +138,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         case .refusal(let explanation):
             return "The on-device model refused the request: \(explanation)"
         case .contextOverflow:
-            return "Input exceeds the 4096-token context window. Shorten the conversation history."
+            return "Input exceeds the model's context window. Shorten the conversation history."
         case .rateLimited:
             return "Apple Intelligence is rate limited. Retry after a few seconds."
         case .concurrentRequest:

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -111,9 +111,10 @@ actor TokenCounter {
     /// repeated mid-flight access on Hummingbird's dispatch queue can destabilize
     /// the process in some macOS 26.4 environments.
     var supportedLanguages: [String] {
+        var seen = Set<String>()
         var ids: [String] = []
         for language in model.supportedLanguages {
-            if let id = language.languageCode?.identifier {
+            if let id = language.languageCode?.identifier, seen.insert(id).inserted {
                 ids.append(id)
             }
         }

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -33,7 +33,7 @@ func runApfelErrorMessageTests() {
     test("ApfelError.contextOverflow.openAIMessage") {
         try assertEqual(
             ApfelError.contextOverflow.openAIMessage,
-            "Input exceeds the 4096-token context window. Shorten the conversation history."
+            "Input exceeds the model's context window. Shorten the conversation history."
         )
     }
     test("ApfelError.rateLimited.openAIMessage") {

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -584,6 +584,17 @@ def test_health_schema():
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
 
 
+def test_health_no_duplicate_languages():
+    """supported_languages must not contain duplicate entries (#329)."""
+    resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+    data = resp.json()
+    langs = data.get("supported_languages", [])
+    assert isinstance(langs, list)
+    assert len(langs) == len(set(langs)), (
+        f"supported_languages contains duplicates: {langs}"
+    )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #330. Fixes #329.

## Summary

Two small, independent fixes from the v1.7.1 bug sweep:

**1. Hardcoded 4096 in contextOverflow message (#330)**

`ApfelError.openAIMessage` for `.contextOverflow` hardcoded `"4096-token"` in the user-facing error string. Every other runtime path reads the dynamic `TokenCounter.shared.contextSize`, but this one string was a literal. Truthful on macOS 26.x but becomes a lie when macOS 27 reports a different window size.

Changed `"Input exceeds the 4096-token context window."` to `"Input exceeds the model's context window."` - always accurate regardless of OS version. Updated the pinned test in `ApfelErrorMessageTests.swift` to match.

**2. Duplicate entries in /health supported_languages (#329)**

`TokenCounter.supportedLanguages` mapped locale objects (`en_US`, `en_GB`, `en_AU`) to bare ISO language codes without deduplicating, producing `en x3, es x3, zh x3` in the `/health` JSON. Added an ordered `Set` to preserve first-seen order while eliminating duplicates.

Added a model-free integration test (`test_health_no_duplicate_languages`) in `openapi_spec_test.py` so this runs in CI.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Verify `/health` `supported_languages` has no duplicates locally

### What I verified (static only)

- Diff is 4 files: `Sources/Core/ApfelError.swift`, `Tests/apfelTests/ApfelErrorMessageTests.swift`, `Sources/TokenCounter.swift`, `Tests/integration/openapi_spec_test.py`.
- No other callers pin the exact `"4096-token"` error string (grep-verified).
- The `Set.insert(_:).inserted` pattern correctly deduplicates while preserving insertion order.
- The new integration test is model-free (no `@pytest.mark.model`) and will run in CI.
- Swift 6 concurrency: no data races introduced. `Set<String>` is a local value type inside an actor-isolated computed property.
- No touches to release infrastructure, guardrails, CI workflows, or dependencies.

### What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner.

### Anything that seemed suspicious

Nothing - both are straightforward bugs from the v1.7.1 bug sweep, filed by Arthur-Ficial.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._