### PR TITLE
fix(tokens): derive approximate flag from actual counting (#327)

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -91,12 +91,13 @@ func countTokens(
     let outputReserve = options.contextConfig.outputReserve
     let contextSize = await TokenCounter.shared.contextSize
     let tokenCountFallback = await TokenCounter.shared.tokenCountFallback
-    let approximate = tokenCountFallback != nil
+    let preflightApproximate = tokenCountFallback != nil
+    await TokenCounter.shared.resetFallbackTracking()
 
     let inputEntries: [Transcript.Entry]
     let noToolEntries: [Transcript.Entry]?
 
-    if approximate {
+    if preflightApproximate {
         // Avoid LanguageModelSession construction when the model is unavailable.
         inputEntries = []
         noToolEntries = nil
@@ -120,7 +121,7 @@ func countTokens(
     }
 
     let total: Int
-    if approximate {
+    if preflightApproximate {
         var approxTotal = await TokenCounter.shared.count(mergedPrompt)
         if let sys = systemPrompt, !sys.isEmpty {
             approxTotal += await TokenCounter.shared.count(sys)
@@ -150,7 +151,7 @@ func countTokens(
     }
 
     let mcpToolTokens: Int
-    if approximate {
+    if preflightApproximate {
         mcpToolTokens = 0
     } else if let baseline = noToolEntries {
         let baselineCount = await TokenCounter.shared.count(entries: baseline)
@@ -158,6 +159,9 @@ func countTokens(
     } else {
         mcpToolTokens = 0
     }
+
+    let runtimeFellBack = await TokenCounter.shared.didFallBack
+    let approximate = preflightApproximate || runtimeFellBack
 
     let report = TokenBudgetReport.make(
         promptTokens: promptTokens,
@@ -170,8 +174,16 @@ func countTokens(
         approximate: approximate
     )
 
-    if let tokenCountFallback, !quietMode {
-        printStderr("\(styledErr("apfel:", .yellow)) \(tokenCountFallback.message)")
+    let effectiveFallback: TokenCountFallback?
+    if let tokenCountFallback {
+        effectiveFallback = tokenCountFallback
+    } else if runtimeFellBack {
+        effectiveFallback = .transientError
+    } else {
+        effectiveFallback = nil
+    }
+    if let effectiveFallback, !quietMode {
+        printStderr("\(styledErr("apfel:", .yellow)) \(effectiveFallback.message)")
     }
 
     switch outputFormat {

--- a/Sources/Core/TokenCountFallback.swift
+++ b/Sources/Core/TokenCountFallback.swift
@@ -16,6 +16,11 @@ public enum TokenCountFallback: Sendable, Equatable {
     /// The on-device model reports unavailable (Apple Intelligence disabled,
     /// device not eligible, model not ready).
     case modelUnavailable
+    /// The real tokenizer API was expected to work (OS new enough, model
+    /// available) but threw an error during counting. The chars/4 fallback
+    /// was used silently; this case surfaces that to the caller so the
+    /// `approximate` flag stays truthful (#327).
+    case transientError
 
     /// Decide the fallback reason from runtime facts. The OS check wins over
     /// model availability: on an old OS the real API does not exist at all,
@@ -37,6 +42,8 @@ public enum TokenCountFallback: Sendable, Equatable {
             return "token count is approximate (the on-device tokenizer API requires macOS 26.4+; this Mac runs macOS \(currentOS); using chars/4 fallback)"
         case .modelUnavailable:
             return "token count is approximate (Apple Intelligence unavailable; using chars/4 fallback)"
+        case .transientError:
+            return "token count is approximate (the on-device tokenizer returned an error during counting; using chars/4 fallback)"
         }
     }
 }

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -11,21 +11,33 @@ import ApfelCore
 actor TokenCounter {
     static let shared = TokenCounter()
     private let model = SystemLanguageModel.default
+    private var _fellBack = false
+
+    func resetFallbackTracking() {
+        _fellBack = false
+    }
+
+    var didFallBack: Bool {
+        _fellBack
+    }
 
     /// Count tokens in text using the real FoundationModels API.
     /// Falls back to chars/4 approximation on error or when the model is unavailable.
     func count(_ text: String) async -> Int {
         guard !text.isEmpty else { return 0 }
         guard isAvailable else {
+            _fellBack = true
             return max(1, text.count / 4)
         }
         if #available(macOS 26.4, *) {
             do {
                 return try await model.tokenCount(for: text)
             } catch {
+                _fellBack = true
                 return max(1, text.count / 4)
             }
         } else {
+            _fellBack = true
             return max(1, text.count / 4)
         }
     }
@@ -125,15 +137,18 @@ actor TokenCounter {
     func count(entries: [Transcript.Entry]) async -> Int {
         guard !entries.isEmpty else { return 0 }
         guard isAvailable else {
+            _fellBack = true
             return fallbackCount(entries: entries)
         }
         if #available(macOS 26.4, *) {
             do {
                 return try await model.tokenCount(for: entries)
             } catch {
+                _fellBack = true
                 return fallbackCount(entries: entries)
             }
         } else {
+            _fellBack = true
             return fallbackCount(entries: entries)
         }
     }

--- a/Tests/apfelTests/TokenCountFallbackTests.swift
+++ b/Tests/apfelTests/TokenCountFallbackTests.swift
@@ -44,4 +44,18 @@ func runTokenCountFallbackTests() {
         try assertTrue(msg.contains("Apple Intelligence unavailable"))
         try assertTrue(msg.contains("chars/4"))
     }
+
+    test("transientError message names the runtime error and the fallback (#327)") {
+        let msg = TokenCountFallback.transientError.message
+        try assertTrue(msg.contains("error during counting"))
+        try assertTrue(msg.contains("chars/4"))
+        try assertTrue(!msg.contains("Apple Intelligence unavailable"))
+        try assertTrue(!msg.contains("macOS 26.4"))
+    }
+
+    test("reason returns nil even when transientError exists as a case (#327)") {
+        let reason = TokenCountFallback.reason(
+            modelAvailable: true, osSupportsTokenCounting: true, currentOS: "26.5.0")
+        try assertTrue(reason == nil)
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #327.

## Root cause

`TokenCounter.count()` and `count(entries:)` silently fall back to chars/4 on transient SDK errors (the `catch` blocks on `TokenCounter.swift:35-37` and `:146-148`) without signalling the caller. Meanwhile `CLI.countTokens()` pre-computes `approximate` from a single snapshot of `tokenCountFallback` at line 93, then runs the actual counting later - a classic TOCTOU. If `model.tokenCount(for:)` throws between those two points (transient SDK error, Apple Intelligence toggled mid-run), the report emits `"approximate": false` with chars/4 numbers - a false exactness claim in machine-readable output.

## The fix

Three coordinated changes that eliminate the desync:

1. **`TokenCounter` now tracks actual fallback** via an actor-isolated `_fellBack` flag. Every fallback path in `count()` and `count(entries:)` sets it. `resetFallbackTracking()` clears it before a counting session, `didFallBack` reads it after.

2. **`CLI.countTokens()` derives `approximate` from what happened, not what was predicted.** The pre-flight `tokenCountFallback` check (`preflightApproximate`) still gates session construction (correct - you shouldn't build a `LanguageModelSession` if the model is unavailable). But the report's `approximate` field is now `preflightApproximate || runtimeFellBack`, so a transient throw during counting correctly marks the output as approximate.

3. **`TokenCountFallback.transientError`** - new case so the stderr warning is honest about the cause ("the on-device tokenizer returned an error during counting") rather than silent.

## Test coverage

- Added `TokenCountFallbackTests: "transientError message names the runtime error and the fallback (#327)"` - verifies the new case's message content and that it doesn't falsely claim OS-too-old or model-unavailable.
- Added `TokenCountFallbackTests: "reason returns nil even when transientError exists as a case (#327)"` - confirms the pre-flight `reason()` factory is unaffected (transientError is a runtime-only signal, never returned by `reason()`).
- Existing `TokenCountFallbackTests` cover the unchanged `osTooOld` and `modelUnavailable` paths.

## What I verified (static only)

- The `_fellBack` flag is set in all six fallback paths (two in `count()`, four in `count(entries:)`).
- `resetFallbackTracking()` is called before the counting block in `countTokens()`, so stale state from a prior call cannot leak.
- `didFallBack` is read once after all counting completes, before the report is constructed.
- The `preflightApproximate` rename correctly replaces all three uses of the old `approximate` variable that gate code paths (lines 100, 124, 154).
- Actor isolation on `TokenCounter` makes the flag thread-safe - no concurrent mutation possible.
- `--count-tokens` and `--serve` are mutually exclusive CLI modes, so server-side `count()` calls cannot interfere with the flag during `countTokens()`.
- No exhaustive switches on `TokenCountFallback` outside the enum's own `message` property (which is updated).
- Swift 6 concurrency: no data races introduced - `_fellBack` is an actor-isolated stored property.
- Diff limited to `Sources/CLI.swift`, `Sources/TokenCounter.swift`, `Sources/Core/TokenCountFallback.swift`, `Tests/apfelTests/TokenCountFallbackTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by Arthur-Ficial in the v1.7.1 bug sweep.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_019rPhQXBLgJPTwHftmPmBRF)_