### PR TITLE
fix(server): deduplicate supported_languages in /health (#329)

### DIFF
--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -95,9 +95,10 @@ actor TokenCounter {
     /// repeated mid-flight access on Hummingbird's dispatch queue can destabilize
     /// the process in some macOS 26.4 environments.
     var supportedLanguages: [String] {
+        var seen = Set<String>()
         var ids: [String] = []
         for language in model.supportedLanguages {
-            if let id = language.languageCode?.identifier {
+            if let id = language.languageCode?.identifier, seen.insert(id).inserted {
                 ids.append(id)
             }
         }

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -560,6 +560,16 @@ def test_health_schema():
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
 
 
+def test_health_supported_languages_no_duplicates():
+    """/health supported_languages must not contain duplicate entries (#329)."""
+    resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+    assert resp.status_code == 200
+    langs = resp.json().get("supported_languages", [])
+    assert len(langs) == len(set(langs)), (
+        f"supported_languages contains duplicates: {langs}"
+    )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #329.

## Root cause

`TokenCounter.supportedLanguages` iterates `SystemLanguageModel.default.supportedLanguages` (which yields locale identifiers like `en_US`, `en_GB`, `en_AU`), extracts each `languageCode?.identifier`, and appends to a plain array. Multiple locales sharing the same language code produce duplicate entries - the v1.7.1 `/health` endpoint returns `en` three times, `es` three times, `zh` three times, `fr` twice, and `pt` twice. The same duplicated list also appears in `apfel --model-info` output via the same property.

## The fix

Added an ordered-set deduplication in `TokenCounter.supportedLanguages`: a `Set<String>` tracks seen codes, and `seen.insert(id).inserted` gates the append. This preserves the SDK's iteration order while eliminating duplicates. One line added, one line changed - the smallest possible fix.

## Test coverage

- Added `test_health_supported_languages_no_duplicates` to `Tests/integration/openapi_spec_test.py` - asserts `len(langs) == len(set(langs))` on the `/health` response. This is model-free (no `@pytest.mark.model`) so it runs in CI on every push.
- Existing `test_health_supported_languages_populated` (in `openai_client_test.py`, model-dependent) still covers the happy path of a non-empty list with `"en"` present.

## What I verified (static only)

- The `seen.insert(id).inserted` pattern is idiomatic Swift and used elsewhere in the codebase.
- The fix is inside `TokenCounter` (an actor), so both call sites (`Server.swift:64` startup cache and `CLI.swift:407` model-info) get the deduplicated list automatically.
- Swift 6 concurrency: no data races introduced - `seen` and `ids` are local variables inside a synchronous computed property on an actor.
- Diff limited to `Sources/TokenCounter.swift` and `Tests/integration/openapi_spec_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward deduplication bug with a clear root cause.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjRzZg1PXp5WvguUSGT4PD)_