### PR TITLE
fix(count-tokens): gate session skip on modelUnavailable, not approximate (#326)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -95,8 +95,9 @@ func countTokens(
 
     let inputEntries: [Transcript.Entry]
     let noToolEntries: [Transcript.Entry]?
+    let skipSession = tokenCountFallback?.skipSessionConstruction ?? false
 
-    if approximate {
+    if skipSession {
         // Avoid LanguageModelSession construction when the model is unavailable.
         inputEntries = []
         noToolEntries = nil
@@ -120,7 +121,7 @@ func countTokens(
     }
 
     let total: Int
-    if approximate {
+    if skipSession {
         var approxTotal = await TokenCounter.shared.count(mergedPrompt)
         if let sys = systemPrompt, !sys.isEmpty {
             approxTotal += await TokenCounter.shared.count(sys)
@@ -150,7 +151,7 @@ func countTokens(
     }
 
     let mcpToolTokens: Int
-    if approximate {
+    if skipSession {
         mcpToolTokens = 0
     } else if let baseline = noToolEntries {
         let baselineCount = await TokenCounter.shared.count(entries: baseline)

--- a/Sources/Core/TokenCountFallback.swift
+++ b/Sources/Core/TokenCountFallback.swift
@@ -30,6 +30,19 @@ public enum TokenCountFallback: Sendable, Equatable {
         return nil
     }
 
+    /// Whether this fallback reason means session construction is unsafe.
+    /// `.modelUnavailable` means the model cannot be used at all, so
+    /// `LanguageModelSession` construction must be skipped. `.osTooOld` means
+    /// the tokenizer API is missing but the model itself is available -
+    /// session construction is safe and yields real transcript entries that
+    /// the chars/4 fallback can count, including tool schemas (#326).
+    public var skipSessionConstruction: Bool {
+        switch self {
+        case .modelUnavailable: return true
+        case .osTooOld: return false
+        }
+    }
+
     /// Human-readable explanation for the stderr warning.
     public var message: String {
         switch self {

--- a/Tests/apfelTests/TokenCountFallbackTests.swift
+++ b/Tests/apfelTests/TokenCountFallbackTests.swift
@@ -44,4 +44,26 @@ func runTokenCountFallbackTests() {
         try assertTrue(msg.contains("Apple Intelligence unavailable"))
         try assertTrue(msg.contains("chars/4"))
     }
+
+    // #326: osTooOld must not skip session construction (model is available,
+    // only the tokenizer API is missing). Skipping drops MCP tool schemas
+    // from the count, making --strict false-pass.
+
+    test("osTooOld does not skip session construction (#326)") {
+        let fallback = TokenCountFallback.osTooOld(currentOS: "26.3.1")
+        try assertFalse(fallback.skipSessionConstruction,
+            "osTooOld must not skip session construction - model is available")
+    }
+
+    test("modelUnavailable skips session construction") {
+        let fallback = TokenCountFallback.modelUnavailable
+        try assertTrue(fallback.skipSessionConstruction,
+            "modelUnavailable must skip session construction")
+    }
+
+    test("nil fallback means no skip (real API usable)") {
+        let fallback = TokenCountFallback.reason(
+            modelAvailable: true, osSupportsTokenCounting: true, currentOS: "26.4.0")
+        try assertTrue(fallback == nil)
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #326.

## Summary

- `countTokens` gated session construction on `approximate` (any non-nil `TokenCountFallback`), but `.osTooOld` machines (macOS 26.0-26.3) have the model available - only the tokenizer API is missing. Skipping session construction on these machines set `inputEntries = []` and `mcpToolTokens = 0`, so `--strict` could false-pass when MCP tool schemas would push the real total over budget.
- Added `TokenCountFallback.skipSessionConstruction` property that returns `true` only for `.modelUnavailable`. On `.osTooOld`, session construction proceeds normally and the chars/4 fallback counts real transcript entries including tool schemas.
- Added 3 unit tests locking this behavior.

## Root cause

The `countTokens` function in `CLI.swift` used `approximate` (which is `true` for any non-nil `TokenCountFallback`) as the gate for skipping `LanguageModelSession` construction. The comment said "when the model is unavailable" but the condition was too broad: `.osTooOld` (macOS 26.0-26.3 with Apple Intelligence ON) also matched, even though the model IS available and session construction is safe. This made `inputEntries = []` and `mcpToolTokens = 0` on those machines, so `--count-tokens --strict --mcp server.py` could exit 0 ("fits") when the identical real request would overflow at generation time.

## The fix

Added a `skipSessionConstruction` computed property to `TokenCountFallback` that returns `true` only for `.modelUnavailable` (session can't be built) and `false` for `.osTooOld` (model is fine, just the tokenizer API is missing). Changed the three `approximate` gates in `countTokens` to use `skipSession` instead. The `approximate` variable is preserved for its correct downstream uses (marking the report as approximate, printing the warning).

## Test coverage

- Added `TokenCountFallbackTests: "osTooOld does not skip session construction (#326)"` to lock the bug fix.
- Added `TokenCountFallbackTests: "modelUnavailable skips session construction"` for the other branch.
- Added `TokenCountFallbackTests: "nil fallback means no skip (real API usable)"` for completeness.
- Existing `TokenCountFallbackTests` still cover the `reason()` logic and message formatting.

## What I verified (static only)

- `approximate` is still used correctly at its two remaining sites: `TokenBudgetReport.make(approximate:)` and the stderr warning. Both should fire for any fallback reason.
- `ContextManager.makeSession` uses `LanguageModelSession` construction which requires FoundationModels (macOS 26+), not the tokenCount API (macOS 26.4+), confirming session construction is safe under `.osTooOld`.
- `TokenCounter.count(entries:)` already falls back to `fallbackCount(entries:)` on `.osTooOld`, so passing real transcript entries (including tool schemas) yields correct approximate counts.
- Swift 6 concurrency: no data races introduced. The new property is a pure switch on an enum.
- Diff limited to `Sources/Core/TokenCountFallback.swift`, `Sources/CLI.swift`, `Tests/apfelTests/TokenCountFallbackTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behavior, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug reported by Arthur-Ficial in the v1.7.1 bug sweep.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_014yhpe5zZjCd7ARN479qJzC)_