### PR TITLE
fix(toolcall): recover balanced JSON arguments from unparseable salvage (#367)

### DIFF
--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -139,6 +139,13 @@ public enum ToolCallHandler {
     /// unparseable: the first function name after the marker, plus the raw
     /// (still unparseable) arguments text so downstream validation fails into
     /// the tool-error feedback path rather than executing with defaults.
+    ///
+    /// When the raw arguments text contains a balanced, valid-JSON `{ ... }`
+    /// object (#367), that object is recovered as the arguments string so the
+    /// tool call can actually execute. This handles the common case where the
+    /// model emits unescaped inner quotes around a perfectly valid argument
+    /// object. When no unambiguous object is extractable, the raw text is
+    /// kept so validation still fails loud (#241).
     private static func salvageUnparseableToolCall(from text: String) -> [ParsedToolCall]? {
         guard let start = text.range(of: "{\"tool_calls\"") else { return nil }
         let tail = String(text[start.lowerBound...])
@@ -148,15 +155,54 @@ public enum ToolCallHandler {
             return nil
         }
         let name = String(tail[nameRange])
-        let rawArguments: String
+        var rawArguments: String
         if let argsMarker = tail.range(of: "\"arguments\"") {
             rawArguments = String(tail[argsMarker.upperBound...])
                 .trimmingCharacters(in: CharacterSet(charactersIn: ": \t\n"))
         } else {
             rawArguments = tail
         }
+        if let recovered = extractFirstBalancedObject(from: rawArguments) {
+            rawArguments = recovered
+        }
         let id = "call_\(UUID().uuidString.prefix(8))"
         return [ParsedToolCall(id: id, name: name, argumentsString: rawArguments)]
+    }
+
+    /// Scan `text` for the first balanced `{ ... }` substring that parses as
+    /// valid JSON. The brace counter is string-aware (same technique as
+    /// `extractCandidates`). Returns `nil` when no unambiguous, parseable
+    /// object is found - the caller keeps the raw text so #241 fires.
+    private static func extractFirstBalancedObject(from text: String) -> String? {
+        guard let firstBrace = text.firstIndex(of: "{") else { return nil }
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var idx = firstBrace
+        while idx < text.endIndex {
+            let ch = text[idx]
+            if inString {
+                if escaped { escaped = false }
+                else if ch == "\\" { escaped = true }
+                else if ch == "\"" { inString = false }
+            } else if ch == "\"" {
+                inString = true
+            } else if ch == "{" {
+                depth += 1
+            } else if ch == "}" {
+                depth -= 1
+                if depth == 0 {
+                    let candidate = String(text[firstBrace...idx])
+                    if let data = candidate.data(using: .utf8),
+                       (try? JSONSerialization.jsonObject(with: data)) != nil {
+                        return candidate
+                    }
+                    return nil
+                }
+            }
+            idx = text.index(after: idx)
+        }
+        return nil
     }
 
     // MARK: - Private Helpers

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -352,6 +352,50 @@ func runToolCallHandlerTests() {
         try assertEqual(parsed!["value"] as? String, "ls -l")
     }
 
+    // MARK: - Argument recovery from unparseable tool calls (#367)
+
+    test("recovers balanced JSON arguments from unescaped-quote salvage (#367)") {
+        // Real model output: arguments as a quoted string with unescaped inner
+        // quotes plus the wrapper's trailing "}}]}". The inner object is valid
+        // JSON that salvage should recover.
+        let response = #"{"tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "multiply", "arguments": "{"value1": 1234, "value2": 5678}"}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 1)
+        try assertEqual(result!.first?.name, "multiply")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+        try assertEqual(parsed?["value1"] as? Int, 1234)
+        try assertEqual(parsed?["value2"] as? Int, 5678)
+    }
+
+    test("recovers arguments with different param names (#367)") {
+        // Second captured failure from the issue - same signature, different
+        // parameter names.
+        let response = #"{"tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "multiply", "arguments": "{"number1": 1234, "number2": 5678}"}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "multiply")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+        try assertEqual(parsed?["number1"] as? Int, 1234)
+        try assertEqual(parsed?["number2"] as? Int, 5678)
+    }
+
+    test("non-recoverable salvage still fails loud (#367 respects #241)") {
+        // The existing #358 garbage-placeholder case: no valid JSON object
+        // to extract, so arguments must stay unparseable.
+        let response = #"{"tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "add", "arguments": {"<escaped_json_string>": "{"name": "100", "arguments": {"<escaped_json_string>": "200"}}}}}}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "add")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8))
+        try assertNil(parsed)
+    }
+
     // MARK: - Split prompt methods
 
     test("buildOutputFormatInstructions contains tool names") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #367.

## Root cause

When the on-device model emits tool-call arguments as a quoted string with unescaped inner quotes (e.g. `"arguments": "{"value1": 1234, "value2": 5678}"`), the entire JSON block is unparseable. `salvageUnparseableToolCall` recovers the function name but returns the raw text from after the `"arguments"` marker to end-of-string, carrying the wrapper's trailing `"}}]}"`. `validateToolArguments` then rejects it as invalid JSON, dropping a tool call whose arguments were actually recoverable.

## The fix

Added `extractFirstBalancedObject(from:)` - a string-aware balanced-brace scanner (same technique already used in `extractCandidates` and `stripToolCallJSON`) that finds the first balanced `{ ... }` substring in the raw arguments text and verifies it parses as valid JSON. Called from `salvageUnparseableToolCall` after extracting raw arguments: when a valid object is found, it replaces the raw text so the tool call executes; when no unambiguous object is extractable, the raw text is kept so validation still fails loud, preserving #241's "never guess" principle.

## Test coverage

- Added `ToolCallHandlerTests: "recovers balanced JSON arguments from unescaped-quote salvage (#367)"` - the primary captured failure pattern with `value1`/`value2` params.
- Added `ToolCallHandlerTests: "recovers arguments with different param names (#367)"` - second captured failure with `number1`/`number2` params.
- Added `ToolCallHandlerTests: "non-recoverable salvage still fails loud (#367 respects #241)"` - verifies the existing #358 garbage-placeholder case remains unparseable (no false recovery).
- Existing `"salvages function name from unparseable tool-call JSON"` (#358) still covers the non-recoverable path.
- Existing `"salvage synthesizes an id and survives a preamble"` still covers the preamble case.

## What I verified (static only)

- Traced the balanced-brace scan through all three new test inputs and the two existing salvage tests by hand - all produce the expected results.
- The `extractFirstBalancedObject` helper uses the same string-aware brace-counting pattern as `extractCandidates` (line 187) and `stripToolCallJSON` (line 105) - consistent with existing codebase patterns.
- Swift 6 concurrency: no data races introduced - `extractFirstBalancedObject` is a pure function on value types in a static method.
- Diff limited to `Sources/Core/ToolCallHandler.swift` and `Tests/apfelTests/ToolCallHandlerTests.swift` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or build Swift on this Linux cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward enhancement to the existing salvage path. The issue reporter provided a well-structured write-up with deterministic repro steps and accurate root-cause analysis. No injection attempts or hostile content detected.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2vabiwkVKX2rbaAZDEqsb)_