### PR TITLE
fix(test,docs): seed rotation for guardrail refusals (#323) + drop stale prompt count (#333)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ make preflight                 # full release qualification (unit + integration 
 
 **Version is in `.version` file** (single source of truth). Local builds (`make build`, `make install`) do NOT change the version. Only the release workflow (`make release`) bumps versions. This ensures patch versions mean "published compatible fix", not "someone ran a build". **Never manually edit `.version`, `BuildInfo.swift`, or the README badge** - these are updated atomically by the release workflow.
 
-Regenerate `docs/EXAMPLES.md` (runs 53 prompts against the installed binary, captures real unedited output):
+Regenerate `docs/EXAMPLES.md` (runs the example prompt suite against the installed binary, captures real unedited output):
 ```bash
 bash scripts/generate-examples.sh          # ~2 minutes, overwrites docs/EXAMPLES.md
 ```

--- a/Tests/integration/conftest.py
+++ b/Tests/integration/conftest.py
@@ -8,6 +8,25 @@ import time
 import httpx
 import pytest
 
+
+def is_guardrail_refusal(text):
+    """Detect the on-device model's guardrail refusals.
+
+    The macOS 26.5.2 model refuses prompts more aggressively than earlier
+    versions. Known refusal shapes include ASCII apostrophe ("I'm sorry"),
+    curly apostrophe (U+2019), "I can't", "I cannot provide", "Sorry, ..."
+    with no lead-in, and variants with leading whitespace (#323, #324).
+    """
+    if not text:
+        return False
+    normalized = text.strip().replace("’", "'").lower()
+    starts = ("i'm sorry", "sorry,", "sorry ", "i can't", "i cannot")
+    if not any(normalized.startswith(s) for s in starts):
+        return False
+    keywords = ("cannot", "can't", "violates", "unable to", "not able to",
+                "programming rules", "guidelines")
+    return any(k in normalized for k in keywords)
+
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 BINARY = ROOT / ".build" / "release" / "apfel"
 MCP_SERVER = ROOT / "mcp" / "calculator" / "server.py"

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -183,16 +183,29 @@ def normal_streaming_response():
 
 @pytest.fixture(scope="module")
 def add_tool_response():
-    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
-        ],
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return resp.json()
+    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests.
+
+    Rotates seeds on guardrail refusal: the macOS 26.5.2 model refuses this
+    prompt on some sampling trajectories (#323). The property under test is
+    that the tool result round-trips, not that a particular seed avoids the
+    guardrail.
+    """
+    from conftest import is_guardrail_refusal
+    content = ""
+    for seed in (42, 7, 123):
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
+            ],
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"] or ""
+        if not is_guardrail_refusal(content):
+            return data
+    pytest.fail(f"model guardrail-refused every seed; last: {content}")
 
 
 # ============================================================================
@@ -378,6 +391,29 @@ def test_mcp_tool_timeout_returns_structured_error():
 
 
 # ============================================================================
+# Guardrail refusal detection helper (#323, #324)
+# ============================================================================
+
+@pytest.mark.parametrize("text,expected", [
+    ("I'm sorry, but I cannot comply with your request.", True),
+    ("I’m sorry, but as a language model I cannot comply.", True),
+    ("  I'm sorry, but I cannot provide that.\n", True),
+    ("Sorry, I cannot do that.", True),
+    ("I can't help with that request as it violates guidelines.", True),
+    ("I cannot provide an answer that promotes harm.", True),
+    ("300", False),
+    ("The answer is 42.", False),
+    ("12", False),
+    ("", False),
+    (None, False),
+])
+def test_is_guardrail_refusal(text, expected):
+    """The shared helper must catch all known on-device model refusal variants."""
+    from conftest import is_guardrail_refusal
+    assert is_guardrail_refusal(text) is expected
+
+
+# ============================================================================
 # MCP tool routing (different calculator tools)
 # ============================================================================
 
@@ -391,18 +427,28 @@ def test_mcp_multiply_returns_correct_result(multiply_247x83_response):
 
 
 def test_mcp_sqrt_returns_correct_result():
-    """Sqrt tool: sqrt(144) = 12."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
-        ],
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    data = resp.json()
-    content = data["choices"][0]["message"]["content"] or ""
-    assert data["choices"][0]["finish_reason"] == "stop"
-    assert_no_raw_tool_calls(content)
+    """Sqrt tool: sqrt(144) = 12.
+
+    Rotates seeds on guardrail refusal: the macOS 26.5.2 model refuses this
+    prompt on some sampling trajectories (#320, #323)."""
+    from conftest import is_guardrail_refusal
+    content = ""
+    for seed in (42, 7, 123):
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
+            ],
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"] or ""
+        assert data["choices"][0]["finish_reason"] == "stop"
+        assert_no_raw_tool_calls(content)
+        if not is_guardrail_refusal(content):
+            break
+    else:
+        pytest.fail(f"model guardrail-refused every seed; last: {content}")
     assert "12" in content, f"Expected 12, got: {content}"
 
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**\n\nFixes #323.\nFixes #333.\n\n---\n\n## Fix 1: seed rotation for add_tool_response fixture and sqrt test (#323)\n\n### Root cause\n\nThe `add_tool_response` module fixture in `mcp_server_test.py` uses a hardcoded `seed: 42` and returns whatever the model produces - including guardrail refusals. On macOS 26.5.2, the on-device model refuses the "add 100 and 200" prompt on this seed, returning text like "I'm sorry, but as a language model developed by Apple, I cannot comply with your request." The two consuming tests (`test_mcp_tool_returns_stop_not_tool_calls`, `test_mcp_response_has_valid_usage`) pass only by luck because they don't assert on content value. The `test_mcp_sqrt_returns_correct_result` has the same single-seed vulnerability.\n\n### The fix\n\nThree changes across two files:\n\n1. **Broadened `is_guardrail_refusal` helper in `conftest.py`** - handles all known refusal variants: ASCII and curly apostrophes (U+2019), "I can't", "I cannot provide", "Sorry, ..." without lead-in, and leading whitespace. Shared across test files so future hardening (#324) can import it.\n2. **Seed rotation in `add_tool_response` fixture** - tries seeds (42, 7, 123), returns the first non-refusal response. Fails explicitly if all seeds are refused.\n3. **Seed rotation in `test_mcp_sqrt_returns_correct_result`** - same pattern.\n\n### Test coverage\n\n- Added `mcp_server_test.py::test_is_guardrail_refusal` (11 parametrized cases) to lock down the refusal detector against all known variants including the exact refusal text from #323.\n- Existing `test_mcp_tool_returns_stop_not_tool_calls` and `test_mcp_response_has_valid_usage` still cover the happy path via the fixture.\n\n---\n\n## Fix 2: drop stale prompt count from CLAUDE.md (#333)\n\n### Root cause\n\nCLAUDE.md line 111 hardcoded "runs 53 prompts" for `generate-examples.sh`, but the script now produces 56+ examples. The count went stale when section 14 and other prompts were added.\n\n### The fix\n\nReplaced the hardcoded count with "runs the example prompt suite" so the line cannot go stale again when prompts are added or removed. One line changed in CLAUDE.md.\n\n---\n\n## What I verified (static only)\n\n- Ran the `is_guardrail_refusal` helper directly against all 11 test cases plus the exact refusal text from #323 - all pass.\n- Confirmed the parametrized test is collected correctly by pytest (11 items).\n- Confirmed `grep -c '^\\$ apfel' docs/EXAMPLES.md` returns 56, not 53.\n- Diff limited to `Tests/integration/conftest.py`, `Tests/integration/mcp_server_test.py`, and `CLAUDE.md` - no touches to release infrastructure, guardrails, CI, or dependencies.\n\n## What I did NOT verify\n\n- **Functional correctness for #323. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.\n\n## Anything that seemed suspicious\n\nNothing - straightforward test infrastructure bug and stale documentation.\n\n---\n\ncc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.\n\n_Generated by the apfel bug-solver routine._