### PR TITLE
fix(mcp): coerce string args in calculator + harden guardrail refusal matcher (#322, #324)

### DIFF
--- a/Tests/integration/conftest.py
+++ b/Tests/integration/conftest.py
@@ -9,6 +9,45 @@ import httpx
 import pytest
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def is_guardrail_refusal(text):
+    """Detect the on-device model's in-band guardrail refusals.
+
+    Handles ASCII and curly apostrophes (U+2019), leading whitespace,
+    and common phrasings: "I'm sorry", "I can't", "Sorry, ...",
+    "I cannot provide ...", "violates ... guidelines", etc.
+    """
+    lowered = text.strip().lower().replace("’", "'")
+    if not lowered:
+        return False
+    starts = ("i'm sorry", "sorry,", "sorry ", "i apologize", "i cannot", "i can't")
+    if any(lowered.startswith(s) for s in starts):
+        return True
+    has_sorry = "sorry" in lowered
+    has_cannot = "cannot" in lowered or "can't" in lowered
+    has_violates = "violates" in lowered or "guidelines" in lowered
+    return (has_sorry and has_cannot) or (has_sorry and has_violates)
+
+
+def post_with_seed_rotation(url, json_body, seeds=(42, 7, 123, 99), timeout=60):
+    """POST with automatic seed rotation on guardrail refusals.
+
+    Returns the response JSON for the first non-refused seed.
+    Fails with pytest.fail if every seed is refused.
+    """
+    last_content = ""
+    for seed in seeds:
+        body = {**json_body, "seed": seed}
+        resp = httpx.post(url, json=body, timeout=timeout)
+        data = resp.json()
+        content = (data.get("choices") or [{}])[0].get("message", {}).get("content") or ""
+        if not is_guardrail_refusal(content):
+            return data
+        last_content = content
+    pytest.fail(f"model guardrail-refused every seed; last: {last_content}")
+
+
 BINARY = ROOT / ".build" / "release" / "apfel"
 MCP_SERVER = ROOT / "mcp" / "calculator" / "server.py"
 OPENAI_SPEC = pathlib.Path(__file__).parent / "openai_spec" / "openapi.yaml"

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -24,6 +24,8 @@ import subprocess
 import tempfile
 import time
 
+from conftest import is_guardrail_refusal, post_with_seed_rotation
+
 BASE_URL = "http://localhost:11435"
 API_URL = f"{BASE_URL}/v1"
 MODEL = "apple-foundationmodel"
@@ -235,14 +237,12 @@ def health_response():
 @pytest.fixture(scope="module")
 def multiply_247x83_response():
     """Non-streaming multiply 247*83 -- shared by auto-execute and result tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    return post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Use the multiply tool to compute 247 times 83. Reply with just the number."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    return resp.json()
 
 
 @pytest.fixture(scope="module")
@@ -286,15 +286,12 @@ def normal_streaming_response():
 @pytest.fixture(scope="module")
 def add_tool_response():
     """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    return post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return resp.json()
 
 
 # ============================================================================
@@ -553,16 +550,13 @@ def test_mcp_server_chained_tool_calls_do_not_leak_json():
     on cap exhaustion - never returned as message.content with finish_reason
     stop (#240).
     """
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "First use the multiply tool to compute 6 times 7, then use the add tool to add 100 to that result. Give me the final number."}
         ],
-        "seed": 42,
         "max_tokens": 300,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    data = resp.json()
     choice = data["choices"][0]
     content = choice["message"]["content"]
     # Whether or not the model chains, raw tool-call protocol JSON must never
@@ -664,16 +658,13 @@ def test_mcp_noisy_server_tool_call_succeeds():
     desyncing every later call.
     """
     with running_custom_mcp_server(FIXTURES / "noisy_mcp_server.py") as api_url:
-        resp = httpx.post(f"{api_url}/chat/completions", json={
+        data = post_with_seed_rotation(f"{api_url}/chat/completions", {
             "model": MODEL,
             "messages": [
                 {"role": "user", "content": "Use the multiply tool to compute 247 times 83. Reply with just the number."}
             ],
-            "seed": 42,
             "max_tokens": 128,
         }, timeout=30)
-        assert resp.status_code == 200, f"{resp.status_code}: {resp.text[:200]}"
-        data = resp.json()
         assert data["choices"][0]["finish_reason"] == "stop"
         content = data["choices"][0]["message"]["content"] or ""
         assert "20501" in content or "20,501" in content, \
@@ -729,15 +720,6 @@ def test_mcp_multiply_returns_correct_result(multiply_247x83_response):
     assert "20501" in content or "20,501" in content, f"Expected 20501, got: {content}"
 
 
-def _is_guardrail_refusal(text):
-    """The on-device model's guardrail refusals ("I'm sorry, but I cannot
-    respond ... violates our guidelines" / "... cannot provide an answer that
-    promotes or supports harm"). Incidental model behavior, not a property
-    any test here asserts on."""
-    lowered = text.lower()
-    return lowered.startswith("i'm sorry") and "cannot" in lowered
-
-
 def test_mcp_sqrt_returns_correct_result():
     """Sqrt tool: sqrt(144) = 12.
 
@@ -747,23 +729,15 @@ def test_mcp_sqrt_returns_correct_result():
     round-trips into the final answer, not that a particular seed avoids the
     guardrail, so rotate seeds on refusal and assert on the first real
     answer (#320)."""
-    content = ""
-    for seed in (42, 7, 123):
-        resp = httpx.post(f"{API_URL}/chat/completions", json={
-            "model": MODEL,
-            "messages": [
-                {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
-            ],
-            "seed": seed,
-        }, timeout=TIMEOUT)
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"] or ""
-        assert data["choices"][0]["finish_reason"] == "stop"
-        assert_no_raw_tool_calls(content)
-        if not _is_guardrail_refusal(content):
-            break
-    else:
-        pytest.fail(f"model guardrail-refused every seed; last: {content}")
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
+        ],
+    }, timeout=TIMEOUT)
+    content = data["choices"][0]["message"]["content"] or ""
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert_no_raw_tool_calls(content)
     assert "12" in content, f"Expected 12, got: {content}"
 
 
@@ -779,17 +753,14 @@ def test_mcp_tool_returns_stop_not_tool_calls(add_tool_response):
 
 def test_mcp_auto_execute_preserves_conversation_context():
     """Final MCP answer must retain prior conversation context, not just the last prompt."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Remember this exact code word for later replies: MANGO."},
             {"role": "assistant", "content": "I will remember MANGO."},
             {"role": "user", "content": "Use the multiply tool to compute 6 times 7. Reply with exactly the remembered code word, one space, and the number."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    data = resp.json()
     assert data["choices"][0]["finish_reason"] == "stop"
     content = (data["choices"][0]["message"]["content"] or "").strip()
     assert "42" in content, content

--- a/Tests/integration/test_calculator_server.py
+++ b/Tests/integration/test_calculator_server.py
@@ -1,0 +1,141 @@
+"""
+apfel Integration Tests -- MCP calculator server correctness
+
+Validates that the bundled MCP calculator server (mcp/calculator/server.py)
+returns correct results regardless of argument type. The on-device 3B model
+routinely sends string arguments (e.g. {"a": "999", "b": "1"}) even though
+the schema declares {"type": "number"} -- the server must coerce, not
+string-concatenate.
+
+These tests call the calculator server directly via subprocess (stdio MCP),
+so they need no running apfel binary or Apple Intelligence.
+
+Run: python3 -m pytest Tests/integration/test_calculator_server.py -v
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CALC = ROOT / "mcp" / "calculator" / "server.py"
+
+
+def mcp_call(tool_name, arguments):
+    """Call the MCP calculator server via stdio and return (text, isError)."""
+    init_msg = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "apfel-test", "version": "1.0"},
+        },
+    })
+    call_msg = json.dumps({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments},
+    })
+    proc = subprocess.run(
+        [sys.executable, str(CALC)],
+        input=f"{init_msg}\n{call_msg}\n",
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert proc.returncode == 0, f"calculator server crashed: {proc.stderr}"
+    for line in proc.stdout.strip().split("\n"):
+        msg = json.loads(line)
+        if msg.get("id") == 2:
+            result = msg["result"]
+            text = result["content"][0]["text"]
+            is_error = result.get("isError", False)
+            return text, is_error
+    pytest.fail("no tools/call response from calculator server")
+
+
+# -- String argument coercion (#322) -----------------------------------------
+
+class TestStringArgumentCoercion:
+    """The model often sends string args. The server must coerce, not concatenate."""
+
+    def test_add_string_args_returns_sum_not_concatenation(self):
+        text, is_error = mcp_call("add", {"a": "999", "b": "1"})
+        assert not is_error, f"unexpected error: {text}"
+        assert text == "1000", f"expected '1000', got '{text}' (string concatenation?)"
+
+    def test_add_string_args_never_returns_9991(self):
+        text, _ = mcp_call("add", {"a": "999", "b": "1"})
+        assert text != "9991", "add('999','1') = 9991 means string concatenation, not addition"
+
+    def test_subtract_string_args(self):
+        text, is_error = mcp_call("subtract", {"a": "10", "b": "3"})
+        assert not is_error
+        assert text == "7"
+
+    def test_multiply_string_args(self):
+        text, is_error = mcp_call("multiply", {"a": "247", "b": "83"})
+        assert not is_error
+        assert text == "20501"
+
+    def test_divide_string_args(self):
+        text, is_error = mcp_call("divide", {"a": "10", "b": "4"})
+        assert not is_error
+        assert text == "2.5"
+
+    def test_sqrt_string_arg(self):
+        text, is_error = mcp_call("sqrt", {"a": "144"})
+        assert not is_error
+        assert text == "12"
+
+    def test_power_string_args(self):
+        text, is_error = mcp_call("power", {"a": "2", "b": "10"})
+        assert not is_error
+        assert text == "1024"
+
+    def test_round_number_string_args(self):
+        text, is_error = mcp_call("round_number", {"a": "3.14159", "decimals": "2"})
+        assert not is_error
+        assert text == "3.14"
+
+    def test_add_float_strings(self):
+        text, is_error = mcp_call("add", {"a": "1.5", "b": "2.5"})
+        assert not is_error
+        assert text == "4"
+
+    def test_non_numeric_string_returns_error(self):
+        text, is_error = mcp_call("add", {"a": "hello", "b": "1"})
+        assert is_error, f"expected isError for non-numeric arg, got: {text}"
+        assert "numeric" in text.lower() or "number" in text.lower() or "error" in text.lower()
+
+
+# -- Numeric argument baseline (regression guard) ----------------------------
+
+class TestNumericArgumentBaseline:
+    """Normal numeric arguments must still work after the coercion fix."""
+
+    def test_add_integers(self):
+        text, is_error = mcp_call("add", {"a": 999, "b": 1})
+        assert not is_error
+        assert text == "1000"
+
+    def test_add_floats(self):
+        text, is_error = mcp_call("add", {"a": 1.5, "b": 2.5})
+        assert not is_error
+        assert text == "4"
+
+    def test_multiply_integers(self):
+        text, is_error = mcp_call("multiply", {"a": 247, "b": 83})
+        assert not is_error
+        assert text == "20501"
+
+    def test_divide_by_zero(self):
+        text, is_error = mcp_call("divide", {"a": 10, "b": 0})
+        assert is_error
+        assert "division by zero" in text.lower()
+
+    def test_sqrt_negative(self):
+        text, is_error = mcp_call("sqrt", {"a": -1})
+        assert is_error

--- a/mcp/calculator/server.py
+++ b/mcp/calculator/server.py
@@ -117,11 +117,28 @@ def get_nums(args):
     return nums
 
 
+def _coerce_number(v):
+    """Coerce v to a number. Returns the number or None on failure."""
+    if isinstance(v, (int, float)):
+        return v
+    if isinstance(v, str):
+        try:
+            return float(v) if "." in v else int(v)
+        except ValueError:
+            return None
+    return None
+
+
 def execute(name, args):
     """Execute a tool by name. Tolerates improvised argument keys."""
     nums = get_nums(args)
-    a = args.get("a", nums[0] if nums else 0)
-    b = args.get("b", nums[1] if len(nums) > 1 else 0)
+    a = _coerce_number(args.get("a", nums[0] if nums else 0))
+    b = _coerce_number(args.get("b", nums[1] if len(nums) > 1 else 0))
+
+    if a is None:
+        return "Error: argument 'a' must be numeric"
+    if b is None:
+        return "Error: argument 'b' must be numeric"
 
     try:
         if name == "add":


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #322. Fixes #324.

## Summary

Two bug fixes from the v1.7.1 bug sweep, both in test/MCP infrastructure:

1. **Calculator string concatenation (#322):** The MCP calculator's `execute()` silently string-concatenated when the model sent string arguments (`add("999","1") = "9991"`). Added `_coerce_number()` to convert string args to int/float before arithmetic, with `isError` for non-numeric strings.

2. **Guardrail refusal matcher too narrow (#324):** The `_is_guardrail_refusal` helper in `mcp_server_test.py` only matched ASCII-apostrophe `"I'm sorry" + "cannot"`. Known refusal variants (curly apostrophe U+2019, "I can't", "Sorry, ...", "I cannot provide", leading whitespace) dodged it, breaking seed rotation. Broadened the matcher, moved it plus `post_with_seed_rotation` into `conftest.py`, and wired seed rotation into 6 unprotected seed-pinned tests/fixtures.

## Root cause

**#322:** `args.get("a")` returns the raw string when the model sends `{"a": "999", "b": "1"}`. The existing `get_nums()` helper correctly parses strings, but `a` and `b` were assigned from `args.get()` first (returning the raw string), only falling back to `nums` when the key was absent.

**#324:** The narrow matcher required an exact `startswith("i'm sorry")` with ASCII apostrophe AND `"cannot"` in the text. No `.strip()`, no curly-apostrophe normalization, no coverage for "I can't", "Sorry, ...", or "I cannot provide" without the lead-in. An unmatched refusal broke rotation and failed on the content assert.

## Files changed

| File | Change |
|------|--------|
| `mcp/calculator/server.py` | Add `_coerce_number()`, apply to `a`/`b` in `execute()` |
| `Tests/integration/test_calculator_server.py` | **New.** 15 tests: string args for all 7 tools + numeric baseline |
| `Tests/integration/conftest.py` | Add shared `is_guardrail_refusal()` + `post_with_seed_rotation()` |
| `Tests/integration/mcp_server_test.py` | Remove local `_is_guardrail_refusal`, use shared helpers, wire seed rotation into 6 tests/fixtures |

## Test coverage

- **#322:** `test_calculator_server.py` with 15 tests (string coercion for all 7 tools, non-numeric error, numeric baseline). Tests call the calculator via subprocess MCP protocol - no apfel binary needed, fully CI-compatible.
- **#324:** No new test file needed - the fix hardens existing tests. `is_guardrail_refusal` verified against 14 known refusal/non-refusal variants.

## What I verified (static only)

- #322: Confirmed `execute("add", {"a": "999", "b": "1"})` returns `"9991"` before fix, `"1000"` after. Verified all 7 tools and error case via direct import and MCP subprocess protocol.
- #324: Tested broadened matcher against 14 known variants (curly apostrophe, leading whitespace, "I can't", "Sorry, ...", "I cannot provide", etc.) - all pass.
- Swift 6 concurrency: no production code changed for #324; #322 is pure Python.
- Diff limited to `mcp/calculator/server.py`, `Tests/integration/test_calculator_server.py`, `Tests/integration/conftest.py`, `Tests/integration/mcp_server_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness end-to-end with the model.** This needs `make test` on a Mac with Apple Intelligence.
- **#324 follow-up:** `mcp_remote_test.py` and `openai_client_test.py` have unprotected seed-pinned fixtures that should also use the shared helpers. Noted in the commit message as follow-up work.
- `docs/EXAMPLES.md` line 944 still shows the old buggy calculator output (`9991`). Regenerate with `bash scripts/generate-examples.sh` after merging.

## Anything that seemed suspicious

Nothing - both issues filed by Arthur-Ficial from the v1.7.1 bug sweep. Straightforward test infrastructure bugs.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/test_calculator_server.py -v` (standalone, no apfel needed)
- [ ] `python3 -m pytest Tests/integration/mcp_server_test.py -v` (needs running apfel servers)
- [ ] `bash scripts/generate-examples.sh` to regenerate EXAMPLES.md with the calculator fix

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._