### PR TITLE
fix(mcp,docs): coerce calculator string args (#322) + add missing TOC entry (#331)

### DIFF
--- a/Tests/integration/test_calculator_coercion.py
+++ b/Tests/integration/test_calculator_coercion.py
@@ -1,0 +1,72 @@
+"""Unit tests for MCP calculator server argument coercion.
+
+The on-device 3B model routinely emits tool arguments as strings
+(e.g. {"a": "999", "b": "1"}) even when the schema says type: number.
+The calculator must coerce these to numbers, not silently string-concatenate.
+
+These tests import the calculator server directly - no apfel binary or
+Apple Intelligence needed, so they run in CI.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CALC_PATH = ROOT / "mcp" / "calculator" / "server.py"
+
+
+@pytest.fixture(scope="module")
+def calculator():
+    spec = importlib.util.spec_from_file_location("calculator", str(CALC_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestStringArgCoercion:
+    """String arguments must be coerced to numbers, never concatenated."""
+
+    def test_add_string_args_returns_sum_not_concatenation(self, calculator):
+        result = calculator.execute("add", {"a": "999", "b": "1"})
+        assert result == "1000", f"add('999','1') = {result!r}, expected '1000' (got concatenation?)"
+
+    def test_subtract_string_args(self, calculator):
+        result = calculator.execute("subtract", {"a": "10", "b": "3"})
+        assert result == "7"
+
+    def test_multiply_string_args(self, calculator):
+        result = calculator.execute("multiply", {"a": "247", "b": "83"})
+        assert result == "20501"
+
+    def test_divide_string_args(self, calculator):
+        result = calculator.execute("divide", {"a": "10", "b": "4"})
+        assert result == "2.5"
+
+    def test_sqrt_string_arg(self, calculator):
+        result = calculator.execute("sqrt", {"a": "144"})
+        assert result == "12"
+
+    def test_power_string_args(self, calculator):
+        result = calculator.execute("power", {"a": "2", "b": "10"})
+        assert result == "1024"
+
+    def test_round_number_string_arg(self, calculator):
+        result = calculator.execute("round_number", {"a": "3.14159", "decimals": "2"})
+        assert result == "3.14"
+
+    def test_add_float_strings(self, calculator):
+        result = calculator.execute("add", {"a": "1.5", "b": "2.5"})
+        assert result == "4"
+
+    def test_non_numeric_string_returns_error(self, calculator):
+        result = calculator.execute("add", {"a": "hello", "b": "1"})
+        assert result.startswith("Error:")
+
+    def test_numeric_args_still_work(self, calculator):
+        result = calculator.execute("add", {"a": 999, "b": 1})
+        assert result == "1000"
+
+    def test_mixed_numeric_and_string_args(self, calculator):
+        result = calculator.execute("add", {"a": 999, "b": "1"})
+        assert result == "1000"

--- a/Tests/integration/test_examples_toc.py
+++ b/Tests/integration/test_examples_toc.py
@@ -1,0 +1,80 @@
+"""
+Guard against TOC/body divergence in docs/EXAMPLES.md and its generator script.
+
+The EXAMPLES.md TOC is hardcoded in scripts/generate-examples.sh. If a section
+is added to the body without updating the TOC (or vice versa), these tests fail.
+No apfel binary or Apple Intelligence needed - pure file reads.
+"""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+EXAMPLES_MD = ROOT / "docs" / "EXAMPLES.md"
+GENERATE_SH = ROOT / "scripts" / "generate-examples.sh"
+
+HEADING_RE = re.compile(r"^## (\d+)\. (.+)$", re.MULTILINE)
+ECHO_HEADING_RE = re.compile(r'^echo "## (\d+)\. (.+?)"$', re.MULTILINE)
+TOC_RE = re.compile(r"^\d+\. \[(.+?)\]", re.MULTILINE)
+
+
+def test_every_section_heading_appears_in_toc():
+    """Every ## N. heading in EXAMPLES.md must have a matching TOC entry."""
+    text = EXAMPLES_MD.read_text()
+    toc_end = text.index("\n---")
+    toc_section = text[:toc_end]
+    body_section = text[toc_end:]
+
+    toc_titles = [m.group(1) for m in TOC_RE.finditer(toc_section)]
+    body_headings = [(m.group(1), m.group(2)) for m in HEADING_RE.finditer(body_section)]
+
+    missing = []
+    for num, title in body_headings:
+        if not any(title in t for t in toc_titles):
+            missing.append(f"## {num}. {title}")
+
+    assert not missing, (
+        f"Section headings in body missing from TOC: {missing}. "
+        f"Update the TOC in scripts/generate-examples.sh."
+    )
+
+
+def test_toc_entries_match_body_headings():
+    """Every TOC entry must have a corresponding ## N. heading in the body."""
+    text = EXAMPLES_MD.read_text()
+    toc_end = text.index("\n---")
+    toc_section = text[:toc_end]
+    body_section = text[toc_end:]
+
+    toc_titles = [m.group(1) for m in TOC_RE.finditer(toc_section)]
+    body_titles = [m.group(2) for m in HEADING_RE.finditer(body_section)]
+
+    orphaned = []
+    for toc_title in toc_titles:
+        if not any(toc_title in bt for bt in body_titles):
+            orphaned.append(toc_title)
+
+    assert not orphaned, (
+        f"TOC entries with no matching body heading: {orphaned}. "
+        f"Either add the section or remove the TOC entry."
+    )
+
+
+def test_script_toc_matches_script_sections():
+    """The TOC in generate-examples.sh must list every section the script emits."""
+    script = GENERATE_SH.read_text()
+
+    toc_titles = [m.group(1) for m in TOC_RE.finditer(script)]
+
+    echo_headings = ECHO_HEADING_RE.findall(script)
+    seen = set()
+    script_titles = []
+    for num, title in echo_headings:
+        if title not in seen:
+            seen.add(title)
+            script_titles.append(title)
+
+    missing_from_toc = [t for t in script_titles if not any(t in tc for tc in toc_titles)]
+    assert not missing_from_toc, (
+        f"Script emits sections not listed in its TOC: {missing_from_toc}. "
+        f"Add them to the hardcoded TOC in generate-examples.sh."
+    )

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -21,6 +21,7 @@ This file was generated automatically by `scripts/generate-examples.sh`.
 11. [MCP Tool Calling](#11-mcp-tool-calling)
 12. [Edge Cases](#12-edge-cases)
 13. [Formatting & Structure](#13-formatting--structure)
+14. [File Extraction (PDF, image OCR + understanding)](#14-file-extraction-pdf-image-ocr--understanding)
 
 ---
 

--- a/mcp/calculator/server.py
+++ b/mcp/calculator/server.py
@@ -117,6 +117,15 @@ def get_nums(args):
     return nums
 
 
+def _to_number(v):
+    """Coerce a value to int or float. Raises ValueError on failure."""
+    if isinstance(v, (int, float)):
+        return v
+    if isinstance(v, str):
+        return float(v) if "." in v else int(v)
+    raise ValueError(f"not a valid number: {v!r}")
+
+
 def execute(name, args):
     """Execute a tool by name. Tolerates improvised argument keys."""
     nums = get_nums(args)
@@ -124,6 +133,8 @@ def execute(name, args):
     b = args.get("b", nums[1] if len(nums) > 1 else 0)
 
     try:
+        a = _to_number(a)
+        b = _to_number(b)
         if name == "add":
             r = a + b
         elif name == "subtract":

--- a/scripts/generate-examples.sh
+++ b/scripts/generate-examples.sh
@@ -103,6 +103,7 @@ This file was generated automatically by \`scripts/generate-examples.sh\`.
 11. [MCP Tool Calling](#11-mcp-tool-calling)
 12. [Edge Cases](#12-edge-cases)
 13. [Formatting & Structure](#13-formatting--structure)
+14. [File Extraction (PDF, image OCR + understanding)](#14-file-extraction-pdf-image-ocr--understanding)
 
 ---
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #322.
Fixes #331.

This PR contains two independent bug fixes on the same routine branch. Each commit is self-contained and can be cherry-picked or landed separately if preferred.

---

## Fix 1: MCP calculator string argument coercion (#322)

### Root cause

`execute()` in `mcp/calculator/server.py` extracts arguments via `args.get("a")` and `args.get("b")`, which return raw values from the JSON-RPC params. When the on-device 3B model emits arguments as strings (e.g. `{"a": "999", "b": "1"}`) - which it routinely does despite the schema declaring `type: number` - Python's `+` operator silently concatenates instead of adding. The existing `get_nums()` coercion helper was only used as a fallback for missing keys, not applied to the values actually used in computation.

### The fix

Added a `_to_number()` helper that coerces int, float, and numeric strings to their numeric type, raising `ValueError` for genuinely non-numeric input. The coercion runs at the top of `execute()` on both `a` and `b` before any arithmetic, covering all seven tools. Non-numeric strings produce a proper `isError: true` MCP response instead of a silently wrong answer.

### Test coverage

- Added `Tests/integration/test_calculator_coercion.py` with 11 tests covering: the exact bug (`add("999","1")` must return `"1000"`), string coercion for all 7 tools, float strings, non-numeric rejection, numeric args regression, mixed args.
- Tests import the calculator module directly - no apfel binary or Apple Intelligence needed.

---

## Fix 2: EXAMPLES.md TOC missing section 14 (#331)

### Root cause

The hardcoded Table of Contents in `scripts/generate-examples.sh` (lines 91-105) listed sections 1-13, but the script body emits a 14th section ("File Extraction"). Every regeneration produced an `docs/EXAMPLES.md` whose TOC contradicted its own body. Currently live in the published doc.

### The fix

Added the missing section 14 entry to the TOC in both `scripts/generate-examples.sh` and the live `docs/EXAMPLES.md`.

### Test coverage

- Added `Tests/integration/test_examples_toc.py` with 3 tests:
  - `test_every_section_heading_appears_in_toc` - body headings must have TOC entries
  - `test_toc_entries_match_body_headings` - TOC entries must have body headings
  - `test_script_toc_matches_script_sections` - script's emitted headings must match its TOC
- Verified the test catches the original bug (section 14 missing from old TOC).

---

## What I verified (static only)

- Calculator fix: `_to_number()` reuses the same coercion logic as `get_nums()`. ValueError caught by existing `except Exception` block. Full MCP protocol round-trip verified via subprocess.
- TOC fix: all 3 drift tests pass. Confirmed the test catches the original bug when the fix is reverted.
- Both test files are model-free and need no apfel binary.
- Diff limited to `mcp/calculator/server.py`, `scripts/generate-examples.sh`, `docs/EXAMPLES.md`, and two new test files.
- No touches to release infrastructure, guardrails, CI, dependencies, or forbidden files.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If either fix does not resolve the reported behaviour, ping me in a review comment.

## Anything that seemed suspicious

Nothing - both are straightforward bugs with clear root causes.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._