### PR TITLE
fix(test): broaden guardrail-refusal detection, share via conftest (#324)

### DIFF
--- a/Tests/integration/conftest.py
+++ b/Tests/integration/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for integration tests -- server lifecycle management."""
 import os
 import pathlib
+import re
 import signal
 import subprocess
 import time
@@ -12,6 +13,52 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 BINARY = ROOT / ".build" / "release" / "apfel"
 MCP_SERVER = ROOT / "mcp" / "calculator" / "server.py"
 OPENAI_SPEC = pathlib.Path(__file__).parent / "openai_spec" / "openapi.yaml"
+
+SEED_ROTATION = (42, 7, 123, 99, 256)
+
+_APOSTROPHE_RE = re.compile(r"[‘’`´]")
+
+
+def _normalize_apostrophes(text):
+    return _APOSTROPHE_RE.sub("'", text)
+
+
+def is_guardrail_refusal(text):
+    """Detect the on-device model's guardrail refusals.
+
+    Handles: ASCII and curly apostrophes, leading whitespace, multiple
+    refusal phrasings ("I'm sorry", "Sorry,", "I cannot", "I can't",
+    "violates"). Returns True when the text looks like a refusal rather
+    than a genuine tool-use or content answer.
+    """
+    normalized = _normalize_apostrophes(text.strip()).lower()
+    if not normalized:
+        return False
+    refusal_starts = ("i'm sorry", "i am sorry", "sorry,", "sorry.")
+    refusal_contains = ("cannot", "can't", "violates", "unable to", "not able to")
+    starts = any(normalized.startswith(s) for s in refusal_starts)
+    has_refusal_keyword = any(k in normalized for k in refusal_contains)
+    return starts and has_refusal_keyword
+
+
+def post_with_seed_rotation(url, json_body, seeds=SEED_ROTATION, timeout=60):
+    """POST with automatic seed rotation on guardrail refusal.
+
+    Tries each seed in order; returns the parsed JSON response for the
+    first non-refusal. Calls pytest.fail if every seed is refused.
+    """
+    content = ""
+    for seed in seeds:
+        body = {**json_body, "seed": seed}
+        resp = httpx.post(url, json=body, timeout=timeout)
+        assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+        data = resp.json()
+        content = (data.get("choices", [{}])[0].get("message", {}).get("content") or "")
+        if not is_guardrail_refusal(content):
+            return data
+    pytest.fail(
+        f"model guardrail-refused every seed {seeds}; last content: {content}"
+    )
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -24,6 +24,8 @@ import subprocess
 import tempfile
 import time
 
+from conftest import is_guardrail_refusal, post_with_seed_rotation, SEED_ROTATION
+
 BASE_URL = "http://localhost:11435"
 API_URL = f"{BASE_URL}/v1"
 MODEL = "apple-foundationmodel"
@@ -235,29 +237,31 @@ def health_response():
 @pytest.fixture(scope="module")
 def multiply_247x83_response():
     """Non-streaming multiply 247*83 -- shared by auto-execute and result tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    return post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Use the multiply tool to compute 247 times 83. Reply with just the number."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    return resp.json()
 
 
 @pytest.fixture(scope="module")
 def multiply_streaming_response():
     """Streaming multiply 13*7 -- tests streaming MCP auto-execute."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the multiply tool to compute 13 times 7. Reply with just the number."}
-        ],
-        "stream": True,
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return collect_sse(resp)
+    for seed in SEED_ROTATION:
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the multiply tool to compute 13 times 7. Reply with just the number."}
+            ],
+            "stream": True,
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        assert resp.status_code == 200
+        result = collect_sse(resp)
+        if not is_guardrail_refusal(result[0]):
+            return result
+    pytest.fail(f"model guardrail-refused every seed; last: {result[0]}")
 
 
 @pytest.fixture(scope="module")
@@ -286,15 +290,12 @@ def normal_streaming_response():
 @pytest.fixture(scope="module")
 def add_tool_response():
     """Non-streaming add 100+200 -- shared by stop-not-tool_calls and usage tests."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    return post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Use the add function to add 100 and 200. Reply with just the number."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    return resp.json()
 
 
 # ============================================================================
@@ -408,30 +409,36 @@ def test_client_tools_not_auto_executed():
     Auto-execution only applies to MCP-injected tools. Client tools are the
     client's responsibility to execute.
     """
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
-        "model": MODEL,
-        "messages": [
-            {"role": "user", "content": "Use the get_weather function for Vienna."}
-        ],
-        "tools": [{
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "description": "Get weather for a city",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"city": {"type": "string"}},
-                    "required": ["city"]
+    for seed in SEED_ROTATION:
+        resp = httpx.post(f"{API_URL}/chat/completions", json={
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "Use the get_weather function for Vienna."}
+            ],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"]
+                    }
                 }
-            }
-        }],
-        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
-        "seed": 42,
-    }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["choices"][0]["finish_reason"] == "tool_calls", \
-        f"Expected 'tool_calls' for client tools but got '{data['choices'][0]['finish_reason']}'"
+            }],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "seed": seed,
+        }, timeout=TIMEOUT)
+        assert resp.status_code == 200
+        data = resp.json()
+        if data["choices"][0]["finish_reason"] == "tool_calls":
+            break
+        content = data["choices"][0]["message"].get("content") or ""
+        if not is_guardrail_refusal(content):
+            pytest.fail(f"Expected 'tool_calls' but got '{data['choices'][0]['finish_reason']}': {content}")
+    else:
+        pytest.fail("model guardrail-refused every seed; never produced a tool call")
 
 
 def test_mcp_tool_iserror_is_fed_back_to_model_not_500():
@@ -445,20 +452,16 @@ def test_mcp_tool_iserror_is_fed_back_to_model_not_500():
     failures (timeout, dead pipe) still surface as 500 (covered by the timeout
     and crashed-server tests below).
     """
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Use the divide tool to divide 10 by 0, then tell me what happened."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200, f"isError must no longer 500: {resp.status_code} {resp.text[:200]}"
-    data = resp.json()
     choice = data["choices"][0]
     assert choice["finish_reason"] == "stop"
     content = choice["message"]["content"]
     assert content and content.strip(), "model must produce a recovery answer, not empty content"
-    # The raw tool-call JSON must not leak to the client as the answer.
     assert '"tool_calls"' not in content
 
 
@@ -553,20 +556,15 @@ def test_mcp_server_chained_tool_calls_do_not_leak_json():
     on cap exhaustion - never returned as message.content with finish_reason
     stop (#240).
     """
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "First use the multiply tool to compute 6 times 7, then use the add tool to add 100 to that result. Give me the final number."}
         ],
-        "seed": 42,
         "max_tokens": 300,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    data = resp.json()
     choice = data["choices"][0]
     content = choice["message"]["content"]
-    # Whether or not the model chains, raw tool-call protocol JSON must never
-    # reach the client as the answer.
     assert '"tool_calls"' not in content, f"raw tool-call JSON leaked to client: {content[:300]}"
     assert content and content.strip(), "must produce a natural-language answer"
 
@@ -581,16 +579,13 @@ def test_mcp_huge_tool_output_is_truncated_not_fatal():
     completes with a real answer instead of a context-overflow 500.
     """
     with running_custom_mcp_server(FIXTURES / "huge_output_mcp_server.py") as api_url:
-        resp = httpx.post(f"{api_url}/chat/completions", json={
+        data = post_with_seed_rotation(f"{api_url}/chat/completions", {
             "model": MODEL,
             "messages": [
                 {"role": "user", "content": "Call the fetch_document tool, then summarize the document in one sentence."}
             ],
-            "seed": 42,
             "max_tokens": 200,
         }, timeout=TIMEOUT)
-    assert resp.status_code == 200, f"huge tool output must not overflow: {resp.status_code} {resp.text[:300]}"
-    data = resp.json()
     choice = data["choices"][0]
     content = choice["message"]["content"]
     assert content and content.strip(), "must produce an answer from the truncated result"
@@ -664,16 +659,13 @@ def test_mcp_noisy_server_tool_call_succeeds():
     desyncing every later call.
     """
     with running_custom_mcp_server(FIXTURES / "noisy_mcp_server.py") as api_url:
-        resp = httpx.post(f"{api_url}/chat/completions", json={
+        data = post_with_seed_rotation(f"{api_url}/chat/completions", {
             "model": MODEL,
             "messages": [
                 {"role": "user", "content": "Use the multiply tool to compute 247 times 83. Reply with just the number."}
             ],
-            "seed": 42,
             "max_tokens": 128,
         }, timeout=30)
-        assert resp.status_code == 200, f"{resp.status_code}: {resp.text[:200]}"
-        data = resp.json()
         assert data["choices"][0]["finish_reason"] == "stop"
         content = data["choices"][0]["message"]["content"] or ""
         assert "20501" in content or "20,501" in content, \
@@ -690,26 +682,32 @@ def test_mcp_concurrent_tool_calls_do_not_cross_deliver():
     """
     import concurrent.futures
 
-    def ask(prompt):
+    def ask(prompt, seed):
         return httpx.post(f"{API_URL}/chat/completions", json={
             "model": MODEL,
             "messages": [{"role": "user", "content": prompt}],
-            "seed": 42,
+            "seed": seed,
             "max_tokens": 128,
         }, timeout=TIMEOUT)
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-        fut_multiply = pool.submit(
-            ask, "Use the multiply tool to compute 247 times 83. Reply with just the number.")
-        fut_add = pool.submit(
-            ask, "Use the add function to add 111 and 222. Reply with just the number.")
-        resp_multiply = fut_multiply.result()
-        resp_add = fut_add.result()
+    multiply_content = add_content = ""
+    for seed in SEED_ROTATION:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            fut_multiply = pool.submit(
+                ask, "Use the multiply tool to compute 247 times 83. Reply with just the number.", seed)
+            fut_add = pool.submit(
+                ask, "Use the add function to add 111 and 222. Reply with just the number.", seed)
+            resp_multiply = fut_multiply.result()
+            resp_add = fut_add.result()
 
-    assert resp_multiply.status_code == 200, f"{resp_multiply.status_code}: {resp_multiply.text[:200]}"
-    assert resp_add.status_code == 200, f"{resp_add.status_code}: {resp_add.text[:200]}"
-    multiply_content = resp_multiply.json()["choices"][0]["message"]["content"] or ""
-    add_content = resp_add.json()["choices"][0]["message"]["content"] or ""
+        assert resp_multiply.status_code == 200, f"{resp_multiply.status_code}: {resp_multiply.text[:200]}"
+        assert resp_add.status_code == 200, f"{resp_add.status_code}: {resp_add.text[:200]}"
+        multiply_content = resp_multiply.json()["choices"][0]["message"]["content"] or ""
+        add_content = resp_add.json()["choices"][0]["message"]["content"] or ""
+        if not is_guardrail_refusal(multiply_content) and not is_guardrail_refusal(add_content):
+            break
+    else:
+        pytest.fail(f"model guardrail-refused every seed; multiply: {multiply_content}, add: {add_content}")
     assert "20501" in multiply_content or "20,501" in multiply_content, \
         f"multiply got the wrong result (cross-delivered?): {multiply_content}"
     assert "333" in add_content, \
@@ -729,15 +727,6 @@ def test_mcp_multiply_returns_correct_result(multiply_247x83_response):
     assert "20501" in content or "20,501" in content, f"Expected 20501, got: {content}"
 
 
-def _is_guardrail_refusal(text):
-    """The on-device model's guardrail refusals ("I'm sorry, but I cannot
-    respond ... violates our guidelines" / "... cannot provide an answer that
-    promotes or supports harm"). Incidental model behavior, not a property
-    any test here asserts on."""
-    lowered = text.lower()
-    return lowered.startswith("i'm sorry") and "cannot" in lowered
-
-
 def test_mcp_sqrt_returns_correct_result():
     """Sqrt tool: sqrt(144) = 12.
 
@@ -747,23 +736,15 @@ def test_mcp_sqrt_returns_correct_result():
     round-trips into the final answer, not that a particular seed avoids the
     guardrail, so rotate seeds on refusal and assert on the first real
     answer (#320)."""
-    content = ""
-    for seed in (42, 7, 123):
-        resp = httpx.post(f"{API_URL}/chat/completions", json={
-            "model": MODEL,
-            "messages": [
-                {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
-            ],
-            "seed": seed,
-        }, timeout=TIMEOUT)
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"] or ""
-        assert data["choices"][0]["finish_reason"] == "stop"
-        assert_no_raw_tool_calls(content)
-        if not _is_guardrail_refusal(content):
-            break
-    else:
-        pytest.fail(f"model guardrail-refused every seed; last: {content}")
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "Use the sqrt tool to compute the square root of 144. Reply with just the number."}
+        ],
+    }, timeout=TIMEOUT)
+    content = data["choices"][0]["message"]["content"] or ""
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert_no_raw_tool_calls(content)
     assert "12" in content, f"Expected 12, got: {content}"
 
 
@@ -779,17 +760,14 @@ def test_mcp_tool_returns_stop_not_tool_calls(add_tool_response):
 
 def test_mcp_auto_execute_preserves_conversation_context():
     """Final MCP answer must retain prior conversation context, not just the last prompt."""
-    resp = httpx.post(f"{API_URL}/chat/completions", json={
+    data = post_with_seed_rotation(f"{API_URL}/chat/completions", {
         "model": MODEL,
         "messages": [
             {"role": "user", "content": "Remember this exact code word for later replies: MANGO."},
             {"role": "assistant", "content": "I will remember MANGO."},
             {"role": "user", "content": "Use the multiply tool to compute 6 times 7. Reply with exactly the remembered code word, one space, and the number."}
         ],
-        "seed": 42,
     }, timeout=TIMEOUT)
-    assert resp.status_code == 200
-    data = resp.json()
     assert data["choices"][0]["finish_reason"] == "stop"
     content = (data["choices"][0]["message"]["content"] or "").strip()
     assert "42" in content, content

--- a/Tests/integration/openai_client_test.py
+++ b/Tests/integration/openai_client_test.py
@@ -13,6 +13,8 @@ import pytest
 import openai
 import httpx
 
+from conftest import is_guardrail_refusal, SEED_ROTATION
+
 BASE_URL = "http://localhost:11434/v1"
 MODEL = "apple-foundationmodel"
 
@@ -168,15 +170,21 @@ def test_tool_calling():
             }
         }
     }]
-    resp = client.chat.completions.create(
-        model=MODEL,
-        messages=[{"role": "user", "content": "Use the provided weather function for Vienna. Do not answer directly."}],
-        tools=tools,
-        tool_choice={"type": "function", "function": {"name": "get_weather"}},
-        seed=1,
-    )
-    assert resp.choices[0].finish_reason == "tool_calls"
-    assert len(resp.choices[0].message.tool_calls) > 0
+    for seed in SEED_ROTATION:
+        resp = client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Use the provided weather function for Vienna. Do not answer directly."}],
+            tools=tools,
+            tool_choice={"type": "function", "function": {"name": "get_weather"}},
+            seed=seed,
+        )
+        if resp.choices[0].finish_reason == "tool_calls" and resp.choices[0].message.tool_calls:
+            break
+        content = resp.choices[0].message.content or ""
+        if not is_guardrail_refusal(content):
+            pytest.fail(f"Expected tool_calls but got finish_reason='{resp.choices[0].finish_reason}': {content}")
+    else:
+        pytest.fail(f"model guardrail-refused every seed; never produced a tool call")
     assert resp.choices[0].message.tool_calls[0].function.name == "get_weather"
 
 
@@ -222,50 +230,54 @@ def test_streaming_tool_call_no_content_leak():
             },
         },
     }]
-    content = ""
-    tool_call_chunks = []           # chunks whose delta carries tool_calls
-    finish_reasons = []             # (has_tool_calls, finish_reason) per chunk
-    with httpx.stream(
-        "POST",
-        "http://localhost:11434/v1/chat/completions",
-        json={
-            "model": MODEL,
-            "messages": [{"role": "user", "content": "Use the provided weather function for Vienna. Do not answer directly."}],
-            "tools": tools,
-            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
-            "seed": 1,
-            "stream": True,
-        },
-        timeout=60,
-    ) as resp:
-        for line in resp.iter_lines():
-            if not line.startswith("data: "):
-                continue
-            data = line[6:]
-            if data.strip() == "[DONE]":
-                break
-            chunk = json.loads(data)
-            if not chunk["choices"]:
-                continue
-            delta = chunk["choices"][0]["delta"]
-            fr = chunk["choices"][0]["finish_reason"]
-            if delta.get("content"):
-                content += delta["content"]
-            if delta.get("tool_calls"):
-                tool_call_chunks.append(chunk)
-                # The tool_calls delta chunk itself must NOT carry finish_reason.
-                assert fr is None, \
-                    f"tool_calls delta chunk must not bundle finish_reason; got {fr!r}"
-            finish_reasons.append((bool(delta.get("tool_calls")), fr))
+    for seed in SEED_ROTATION:
+        content = ""
+        tool_call_chunks = []
+        finish_reasons = []
+        with httpx.stream(
+            "POST",
+            "http://localhost:11434/v1/chat/completions",
+            json={
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Use the provided weather function for Vienna. Do not answer directly."}],
+                "tools": tools,
+                "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+                "seed": seed,
+                "stream": True,
+            },
+            timeout=60,
+        ) as resp:
+            for line in resp.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data.strip() == "[DONE]":
+                    break
+                chunk = json.loads(data)
+                if not chunk["choices"]:
+                    continue
+                delta = chunk["choices"][0]["delta"]
+                fr = chunk["choices"][0]["finish_reason"]
+                if delta.get("content"):
+                    content += delta["content"]
+                if delta.get("tool_calls"):
+                    tool_call_chunks.append(chunk)
+                    assert fr is None, \
+                        f"tool_calls delta chunk must not bundle finish_reason; got {fr!r}"
+                finish_reasons.append((bool(delta.get("tool_calls")), fr))
 
-    # No raw tool-call JSON must have been streamed as content.
+        if tool_call_chunks:
+            break
+        if not is_guardrail_refusal(content):
+            pytest.fail(f"Expected tool_calls chunks but got none; content: {content!r}")
+    else:
+        pytest.fail(f"model guardrail-refused every seed; never produced a streaming tool call")
+
     assert "tool_calls" not in content, \
         f"raw tool_calls JSON leaked as content deltas: {content!r}"
-    # A proper tool_calls delta must have been emitted.
     assert tool_call_chunks, "no tool_calls delta chunk was emitted"
     tc = tool_call_chunks[0]["choices"][0]["delta"]["tool_calls"][0]
     assert tc["function"]["name"] == "get_weather"
-    # finish_reason=tool_calls must arrive in a SEPARATE chunk with no tool_calls.
     tool_calls_finish = [fr for has_tc, fr in finish_reasons if fr == "tool_calls" and not has_tc]
     assert tool_calls_finish, \
         "finish_reason=tool_calls must arrive in its own empty-delta chunk"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #324.

## Root cause

The `_is_guardrail_refusal` helper in `mcp_server_test.py` required `lowered.startswith("i'm sorry")` (ASCII apostrophe only) AND `"cannot"` in the text. The on-device model frequently emits curly apostrophes (U+2019), uses alternative phrasings like "I can't", "Sorry,", "I am sorry", or "unable to", and sometimes prepends whitespace. Any of these dodge the matcher, breaking seed rotation and causing the exact flake #320 fixed to recur with different phrasing. The helper also lived in a single file, leaving fixtures in `mcp_remote_test.py` and `openai_client_test.py` with no protection at all - the latter crashes with `IndexError` on `tool_calls[0]` when the model refuses instead of making a tool call.

## The fix

Three changes across the test infrastructure (no production code touched):

1. **`conftest.py`** - Added a broadened `is_guardrail_refusal()` that normalizes apostrophes (ASCII, curly, backtick, acute accent), strips whitespace, and matches against multiple refusal starts ("i'm sorry", "i am sorry", "sorry,", "sorry.") combined with refusal keywords ("cannot", "can't", "violates", "unable to", "not able to"). Also added `post_with_seed_rotation()` - a reusable helper that POSTs with automatic seed rotation through `SEED_ROTATION = (42, 7, 123, 99, 256)`, returning the first non-refusal response or calling `pytest.fail` if every seed is refused.

2. **`mcp_server_test.py`** - Removed the narrow local `_is_guardrail_refusal`. Applied seed rotation to all vulnerable fixtures (`multiply_247x83_response`, `multiply_streaming_response`, `add_tool_response`) and inline tests (`sqrt`, `chained`, `noisy-server`, `MANGO context`, `iserror recovery`, `huge tool output`, `concurrent tool calls`, `client tools not auto-executed`). The sqrt test now uses `post_with_seed_rotation` directly instead of a hand-rolled loop.

3. **`openai_client_test.py`** - Applied seed rotation to `test_tool_calling` and `test_streaming_tool_call_no_content_leak`, preventing `IndexError` crashes when the model refuses instead of producing a tool call.

## Test coverage

- `is_guardrail_refusal` and `post_with_seed_rotation` are exercised by every seed-pinned integration test that uses them - they are the test infrastructure, not tested by separate tests.
- All existing tests are structurally preserved - same assertions, same properties verified - just wrapped in seed rotation.
- The `add_tool_response` fixture fix also addresses #323 (guardrail refusal on seed 42 for add 100+200).

## Deferred to follow-up

- `mcp_remote_test.py` fixtures (`remote_multiply_response`, `remote_add_response`) need the same seed-rotation treatment. Kept out of this PR to stay within scope (3 files).

## What I verified (static only)

- All imports resolve correctly (`from conftest import ...` is the standard pytest pattern for shared test helpers).
- `post_with_seed_rotation` correctly spreads the seed into the JSON body without mutating the original dict.
- The streaming fixture in `mcp_server_test.py` uses inline seed rotation since `post_with_seed_rotation` doesn't handle streaming responses.
- The `tool_choice`-forced tests in both files use a different rotation pattern: they check for `finish_reason == "tool_calls"` rather than content refusal, and only fall through to the refusal check when the model didn't produce a tool call.
- No production code (`Sources/`) touched. No refusal-sniffing added to Sources - this is test-side only, as it should be.
- Swift 6 concurrency: not applicable (Python test files only).
- Diff limited to `Tests/integration/conftest.py`, `Tests/integration/mcp_server_test.py`, `Tests/integration/openai_client_test.py`.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward test infrastructure bug filed by our own bug sweep.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5XjmM73SYRQvcwPwjyw7t)_