### PR TITLE
fix(test,benchmark): seed rotation for add_tool_response (#323) + tokenizer availability (#325)

### DIFF
--- a/Sources/Benchmark.swift
+++ b/Sources/Benchmark.swift
@@ -95,7 +95,7 @@ private func benchmarkReport() async throws -> BenchmarkReport {
         environment: BenchmarkEnvironment(
             model: modelName,
             context_window: await TokenCounter.shared.contextSize,
-            token_counter_available: await TokenCounter.shared.isAvailable
+            token_counter_available: await TokenCounter.shared.isTokenCountingAvailable
         ),
         benchmarks: [
             textExtraction,

--- a/Tests/apfelTests/TokenCountFallbackTests.swift
+++ b/Tests/apfelTests/TokenCountFallbackTests.swift
@@ -44,4 +44,16 @@ func runTokenCountFallbackTests() {
         try assertTrue(msg.contains("Apple Intelligence unavailable"))
         try assertTrue(msg.contains("chars/4"))
     }
+
+    test("model available does not imply token counting available (#325)") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: true, osSupportsTokenCounting: false, currentOS: "26.3.0")
+        try assertTrue(reason != nil)
+    }
+
+    test("token counting available only when both OS and model are ready") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: true, osSupportsTokenCounting: true, currentOS: "26.4.0")
+        try assertTrue(reason == nil)
+    }
 }

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -285,16 +285,24 @@ def normal_streaming_response():
 
 @pytest.fixture(scope="module")
 def add_tool_response():
-    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
-        ],
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return resp.json()
+    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests.
+
+    Rotates seeds on guardrail refusal (#323, same pattern as #320)."""
+    content = ""
+    for seed in (42, 7, 123):
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
+            ],
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"] or ""
+        if not _is_guardrail_refusal(content):
+            return data
+    pytest.fail(f"model guardrail-refused every seed; last: {content}")
 
 
 # ============================================================================
@@ -730,12 +738,18 @@ def test_mcp_multiply_returns_correct_result(multiply_247x83_response):
 
 
 def _is_guardrail_refusal(text):
-    """The on-device model's guardrail refusals ("I'm sorry, but I cannot
-    respond ... violates our guidelines" / "... cannot provide an answer that
-    promotes or supports harm"). Incidental model behavior, not a property
-    any test here asserts on."""
-    lowered = text.lower()
-    return lowered.startswith("i'm sorry") and "cannot" in lowered
+    """Detect the on-device model's guardrail refusals.
+
+    Covers known Apple model variants: ASCII and curly apostrophes,
+    "I can't ...", "Sorry, ...", "I cannot provide ..." (no lead-in),
+    and leading whitespace (#323, #324)."""
+    lowered = text.strip().lower().replace("’", "'")
+    if not lowered:
+        return False
+    starts_sorry = lowered.startswith("i'm sorry") or lowered.startswith("sorry")
+    starts_cannot = lowered.startswith("i cannot") or lowered.startswith("i can't")
+    has_refusal = "cannot" in lowered or "can't" in lowered or "violates" in lowered
+    return (starts_sorry or starts_cannot) and has_refusal
 
 
 def test_mcp_sqrt_returns_correct_result():


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #323.
Fixes #325.

Two independent bug fixes from the v1.7.1 bug sweep, one commit each.

---

## Fix 1: add_tool_response seed rotation (#323)

### Root cause

The `add_tool_response` module fixture uses a fixed `seed: 42` with no guardrail-refusal handling. On macOS 26.5.2 the Apple model guardrail-refuses this prompt on that sampling trajectory, returning refusal content with `finish_reason: "stop"`. The two consuming tests (`test_mcp_tool_returns_stop_not_tool_calls`, `test_mcp_response_has_valid_usage`) pass only by luck - they don't assert on content, so the fixture silently stops exercising the add tool.

### The fix

Applied the same seed-rotation pattern from #320 (sqrt test): the fixture now tries seeds `(42, 7, 123)` and returns the first non-refusal response. If all seeds are refused, it fails with `pytest.fail`.

Also broadened `_is_guardrail_refusal` to catch known Apple model refusal variants: curly apostrophe U+2019, "I can't ...", "Sorry, ...", "I cannot provide ..." (no lead-in), and leading whitespace. Without this, seed rotation would miss refusals phrased differently.

### Test coverage

- The fix IS the test improvement - makes the fixture resilient to guardrail refusals.
- `test_mcp_sqrt_returns_correct_result` (#320) uses the same broadened matcher and benefits.
- Files: `Tests/integration/mcp_server_test.py` only.

---

## Fix 2: benchmark token_counter_available (#325)

### Root cause

`Benchmark.swift:98` populated `token_counter_available` from `TokenCounter.shared.isAvailable` (model generation readiness) instead of `isTokenCountingAvailable` (real tokenizer API usable). On macOS 26.0-26.3 with Apple Intelligence enabled, the model IS available for generation but the `tokenCount` API does not exist - so `--benchmark` reported `"token_counter_available": true` while every count was the chars/4 approximation. The same misclassification #315 fixed for `--count-tokens`, surviving on the benchmark surface.

### The fix

One-line change: use `isTokenCountingAvailable` instead of `isAvailable`, matching the `--count-tokens` path that #315 already corrected.

### Test coverage

- Added two regression tests to `TokenCountFallbackTests.swift`:
  - `model available does not imply token counting available (#325)` - asserts the semantic split
  - `token counting available only when both OS and model are ready` - asserts the positive case
- Files: `Sources/Benchmark.swift`, `Tests/apfelTests/TokenCountFallbackTests.swift`.

---

## What I verified (static only)

- Broadened `_is_guardrail_refusal` tested against 10 cases (6 refusal variants detected, 4 normal responses no false positives).
- Seed rotation follows the exact #320 pattern.
- Benchmark fix matches the corrected `--count-tokens` path from #315.
- Swift 6 concurrency: no new data races - `isTokenCountingAvailable` is on the same `TokenCounter` actor.
- Diff limited to 3 files total - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. The benchmark fix ideally needs verification on macOS 26.0-26.3 where `isAvailable` and `isTokenCountingAvailable` diverge.

## Anything that seemed suspicious

Nothing - both are straightforward bugs from Arthur-Ficial's own v1.7.1 bug sweep.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._