### PR TITLE
fix(error): drop hardcoded 4096 from contextOverflow message (#330)

### DIFF
--- a/Sources/Core/ApfelError.swift
+++ b/Sources/Core/ApfelError.swift
@@ -138,7 +138,7 @@ public enum ApfelError: Error, Equatable, Hashable, Sendable {
         case .refusal(let explanation):
             return "The on-device model refused the request: \(explanation)"
         case .contextOverflow:
-            return "Input exceeds the 4096-token context window. Shorten the conversation history."
+            return "Input exceeds the model's context window. Shorten the conversation history."
         case .rateLimited:
             return "Apple Intelligence is rate limited. Retry after a few seconds."
         case .concurrentRequest:

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -33,7 +33,7 @@ func runApfelErrorMessageTests() {
     test("ApfelError.contextOverflow.openAIMessage") {
         try assertEqual(
             ApfelError.contextOverflow.openAIMessage,
-            "Input exceeds the 4096-token context window. Shorten the conversation history."
+            "Input exceeds the model's context window. Shorten the conversation history."
         )
     }
     test("ApfelError.rateLimited.openAIMessage") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #330.

## Root cause

`ApfelError.openAIMessage` for `.contextOverflow` hardcoded the string "Input exceeds the 4096-token context window." Every other runtime path (`/health`, `--count-tokens`, `TokenCounter.shared.contextSize`) reads the dynamic window size from the OS. The message is truthful on macOS 26.5.2 (which reports 4096), but becomes a lie the day FoundationModels reports a different window - and `docs/coreai-impact.md` predicts 8192 on macOS 27. The pinned test at `ApfelErrorMessageTests.swift:36` locks in the wrong-by-then string.

## The fix

Dropped the hardcoded number from the message: "Input exceeds the model's context window. Shorten the conversation history." This is future-proof regardless of what window size the OS reports, and stays honest. The actual window size is already available through `/health` and `--count-tokens` for clients that need the number.

Chose option (a) from the issue (drop the number) over option (b) (thread the size into the error) because `.contextOverflow` is a simple enum case with no associated value - adding one would change the public `ApfelCore` API surface and break `Equatable`/`Hashable` conformance patterns downstream.

## Test coverage

- Updated `Tests/apfelTests/ApfelErrorMessageTests.swift:36` to pin the new message string.
- The `localizedDescription equals openAIMessage` test at line 157-174 continues to cover the `contextOverflow` case automatically.

## What I verified (static only)

- The message change is the only line touched in `ApfelError.swift`.
- No other source file references the literal "4096-token context window" string in user-facing code.
- Other "4096" mentions in source comments (`BodyLimits.swift`, `Session.swift`, `StreamOutcome.swift`) are documentation/comments, not user-facing messages - those belong to the OS-27 tracking issues #189/#192, not this fix.
- Diff limited to `Sources/Core/ApfelError.swift` and `Tests/apfelTests/ApfelErrorMessageTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run the Swift test runner. The change is a string literal swap with no logic change, but the pinned test must pass under `swift run apfel-tests`.

## Anything that seemed suspicious

Nothing - straightforward string fix with no logic change.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1TpZq4Wo5TXmr2btjX2WM)_