### PR TITLE
fix(tools): salvage function name from unparseable tool-call JSON (#358)

### DIFF
--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -86,6 +86,14 @@ public enum ToolCallHandler {
                 return calls
             }
         }
+        // Salvage: the text clearly contains a tool-call attempt but all
+        // candidates failed JSON parsing (e.g. unescaped inner quotes).
+        // Extract the function name via regex so the existing
+        // invalid-arguments recovery path (#241) can feed a tool error
+        // back to the model instead of leaking raw JSON (#358).
+        if response.contains("{\"tool_calls\"") {
+            return salvageUnparseableToolCall(from: response)
+        }
         return nil
     }
 
@@ -221,6 +229,34 @@ public enum ToolCallHandler {
         var repaired = trimmed
         repaired.insert(contentsOf: String(repeating: "]", count: bracketDepth), at: insertPos)
         return repaired
+    }
+
+    /// Last-resort extraction when all JSON candidates are unparseable (#358).
+    /// Uses regex to pull the function name from the garbled text so the
+    /// downstream MCP executor can report an invalid-arguments error back to
+    /// the model instead of the raw protocol JSON leaking as content.
+    private static func salvageUnparseableToolCall(from text: String) -> [ParsedToolCall]? {
+        // "function": {"name": "X"} shape (most common on-device output)
+        let dictPattern = #""function"\s*:\s*\{\s*"name"\s*:\s*"([^"]+)""#
+        // "function": "X" flat shape (sibling-arguments variant)
+        let flatPattern = #""function"\s*:\s*"([^"{]+)""#
+        for pattern in [dictPattern, flatPattern] {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+            var calls: [ParsedToolCall] = []
+            for match in matches {
+                guard let nameRange = Range(match.range(at: 1), in: text) else { continue }
+                let name = String(text[nameRange]).trimmingCharacters(in: .whitespaces)
+                guard !name.isEmpty else { continue }
+                calls.append(ParsedToolCall(
+                    id: "call_\(UUID().uuidString.prefix(8))",
+                    name: name,
+                    argumentsString: "{}"
+                ))
+            }
+            if !calls.isEmpty { return calls }
+        }
+        return nil
     }
 
     private static func parseToolCallJSON(_ json: String) -> [ParsedToolCall]? {

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -453,7 +453,13 @@ private func nonStreamingResponse(
         responseMessage = OpenAIMessage(role: "assistant", content: nil, tool_calls: openAIToolCalls)
         deliveredContent = rawContent
     } else {
-        deliveredContent = jsonMode ? JSONFenceStripper.strip(rawContent) : rawContent
+        var cleaned = jsonMode ? JSONFenceStripper.strip(rawContent) : rawContent
+        // Backstop: strip unparseable tool-call JSON that detectToolCall
+        // could not salvage, so raw protocol text never leaks (#358).
+        if cleaned.contains("{\"tool_calls\"") {
+            cleaned = stripToolCallJSON(from: cleaned)
+        }
+        deliveredContent = cleaned
         responseMessage = OpenAIMessage(role: "assistant", content: .text(deliveredContent))
     }
 
@@ -592,9 +598,14 @@ private func streamingResponse(
                 // by the tool_calls branch below).
                 let deliveredContent: String
                 if toolCalls == nil, jsonMode || emittedContentCount < prev.count {
-                    deliveredContent = jsonMode
+                    var flushed = jsonMode
                         ? JSONFenceStripper.strip(prev)
                         : String(prev[prev.index(prev.startIndex, offsetBy: emittedContentCount)...])
+                    // Backstop: strip unparseable tool-call JSON (#358).
+                    if flushed.contains("{\"tool_calls\"") {
+                        flushed = stripToolCallJSON(from: flushed)
+                    }
+                    deliveredContent = flushed
                     if !deliveredContent.isEmpty {
                         let contentLine = sseDataLine(sseContentChunk(id: id, created: created, content: deliveredContent, includeUsage: includeUsage))
                         responseLines?.append(contentLine.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -428,9 +428,11 @@ func executeMCPToolCallsForCLI(
         ).content
     }
 
-    // Cap exhausted but the model is still emitting a tool call: strip the raw
-    // JSON so it never reaches the user as text.
-    if ToolCallHandler.detectToolCall(in: finalContent) != nil {
+    // Strip any raw tool-call JSON so it never reaches the user as text.
+    // Covers both parseable calls (cap exhausted) and unparseable ones
+    // that the salvage regex could not recover (#358).
+    if ToolCallHandler.detectToolCall(in: finalContent) != nil
+        || finalContent.contains("{\"tool_calls\"") {
         finalContent = stripToolCallJSON(from: finalContent)
     }
 
@@ -555,9 +557,11 @@ func executeMCPToolCallsForServer(
         currentExecuted = next
     }
 
-    // Cap exhausted but the model is still emitting a tool call: strip the raw
-    // JSON so it never reaches the client as content with finish_reason stop.
-    if ToolCallHandler.detectToolCall(in: finalContent) != nil {
+    // Strip any raw tool-call JSON so it never reaches the client as
+    // content with finish_reason stop. Covers both parseable calls (cap
+    // exhausted) and unparseable ones that salvage could not recover (#358).
+    if ToolCallHandler.detectToolCall(in: finalContent) != nil
+        || finalContent.contains("{\"tool_calls\"") {
         finalContent = stripToolCallJSON(from: finalContent)
     }
 

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -306,6 +306,41 @@ func runToolCallHandlerTests() {
         try assertEqual(parsed!["value"] as? String, "ls -l")
     }
 
+    // MARK: - Salvage unparseable tool-call JSON (#358)
+
+    test("salvages function name from unparseable tool-call JSON (#358)") {
+        // The model emits tool-call JSON with unescaped inner quotes that
+        // JSONSerialization cannot parse. detectToolCall must still return
+        // a ParsedToolCall so the invalid-arguments recovery path (#241)
+        // feeds a tool error back to the model instead of leaking raw JSON.
+        let response = #"{"tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "add", "arguments": {"": "{"name": "100", "arguments": {"": "200"}}}}}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 1)
+        try assertEqual(result!.first?.name, "add")
+        try assertTrue(result!.first!.id.hasPrefix("call_"), "salvaged call must have a synthesized id")
+    }
+
+    test("salvages function name with preamble text before unparseable JSON (#358)") {
+        let response = "I'll calculate that for you.\n" + #"{"tool_calls": [{"type": "function", "function": {"name": "multiply", "arguments": {"broken JSON}}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "multiply")
+    }
+
+    test("salvage returns nil when no function name is extractable") {
+        // Contains {"tool_calls" but no recognisable function name pattern
+        let response = #"{"tool_calls": [{"garbled": true}]}"#
+        try assertNil(ToolCallHandler.detectToolCall(in: response))
+    }
+
+    test("salvage uses empty arguments so MCP server can report the error (#358)") {
+        let response = #"{"tool_calls": [{"function": {"name": "sqrt", "arguments": {INVALID}}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.argumentsString, "{}")
+    }
+
     // MARK: - Split prompt methods
 
     test("buildOutputFormatInstructions contains tool names") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #358.

## Root cause

When the on-device model emits tool-call JSON with unescaped inner quotes (e.g. a `<placeholder>` with nested `"name": "100"` inside the arguments value), `JSONSerialization` fails on every candidate extracted by `detectToolCall`. The function returns nil, and the pipeline treats the output as a normal text answer - delivering the raw `{"tool_calls": ...}` protocol JSON to the client as `message.content` with `finish_reason: "stop"`. This is the same leak class as #240/#244, via a hole neither covered: a tool-call attempt whose JSON is *unparseable* (vs. missing id / unclosed brackets / trailing text).

## The fix

Two-layer defense:

1. **Parser salvage** (`ToolCallHandler.detectToolCall`): After all candidates fail JSON parsing, if the response contains `{"tool_calls"`, a new `salvageUnparseableToolCall` method uses regex to extract function names from `"function": {"name": "X"}` patterns in the garbled text. Returns a `ParsedToolCall` with empty arguments `"{}"`, so the existing invalid-arguments recovery path (#241) feeds a tool error back to the model instead of leaking. Tries the common dict shape first, then the flat `"function": "X"` shape as fallback.

2. **Output backstop** (Session.swift CLI + server paths, Handlers.swift non-streaming + streaming paths): Even if salvage fails and `detectToolCall` returns nil, any content still containing `{"tool_calls"` is passed through `stripToolCallJSON` before delivery. This catches edge cases where even the regex cannot extract a function name.

## Test coverage

- Added `ToolCallHandlerTests: "salvages function name from unparseable tool-call JSON (#358)"` - the exact reproduction case from the issue (unescaped inner quotes).
- Added `ToolCallHandlerTests: "salvages function name with preamble text before unparseable JSON (#358)"` - garbled JSON after prose text.
- Added `ToolCallHandlerTests: "salvage returns nil when no function name is extractable"` - confirms no false positives when `{"tool_calls"` is present but no function pattern matches.
- Added `ToolCallHandlerTests: "salvage uses empty arguments so MCP server can report the error (#358)"` - confirms arguments are `"{}"` so the MCP server can report the error back.
- Existing tests verified unaffected: `"returns nil for partial/malformed JSON"`, `"function that is neither dict nor string skips the call"`, all synthesized-id tests.

## What I verified (static only)

- All four new tests exercise the salvage code path with inputs that are genuinely unparseable by JSONSerialization.
- Existing `assertNil` tests (`{tool_calls: broken}`, `{}`, `{"tool_calls": []}`, `"function": 42`) are unaffected by the salvage - none contain a regex-matchable function name pattern.
- Swift 6 concurrency: no data races introduced (all new code is in static methods on a stateless enum).
- Diff limited to `Sources/Core/ToolCallHandler.swift`, `Sources/Session.swift`, `Sources/Handlers.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug reported by the project owner during the v1.7.1 bug sweep. The issue body describes the exact model output and code path.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_013CujbWQnr9X38DPBjAoJjH)_