### PR TITLE
fix(mcp): coerce string args in calculator + rotate seeds in add fixture (#322, #323)

### DIFF
--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -285,16 +285,26 @@ def normal_streaming_response():
 
 @pytest.fixture(scope="module")
 def add_tool_response():
-    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
-        ],
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return resp.json()
+    """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests.
+
+    Rotates seeds on guardrail refusal (#323), matching the pattern from #320.
+    The macOS 26.5.2 model guardrail-refuses this prompt on seed 42."""
+    prompt = "Use the add function to add 100 and 200. Reply with just the number."
+    for seed in (42, 7, 123, 0, 99):
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"] or ""
+        if not _is_guardrail_refusal(content):
+            return data
+    pytest.fail(
+        f"model guardrail-refused add(100,200) on every seed (42,7,123,0,99); "
+        f"last content: {content}"
+    )
 
 
 # ============================================================================

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -980,3 +980,72 @@ def test_temperature_zero_with_mcp():
     assert data["choices"][0]["finish_reason"] == "stop"
     content = data["choices"][0]["message"]["content"]
     assert content is not None
+
+
+# ============================================================================
+# Calculator execute() direct tests - model-free (#322)
+#
+# The on-device model routinely emits string arguments (e.g. {"a":"999","b":"1"}).
+# Before #322, add() string-concatenated instead of adding: 999+1 = "9991".
+# These tests import the calculator module directly - no server, no model needed.
+# ============================================================================
+
+def _load_calculator():
+    """Import the calculator server module for direct testing."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "calculator_server", str(ROOT / "mcp" / "calculator" / "server.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_calculator_add_string_args_coerced():
+    """String arguments to add() must be coerced to numbers, not concatenated (#322)."""
+    mod = _load_calculator()
+    result = mod.execute("add", {"a": "999", "b": "1"})
+    assert result == "1000", f"String args concatenated instead of added: {result}"
+
+
+def test_calculator_add_numeric_args_unchanged():
+    """Numeric arguments to add() still work correctly after coercion fix."""
+    mod = _load_calculator()
+    assert mod.execute("add", {"a": 999, "b": 1}) == "1000"
+
+
+def test_calculator_multiply_string_args_coerced():
+    """String arguments to multiply() must be coerced to numbers (#322)."""
+    mod = _load_calculator()
+    result = mod.execute("multiply", {"a": "247", "b": "83"})
+    assert result == "20501", f"String multiply failed: {result}"
+
+
+def test_calculator_string_float_args_coerced():
+    """String float arguments are coerced correctly."""
+    mod = _load_calculator()
+    assert mod.execute("add", {"a": "1.5", "b": "2.5"}) == "4"
+
+
+def test_calculator_non_numeric_string_returns_error():
+    """Non-numeric string args return an error, not a crash (#322)."""
+    mod = _load_calculator()
+    result = mod.execute("add", {"a": "abc", "b": "1"})
+    assert result.startswith("Error:"), f"Expected error for non-numeric args, got: {result}"
+
+
+def test_calculator_all_tools_coerce_string_args():
+    """All seven calculator tools coerce string arguments to numbers (#322)."""
+    mod = _load_calculator()
+    cases = [
+        ("add", {"a": "10", "b": "3"}, "13"),
+        ("subtract", {"a": "10", "b": "3"}, "7"),
+        ("multiply", {"a": "10", "b": "3"}, "30"),
+        ("divide", {"a": "10", "b": "4"}, "2.5"),
+        ("sqrt", {"a": "144"}, "12"),
+        ("power", {"a": "2", "b": "10"}, "1024"),
+        ("round_number", {"a": "3.14159", "decimals": "2"}, "3.14"),
+    ]
+    for tool, args, expected in cases:
+        result = mod.execute(tool, args)
+        assert result == expected, f"{tool}({args}) = {result}, expected {expected}"

--- a/mcp/calculator/server.py
+++ b/mcp/calculator/server.py
@@ -117,11 +117,30 @@ def get_nums(args):
     return nums
 
 
+def to_num(v):
+    """Coerce a value to a number. The on-device model routinely emits string
+    arguments; without coercion, add("999","1") string-concatenates to "9991"."""
+    if isinstance(v, (int, float)):
+        return v
+    if isinstance(v, str):
+        try:
+            return float(v) if "." in v else int(v)
+        except ValueError:
+            pass
+    raise TypeError(f"not a number: {v!r}")
+
+
 def execute(name, args):
     """Execute a tool by name. Tolerates improvised argument keys."""
     nums = get_nums(args)
     a = args.get("a", nums[0] if nums else 0)
     b = args.get("b", nums[1] if len(nums) > 1 else 0)
+
+    try:
+        a = to_num(a)
+        b = to_num(b)
+    except TypeError as e:
+        return f"Error: {e}"
 
     try:
         if name == "add":


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**\n\nFixes #322. Fixes #323.\n\nTwo related MCP calculator fixes in one branch.\n\n---\n\n## Fix 1: coerce string arguments to numbers in calculator execute() (#322)\n\n### Root cause\n\n`execute()` in `mcp/calculator/server.py` extracts arguments with `args.get("a")`, which returns the raw value from the JSON-RPC params - including strings. The `get_nums()` helper does coerce strings to numbers, but it is only used as a fallback when the named key is missing. When the on-device model emits `{"a": "999", "b": "1"}` (which it routinely does), Python's `+` operator string-concatenates: `"999" + "1" = "9991"`. `multiply` crashes with TypeError on the same input. Non-numeric strings like `"abc"` are silently accepted and produce garbage.\n\n### The fix\n\nAdds `to_num()` - a coercion function that converts string values to int or float (matching the logic already in `get_nums()`), raising `TypeError` for truly non-numeric input. Applied to both `a` and `b` at the top of `execute()`, before any arithmetic. Non-numeric values now return an `isError` result instead of silent garbage.\n\nThe fix covers all seven tools (add, subtract, multiply, divide, sqrt, power, round_number) because the coercion sits above the tool dispatch.\n\n### Test coverage\n\n- `test_calculator_add_string_args_coerced` - the headline bug ("999" + "1" = 1000, not "9991")\n- `test_calculator_add_numeric_args_unchanged` - regression guard for numeric args\n- `test_calculator_multiply_string_args_coerced` - multiply with string args (was crashing)\n- `test_calculator_string_float_args_coerced` - string float args ("1.5" + "2.5" = 4)\n- `test_calculator_non_numeric_string_returns_error` - non-numeric strings return Error, not garbage\n- `test_calculator_all_tools_coerce_string_args` - parametric test covering all 7 tools with string inputs\n\nAll tests are model-free (they import the calculator module directly, no server or Apple Intelligence needed).\n\n---\n\n## Fix 2: rotate seeds on guardrail refusal in add_tool_response fixture (#323)\n\n### Root cause\n\nThe `add_tool_response` fixture hardcoded `seed: 42`, which on macOS 26.5.2 deterministically guardrail-refuses the add(100,200) prompt. The two consuming tests (`test_mcp_tool_returns_stop_not_tool_calls`, `test_mcp_response_has_valid_usage`) passed only by luck since they don't assert on content.\n\n### The fix\n\nApplies the same seed rotation pattern from #320: try seeds (42, 7, 123, 0, 99) in order, skip guardrail refusals via `_is_guardrail_refusal()`, assert on the first non-refusal response. `pytest.fail()` fires with the full seed list if every seed refuses.\n\n---\n\n## What I verified (static only)\n\n- `to_num()` mirrors the coercion logic already in `get_nums()` (string with "." -> float, else int)\n- `TypeError` is caught before the arithmetic `try` block, producing a clean `Error:` message consistent with existing error paths\n- `round_number`'s `decimals` arg already uses `int()` coercion independently - no change needed\n- Existing behaviour preserved: numeric args, division by zero, unknown tool, sqrt of negative, fallback key extraction (verified by running the calculator module directly)\n- Seed rotation fixture uses the same `_is_guardrail_refusal()` helper as the sqrt test (#320)\n- Diff limited to `mcp/calculator/server.py` and `Tests/integration/mcp_server_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies\n\n## What I did NOT verify\n\n- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. The calculator fix itself is pure Python and fully testable here, but the integration tests that exercise it end-to-end through the apfel server need the real model.\n\n## Anything that seemed suspicious\n\nNothing - straightforward bugs with clear root causes.\n\n---\n\ncc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.\n\n_Generated by the apfel bug-solver routine._