### PR TITLE
fix(benchmark): report tokenizer availability, not model availability (#328)

### DIFF
--- a/Sources/Benchmark.swift
+++ b/Sources/Benchmark.swift
@@ -95,7 +95,7 @@ private func benchmarkReport() async throws -> BenchmarkReport {
         environment: BenchmarkEnvironment(
             model: modelName,
             context_window: await TokenCounter.shared.contextSize,
-            token_counter_available: await TokenCounter.shared.isAvailable
+            token_counter_available: await TokenCounter.shared.isTokenCountingAvailable
         ),
         benchmarks: [
             textExtraction,

--- a/Tests/integration/performance_test.py
+++ b/Tests/integration/performance_test.py
@@ -76,3 +76,22 @@ def test_benchmark_reports_real_speedups():
         "response_encode",
     ]:
         assert benchmarks[name]["current_avg_ms"] >= 0
+
+
+def test_benchmark_environment_token_counter_reflects_tokenizer():
+    """token_counter_available must reflect tokenizer API availability, not
+    model generation availability (#328, #325). On macOS < 26.4 with Apple
+    Intelligence enabled, the model can generate but the tokenizer API does
+    not exist - the field must be false in that case."""
+    result = subprocess.run(
+        [str(BINARY), "--benchmark", "-o", "json"],
+        text=True,
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    env = payload["environment"]
+    assert isinstance(env["token_counter_available"], bool)
+    assert env["context_window"] > 0


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #328.
Also fixes #325.

## Root cause

`Benchmark.swift:98` populated the `token_counter_available` environment field from `TokenCounter.shared.isAvailable`, which reports whether the model is available for *generation*. The field should reflect whether the *tokenizer API* is usable - that's `TokenCounter.shared.isTokenCountingAvailable`. On macOS 26.0-26.3 with Apple Intelligence enabled, the model can generate fine but the `tokenCount(for:)` API does not exist (it was introduced in macOS 26.4). The benchmark falsely reported `token_counter_available: true` while every count in the report was the chars/4 approximation.

This also revived `isTokenCountingAvailable` from dead-code status - it had zero callers after #315 rewired `countTokens` to use `tokenCountFallback` directly. With Benchmark now calling it, the compiler prevents it from rotting back to dead code.

## The fix

One-line change in `Sources/Benchmark.swift`: `isAvailable` to `isTokenCountingAvailable`. The property already existed and was correct - it just had no callers.

## Test coverage

- Added `Tests/integration/performance_test.py:test_benchmark_environment_token_counter_reflects_tokenizer` to lock the environment field's presence and type.
- Existing `TokenCountFallbackTests` cover the underlying logic (`tokenCountFallback == nil` is what `isTokenCountingAvailable` delegates to).

## What I verified (static only)

- `isTokenCountingAvailable` is defined at `Sources/TokenCounter.swift:50-52` as `tokenCountFallback == nil` - correct semantics.
- `tokenCountFallback` distinguishes `.osTooOld` from `.modelUnavailable` (#315) - the property inherits this distinction.
- The `BenchmarkEnvironment` struct's `token_counter_available` field is `Bool` - type-compatible.
- grep confirms `isTokenCountingAvailable` now has exactly one caller (Benchmark.swift) - no longer dead code.
- Swift 6 concurrency: no data races introduced (both properties are on the same `TokenCounter` actor).
- Diff limited to `Sources/Benchmark.swift` and `Tests/integration/performance_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by Arthur-Ficial in the v1.7.1 sweep.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_015zPzMJiiyXyWaga1H5av94)_