### PR TITLE
fix(server): deduplicate /health supported_languages (#329) + docs(count-tokens): document fallback (#335)

### DIFF
--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -95,9 +95,10 @@ actor TokenCounter {
     /// repeated mid-flight access on Hummingbird's dispatch queue can destabilize
     /// the process in some macOS 26.4 environments.
     var supportedLanguages: [String] {
+        var seen = Set<String>()
         var ids: [String] = []
         for language in model.supportedLanguages {
-            if let id = language.languageCode?.identifier {
+            if let id = language.languageCode?.identifier, seen.insert(id).inserted {
                 ids.append(id)
             }
         }

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -560,6 +560,16 @@ def test_health_schema():
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
 
 
+def test_health_supported_languages_no_duplicates():
+    """/health supported_languages must not contain duplicate entries (#329)."""
+    resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+    assert resp.status_code == 200
+    langs = resp.json().get("supported_languages", [])
+    assert len(langs) == len(set(langs)), (
+        f"supported_languages contains duplicates: {langs}"
+    )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================

--- a/Tests/integration/test_man_page.py
+++ b/Tests/integration/test_man_page.py
@@ -194,3 +194,15 @@ def test_bidirectional_exit_code_coverage():
         assert f".B {code}\n" in man_text, (
             f"Exit code {code} declared in ApfelExitCodes but not documented in man page"
         )
+
+
+def test_count_tokens_documents_approximate_field():
+    """Man page must mention the approximate field alongside --count-tokens (#335)."""
+    text = MAN_SOURCE.read_text()
+    ct_idx = text.find("count-tokens")
+    assert ct_idx >= 0, "--count-tokens not found in man page source"
+    after_ct = text[ct_idx:ct_idx + 800]
+    assert "approximate" in after_ct, (
+        "Man page documents --count-tokens but does not mention the "
+        "'approximate' JSON field. See #335."
+    )

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,6 +35,11 @@ MODEL
   --retry [n]                             Retry transient errors with backoff (default: 3)
   --debug                                 Enable debug logging to stderr (all modes)
   --count-tokens                          Count tokens without calling the model
+                                          Falls back to chars/4 approximation with a
+                                          stderr warning when the real tokenizer API is
+                                          unavailable (macOS < 26.4 or Apple Intelligence
+                                          disabled). JSON output includes an "approximate"
+                                          boolean field.
   --strict                                With --count-tokens: exit 4 if over budget
 
 CONTEXT (--chat)

--- a/man/apfel.1.in
+++ b/man/apfel.1.in
@@ -173,6 +173,14 @@ Accepts the same input flags as a single prompt
 .BR \-\-system ,
 .BR \-\-mcp ,
 etc.).
+When the real tokenizer API is unavailable (macOS < 26.4, or Apple
+Intelligence disabled), counts fall back to a chars/4 approximation and
+a warning is printed to standard error naming the reason.
+With
+.BR \-o\ json ,
+the output includes an
+.B approximate
+boolean field indicating whether the counts are exact or estimated.
 .TP
 .B \-\-strict
 With


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #329. Fixes #335.

---

## Fix 1: Deduplicate /health supported_languages (#329)

### Root cause

`TokenCounter.supportedLanguages` maps the SDK's `model.supportedLanguages` locale identifiers (e.g. `en_US`, `en_GB`, `en_AU`) to bare ISO language codes but appends each to an array without deduplication. This produces duplicates in the `/health` and `/v1/models` JSON responses (`en x3, es x3, zh x3, fr x2, pt x2` on macOS 26.5.2).

### The fix

Added a `seen` set using the `Set.insert(_:).inserted` pattern to skip duplicates while preserving insertion order. One line added, one line changed in `Sources/TokenCounter.swift`.

### Test coverage

- Added `test_health_supported_languages_no_duplicates` in `Tests/integration/openapi_spec_test.py` - model-free, runs in CI.
- Existing `test_health_supported_languages_populated` still covers the non-empty and `en`-present contract.

---

## Fix 2: Document chars/4 fallback and approximate field (#335)

### Root cause

The `--count-tokens` flag has undocumented behaviour: when the real tokenizer API is unavailable (macOS < 26.4 or Apple Intelligence disabled), counts fall back to a chars/4 approximation, a stderr warning names the reason (#315), and JSON output carries an `approximate` boolean field. None of this appeared in the man page or CLI reference.

### The fix

- **man/apfel.1.in**: Added fallback explanation and `approximate` field documentation to the `--count-tokens` entry.
- **docs/cli-reference.md**: Added the same information under the `--count-tokens` flag description.
- **Tests/integration/test_man_page.py**: Added `test_count_tokens_documents_approximate_field` drift test.

---

## What I verified (static only)

- Swift 6 concurrency: no data races introduced (dedup is a local variable change inside an actor-isolated computed property).
- Diff limited to `Sources/TokenCounter.swift`, `Tests/integration/openapi_spec_test.py`, `man/apfel.1.in`, `docs/cli-reference.md`, and `Tests/integration/test_man_page.py`.
- No touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or `mandoc -Tlint`.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._