### PR TITLE
fix(test): rotate seeds on guardrail refusal in add_tool_response (#323)

### DIFF
--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -285,16 +285,24 @@ def normal_streaming_response():
 
 @pytest.fixture(scope="module")
 def add_tool_response():
-    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
-        ],
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return resp.json()
+    """Non-streaming add 100+200 -- shared by stop-not-tool_calls, usage, and
+    result tests. Rotates seeds on guardrail refusal (#323)."""
+    for seed in (42, 7, 123, 0, 99):
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
+            ],
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"] or ""
+        if not _is_guardrail_refusal(content):
+            return data
+    pytest.fail(
+        f"model guardrail-refused add(100,200) on every seed; last content: {content}"
+    )
 
 
 # ============================================================================
@@ -765,6 +773,16 @@ def test_mcp_sqrt_returns_correct_result():
     else:
         pytest.fail(f"model guardrail-refused every seed; last: {content}")
     assert "12" in content, f"Expected 12, got: {content}"
+
+
+def test_mcp_add_returns_correct_result(add_tool_response):
+    """Add tool: 100 + 200 = 300. Seed rotation in fixture guards against
+    guardrail refusals that silently pass content asserts (#323)."""
+    data = add_tool_response
+    content = data["choices"][0]["message"]["content"] or ""
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert_no_raw_tool_calls(content)
+    assert "300" in content, f"Expected 300, got: {content}"
 
 
 def test_mcp_tool_returns_stop_not_tool_calls(add_tool_response):


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #323.

## Summary

The `add_tool_response` module fixture (`mcp_server_test.py:287`) hardcoded `seed: 42`. On macOS 26.5.2, this seed causes the on-device model to guardrail-refuse the add(100,200) prompt, returning refusal content with `finish_reason: "stop"`. The two consuming tests (`test_mcp_tool_returns_stop_not_tool_calls`, `test_mcp_response_has_valid_usage`) passed only by luck - they don't assert on content, and the refusal text happens to contain "300".

## Root cause

Same class as #320: the macOS 26.5.2 model guardrail-refuses benign math prompts on certain seed values. The `add_tool_response` fixture had no seed rotation, so a deterministic refusal on seed 42 made the fixture silently return refusal content instead of a genuine tool result.

## The fix

- Added seed rotation `(42, 7, 123, 0, 99)` to the `add_tool_response` fixture, using the existing `_is_guardrail_refusal()` helper to detect and skip refusals. Starts with seed 42 so existing behaviour is preserved when that seed works. Falls through to `pytest.fail()` with diagnostic output if every seed refuses.
- Added `test_mcp_add_returns_correct_result` to explicitly assert the response contains "300" - this locks in the bug so it can't silently regress again.

## Test coverage

- Added `test_mcp_add_returns_correct_result` to assert `finish_reason == "stop"`, no raw tool-call JSON leak, and "300" in content.
- Existing `test_mcp_tool_returns_stop_not_tool_calls` and `test_mcp_response_has_valid_usage` continue to share the fixture.

## What I verified (static only)

- `_is_guardrail_refusal` (line 732) checks `text.lower().startswith("i'm sorry") and "cannot" in lowered` which matches the reported refusal format ("I'm sorry, but as a language model developed by Apple, I cannot comply...").
- The seed list `[42, 7, 123, 0, 99]` starts with 42 so existing behaviour is preserved when seed 42 works.
- Seed rotation only skips guardrail refusals - HTTP errors and non-refusal failures propagate normally.
- Diff limited to `Tests/integration/mcp_server_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward test-only fix applying an established pattern (#320) to a second fixture.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full unit + integration with Apple Intelligence) to confirm the add fixture no longer returns refusal content on macOS 26.5.2

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_016s3ua3yhU47PSGcSJx5J9o)_