### PR TITLE
fix(mcp): coerce string arguments to numbers in calculator server (#322)

### DIFF
--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -17,6 +17,7 @@ tests that check different aspects of the same response share a single call.
 import json
 import contextlib
 import pathlib
+import sys
 import pytest
 import httpx
 import socket
@@ -980,3 +981,103 @@ def test_temperature_zero_with_mcp():
     assert data["choices"][0]["finish_reason"] == "stop"
     content = data["choices"][0]["message"]["content"]
     assert content is not None
+
+
+# ============================================================================
+# MCP calculator: numeric coercion (model-free, no Apple Intelligence needed)
+# ============================================================================
+
+def _mcp_call_raw(tool_name, arguments):
+    """Call the MCP calculator server via stdio, return (text, isError)."""
+    init_msg = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                   "clientInfo": {"name": "apfel-test", "version": "1.0"}}
+    })
+    call_msg = json.dumps({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments}
+    })
+    mcp_script = ROOT / "mcp" / "calculator" / "server.py"
+    proc = subprocess.run(
+        [sys.executable, str(mcp_script)],
+        input=f"{init_msg}\n{call_msg}\n",
+        capture_output=True, text=True, timeout=5,
+    )
+    for line in proc.stdout.strip().split("\n"):
+        msg = json.loads(line)
+        if msg.get("id") == 2:
+            result = msg["result"]
+            return result["content"][0]["text"], result.get("isError", False)
+    raise RuntimeError("no tools/call response from MCP server")
+
+
+class TestMcpCalculatorNumericCoercion:
+    """The on-device model routinely sends string arguments to calculator tools.
+    The server must coerce them to numbers, never string-concatenate (#322).
+
+    Model-free: exercises the calculator server.py directly via stdio.
+    """
+
+    def test_add_string_args_returns_sum_not_concatenation(self):
+        """add(a="999", b="1") must return 1000, not "9991"."""
+        text, is_error = _mcp_call_raw("add", {"a": "999", "b": "1"})
+        assert text != "9991", "string concatenation instead of numeric addition"
+        if is_error:
+            assert "number" in text.lower(), f"unexpected error: {text}"
+        else:
+            assert text == "1000", f"expected 1000, got {text}"
+
+    def test_multiply_string_args(self):
+        """multiply(a="7", b="6") must return 42."""
+        text, is_error = _mcp_call_raw("multiply", {"a": "7", "b": "6"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "42", f"expected 42, got {text}"
+
+    def test_subtract_string_args(self):
+        """subtract(a="10", b="3") must return 7."""
+        text, is_error = _mcp_call_raw("subtract", {"a": "10", "b": "3"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "7", f"expected 7, got {text}"
+
+    def test_divide_string_args(self):
+        """divide(a="10", b="2") must return 5."""
+        text, is_error = _mcp_call_raw("divide", {"a": "10", "b": "2"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "5", f"expected 5, got {text}"
+
+    def test_sqrt_string_arg(self):
+        """sqrt(a="144") must return 12."""
+        text, is_error = _mcp_call_raw("sqrt", {"a": "144"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "12", f"expected 12, got {text}"
+
+    def test_power_string_args(self):
+        """power(a="2", b="10") must return 1024."""
+        text, is_error = _mcp_call_raw("power", {"a": "2", "b": "10"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "1024", f"expected 1024, got {text}"
+
+    def test_round_number_string_args(self):
+        """round_number(a="3.14159", decimals="2") must return 3.14."""
+        text, is_error = _mcp_call_raw("round_number", {"a": "3.14159", "decimals": "2"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "3.14", f"expected 3.14, got {text}"
+
+    def test_non_numeric_string_returns_error(self):
+        """add(a="hello", b="1") must return an isError result."""
+        text, is_error = _mcp_call_raw("add", {"a": "hello", "b": "1"})
+        assert is_error, f"non-numeric input should return isError, got: {text}"
+        assert "number" in text.lower(), f"error message should mention 'number': {text}"
+
+    def test_numeric_args_still_work(self):
+        """add(a=999, b=1) with proper numeric types still returns 1000."""
+        text, is_error = _mcp_call_raw("add", {"a": 999, "b": 1})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "1000", f"expected 1000, got {text}"
+
+    def test_float_string_args(self):
+        """add(a="1.5", b="2.5") must return 4."""
+        text, is_error = _mcp_call_raw("add", {"a": "1.5", "b": "2.5"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "4", f"expected 4, got {text}"

--- a/mcp/calculator/server.py
+++ b/mcp/calculator/server.py
@@ -117,11 +117,34 @@ def get_nums(args):
     return nums
 
 
+def _coerce_num(value):
+    """Coerce a value to a number, or return None if not numeric."""
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        try:
+            return float(value) if "." in value else int(value)
+        except ValueError:
+            return None
+    return None
+
+
 def execute(name, args):
     """Execute a tool by name. Tolerates improvised argument keys."""
     nums = get_nums(args)
-    a = args.get("a", nums[0] if nums else 0)
-    b = args.get("b", nums[1] if len(nums) > 1 else 0)
+    raw_a = args.get("a", nums[0] if nums else None)
+    raw_b = args.get("b", nums[1] if len(nums) > 1 else None)
+
+    a = _coerce_num(raw_a)
+    b = _coerce_num(raw_b)
+
+    needs_a = name in ("add", "subtract", "multiply", "divide", "sqrt", "power", "round_number")
+    needs_b = name in ("add", "subtract", "multiply", "divide", "power")
+
+    if needs_a and a is None:
+        return f"Error: argument 'a' must be a number, got {raw_a!r}"
+    if needs_b and b is None:
+        return f"Error: argument 'b' must be a number, got {raw_b!r}"
 
     try:
         if name == "add":
@@ -139,8 +162,11 @@ def execute(name, args):
         elif name == "power":
             r = a ** b
         elif name == "round_number":
-            decimals = int(args.get("decimals", args.get("n", nums[1] if len(nums) > 1 else 0)))
-            r = round(a, decimals)
+            raw_dec = args.get("decimals", args.get("n", nums[1] if len(nums) > 1 else 0))
+            dec = _coerce_num(raw_dec)
+            if dec is None:
+                return f"Error: argument 'decimals' must be a number, got {raw_dec!r}"
+            r = round(a, int(dec))
         else:
             return f"Error: unknown tool '{name}'"
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #322.

## Root cause

`execute()` in `mcp/calculator/server.py` uses `args.get("a", ...)` which returns the raw value from the JSON arguments dict. When the on-device model sends string arguments - which the ~3B model routinely does - `a` and `b` are strings, and Python's `+` operator concatenates instead of adding. So `add(a="999", b="1")` silently returns `"9991"` instead of `1000`. The `get_nums()` helper does coerce strings to numbers, but it only serves as a fallback when the `"a"` / `"b"` keys are missing from the dict - which they almost never are.

## The fix

Added a `_coerce_num()` helper that converts a value to `int` or `float` (returning `None` for genuinely non-numeric input). `execute()` now runs every argument through `_coerce_num()` before any arithmetic, and returns an `isError` result when coercion fails. This covers all seven tools (`add`, `subtract`, `multiply`, `divide`, `sqrt`, `power`, `round_number`), including the `decimals` parameter on `round_number`. Numeric arguments pass through unchanged; string-encoded numbers are coerced; non-numeric strings get a clear error message.

## Test coverage

- Added `TestMcpCalculatorNumericCoercion` class (10 tests) in `Tests/integration/mcp_server_test.py`:
  - `test_add_string_args_returns_sum_not_concatenation` - the exact bug scenario
  - `test_multiply_string_args`, `test_subtract_string_args`, `test_divide_string_args`, `test_sqrt_string_arg`, `test_power_string_args`, `test_round_number_string_args` - all seven tools with string args
  - `test_non_numeric_string_returns_error` - genuinely non-numeric input returns `isError`
  - `test_numeric_args_still_work` - regression guard for proper numeric types
  - `test_float_string_args` - float string coercion
- Tests are model-free (call `server.py` directly via stdio, no Apple Intelligence needed).
- Existing tests (multiply 247x83, add 100+200, sqrt 144, etc.) still exercise the happy path through the HTTP server.

## What I verified (static only)

- All 10 new tests pass when running the calculator server directly via stdio on the cloud runner.
- The old code produces `"9991"` for `add("999","1")` (string concatenation confirmed).
- The fix produces `"1000"` for the same input (numeric addition confirmed).
- `_coerce_num()` matches the existing coercion logic in `get_nums()` so behavior is consistent.
- No changes to any Swift source, release infrastructure, CI, or dependencies.
- Diff limited to `mcp/calculator/server.py` and `Tests/integration/mcp_server_test.py`.

## What I did NOT verify

- **Functional correctness through the full stack. This needs `make test` on a Mac with Apple Intelligence.** The new tests exercise `server.py` in isolation. The existing model-dependent integration tests (multiply, add, sqrt fixtures) will verify the fix works end-to-end when run locally. I cannot run FoundationModels code.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by `Arthur-Ficial` (us) as part of the v1.7.1 bug sweep.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCtRBpPw1xDWKVQfbgpxW7)_