### PR TITLE
fix(error,test): drop hardcoded 4096 + add require_model() to MCP-timeout tests (#330, #337)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -138,7 +138,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         case .refusal(let explanation):
             return "The on-device model refused the request: \(explanation)"
         case .contextOverflow:
-            return "Input exceeds the 4096-token context window. Shorten the conversation history."
+            return "Input exceeds the model's context window. Shorten the conversation history."
         case .rateLimited:
             return "Apple Intelligence is rate limited. Retry after a few seconds."
         case .concurrentRequest:

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -33,7 +33,7 @@ func runApfelErrorMessageTests() {
     test("ApfelError.contextOverflow.openAIMessage") {
         try assertEqual(
             ApfelError.contextOverflow.openAIMessage,
-            "Input exceeds the 4096-token context window. Shorten the conversation history."
+            "Input exceeds the model's context window. Shorten the conversation history."
         )
     }
     test("ApfelError.rateLimited.openAIMessage") {

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -1250,6 +1250,7 @@ def test_mcp_timeout_env_var_in_help():
 # MCP timeout path is unreachable on GitHub runners.
 def test_mcp_timeout_short_causes_fast_failure():
     """--mcp-timeout 1 with a slow MCP server should fail within ~2 seconds."""
+    require_model()
     slow_server = str(ROOT / "Tests" / "integration" / "fixtures" / "slow_startup_mcp_server.py")
     start = time.time()
     result = run_cli(
@@ -1268,6 +1269,7 @@ def test_mcp_timeout_short_causes_fast_failure():
 # MCP timeout path is unreachable on GitHub runners.
 def test_mcp_timeout_env_var_works():
     """APFEL_MCP_TIMEOUT=1 should timeout same as --mcp-timeout 1."""
+    require_model()
     slow_server = str(ROOT / "Tests" / "integration" / "fixtures" / "slow_startup_mcp_server.py")
     start = time.time()
     result = run_cli(


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #330.
Fixes #337.

---

## Fix 1: drop hardcoded 4096 from contextOverflow message (#330)

### Root cause

`ApfelError.openAIMessage` for `.contextOverflow` hardcodes the string `"Input exceeds the 4096-token context window."` while every runtime path elsewhere reads the dynamic `TokenCounter.shared.contextSize`. The `/health` endpoint, `--count-tokens`, and `--benchmark` all report the live value from the SDK. This one error message is truthful today (macOS 26.5.2 still reports 4096), but becomes a lie the day the OS reports a different window size - and `docs/coreai-impact.md` already predicts 8192 on macOS 27.

### The fix

Dropped the hardcoded "4096-token" from the message. The new wording is `"Input exceeds the model's context window. Shorten the conversation history."` - honest regardless of what the model's actual context size is. Users who need the exact number can check `/health` or `--count-tokens`.

### Test coverage

- Updated `Tests/apfelTests/ApfelErrorMessageTests.swift` line 36 (`ApfelError.contextOverflow.openAIMessage` pinned-string test) to match the new wording.
- The `localizedDescription == openAIMessage` round-trip test (line 157-174) passes automatically since it compares the two dynamically.
- All existing `contextOverflow` tests (cliLabel, openAIType, httpStatusCode, isRetryable, exit code mapping, classify, StreamErrorResolver) are unaffected.

### Files changed

- `Sources/Core/ApfelError.swift` (1 line)
- `Tests/apfelTests/ApfelErrorMessageTests.swift` (1 line)

---

## Fix 2: add require_model() to MCP-timeout tests (#337)

### Root cause

The two MCP-timeout tests added in fd49fcf (`test_mcp_timeout_short_causes_fast_failure` and `test_mcp_timeout_env_var_works`) carry `@pytest.mark.model` but never call `require_model()`. Every other model-marked test in the file calls it as its first line - these two were the only exceptions. On a model-free machine running without `-m "not model"`, they fail with a misleading error instead of the discipline's clear diagnostic.

### The fix

Added `require_model()` as the first line of both tests, matching the pattern of every other `@pytest.mark.model` test in `cli_e2e_test.py` (23 other call sites).

### Files changed

- `Tests/integration/cli_e2e_test.py` (2 lines added)

---

## What I verified (static only)

- Grep-confirmed the hardcoded "4096-token" string appeared in exactly two places (source + pinned test). Both updated.
- Grep-confirmed every other `@pytest.mark.model` test calls `require_model()` (23 call sites, now 25).
- No integration tests assert on the exact contextOverflow message string.
- Swift 6 concurrency: no data races introduced.
- Diff limited to 3 files - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - both are straightforward fixes filed by Arthur-Ficial in the v1.7.1 bug sweep.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._