### PR TITLE
fix(mcp): coerce string arguments to numbers in calculator (#322)

### DIFF
--- a/Tests/integration/test_calculator.py
+++ b/Tests/integration/test_calculator.py
@@ -1,0 +1,115 @@
+"""Unit tests for the MCP calculator server (model-free).
+
+Tests the calculator's execute() and _coerce_num() functions directly,
+without any server or model dependency. Validates that string arguments
+from the on-device model are coerced to numbers, not concatenated.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CALC_PATH = ROOT / "mcp" / "calculator" / "server.py"
+
+spec = importlib.util.spec_from_file_location("calculator", CALC_PATH)
+calculator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(calculator)
+
+execute = calculator.execute
+_coerce_num = calculator._coerce_num
+
+
+class TestCoerceNum:
+    def test_int_passthrough(self):
+        assert _coerce_num(42) == 42
+
+    def test_float_passthrough(self):
+        assert _coerce_num(3.14) == 3.14
+
+    def test_string_int(self):
+        assert _coerce_num("999") == 999
+
+    def test_string_float(self):
+        assert _coerce_num("3.14") == 3.14
+
+    def test_non_numeric_string_raises(self):
+        with pytest.raises(ValueError):
+            _coerce_num("abc")
+
+    def test_none_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            _coerce_num(None)
+
+    def test_list_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            _coerce_num([1, 2])
+
+
+class TestExecuteStringArgs:
+    """The core regression: string args must compute, not concatenate (#322)."""
+
+    def test_add_string_args_computes_sum(self):
+        result = execute("add", {"a": "999", "b": "1"})
+        assert result == "1000", f"add('999','1') must be 1000, got {result}"
+
+    def test_add_string_args_never_concatenates(self):
+        result = execute("add", {"a": "999", "b": "1"})
+        assert result != "9991", "add() must not string-concatenate"
+
+    def test_subtract_string_args(self):
+        assert execute("subtract", {"a": "10", "b": "3"}) == "7"
+
+    def test_multiply_string_args(self):
+        assert execute("multiply", {"a": "247", "b": "83"}) == "20501"
+
+    def test_divide_string_args(self):
+        assert execute("divide", {"a": "10", "b": "4"}) == "2.5"
+
+    def test_sqrt_string_arg(self):
+        assert execute("sqrt", {"a": "144"}) == "12"
+
+    def test_power_string_args(self):
+        assert execute("power", {"a": "2", "b": "10"}) == "1024"
+
+    def test_round_number_string_arg(self):
+        assert execute("round_number", {"a": "3.14159", "decimals": "2"}) == "3.14"
+
+    def test_non_numeric_string_returns_error(self):
+        result = execute("add", {"a": "hello", "b": "1"})
+        assert result.startswith("Error:")
+
+    def test_mixed_string_and_numeric(self):
+        assert execute("add", {"a": "999", "b": 1}) == "1000"
+        assert execute("add", {"a": 999, "b": "1"}) == "1000"
+
+
+class TestExecuteNumericArgs:
+    """Regression guard: normal numeric args still work after the fix."""
+
+    def test_add(self):
+        assert execute("add", {"a": 10, "b": 3}) == "13"
+
+    def test_subtract(self):
+        assert execute("subtract", {"a": 10, "b": 3}) == "7"
+
+    def test_multiply(self):
+        assert execute("multiply", {"a": 247, "b": 83}) == "20501"
+
+    def test_divide(self):
+        assert execute("divide", {"a": 10, "b": 4}) == "2.5"
+
+    def test_divide_by_zero(self):
+        assert execute("divide", {"a": 10, "b": 0}) == "Error: division by zero"
+
+    def test_sqrt(self):
+        assert execute("sqrt", {"a": 144}) == "12"
+
+    def test_power(self):
+        assert execute("power", {"a": 2, "b": 10}) == "1024"
+
+    def test_round_number(self):
+        assert execute("round_number", {"a": 3.14159, "decimals": 2}) == "3.14"
+
+    def test_unknown_tool(self):
+        assert execute("unknown", {"a": 1}) == "Error: unknown tool 'unknown'"

--- a/mcp/calculator/server.py
+++ b/mcp/calculator/server.py
@@ -117,11 +117,29 @@ def get_nums(args):
     return nums
 
 
+def _coerce_num(v):
+    """Coerce a value to a number. Raises ValueError on failure."""
+    if isinstance(v, (int, float)):
+        return v
+    if isinstance(v, str):
+        return float(v) if "." in v else int(v)
+    raise ValueError(f"not a number: {v!r}")
+
+
 def execute(name, args):
     """Execute a tool by name. Tolerates improvised argument keys."""
     nums = get_nums(args)
-    a = args.get("a", nums[0] if nums else 0)
-    b = args.get("b", nums[1] if len(nums) > 1 else 0)
+    raw_a = args.get("a", nums[0] if nums else 0)
+    raw_b = args.get("b", nums[1] if len(nums) > 1 else 0)
+
+    try:
+        a = _coerce_num(raw_a)
+    except (ValueError, TypeError):
+        return f"Error: argument 'a' is not a valid number: {raw_a!r}"
+    try:
+        b = _coerce_num(raw_b)
+    except (ValueError, TypeError):
+        return f"Error: argument 'b' is not a valid number: {raw_b!r}"
 
     try:
         if name == "add":


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #322.

## Root cause

`execute()` in `mcp/calculator/server.py` uses `args.get("a")` which returns the raw value from the JSON arguments. The on-device 3B model routinely sends string-typed arguments (`{"a":"999","b":"1"}`) despite the schema declaring `type: number`. Python's `+` operator then string-concatenates instead of adding, producing `9991` instead of `1000` - a silently wrong result with no error signal. This is live in the published `docs/EXAMPLES.md` (line 944). `multiply` at least fails loudly on string input; `add` fails silently, violating the "honest about limitations" principle.

## The fix

Added `_coerce_num()` that converts string arguments to their numeric equivalents (int or float) before any arithmetic, raising `ValueError` for genuinely non-numeric strings. Applied it to `a` and `b` at the top of `execute()`, returning a clear `Error:` message (which triggers `isError: true` in the MCP response) for values that can't be coerced. The existing `get_nums()` helper already had this coercion logic for its fallback path, but values retrieved directly via `args.get()` bypassed it.

## Test coverage

- Added `Tests/integration/test_calculator.py` with 26 model-free tests:
  - `TestCoerceNum` (7 tests): int/float passthrough, string-to-int, string-to-float, non-numeric rejection, None/list rejection
  - `TestExecuteStringArgs` (10 tests): the core regression - string args to all seven tools must compute correctly, non-numeric strings must return errors, mixed string+numeric args must work
  - `TestExecuteNumericArgs` (9 tests): regression guard confirming normal numeric args still work for all tools including edge cases (division by zero, unknown tool)

## What I verified (static only)

- `_coerce_num` handles int, float, and string inputs; rejects None, lists, and non-numeric strings
- `args.get("a")` returning `"999"` now passes through `_coerce_num("999")` which returns `999` (int), so `a + b` does arithmetic
- Non-numeric strings like `"hello"` return `Error:` prefix, which the MCP response handler at line 197 maps to `isError: true`
- `decimals` in `round_number` already uses `int()` coercion (line 160) - no change needed
- All 26 tests pass (`pytest --noconftest`)
- Diff limited to `mcp/calculator/server.py` and `Tests/integration/test_calculator.py` - no touches to release infrastructure, guardrails, CI, or dependencies
- Swift 6 concurrency: not applicable (Python-only change)

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. The calculator tests are model-free and will run as part of `make test`'s pytest discovery, but the full MCP integration (model calls tool, tool returns result, model incorporates answer) needs a real device.

## Anything that seemed suspicious

Nothing - straightforward bug with a clear root cause. The issue body accurately described the problem and the fix direction aligned with what the code needed.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1TpZq4Wo5TXmr2btjX2WM)_