### PR TITLE
fix(server): context_window reports 0 on macOS 27 (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/health` and `/v1/models` no longer report `context_window: 0` on macOS 27. The server cached `model.contextSize` once at startup before `prewarm()`, and on macOS 27 the SDK returns 0 for an uninitialised model - locking in 0 for the lifetime of the process. `context_window` is now a per-request read (same cost profile as the already-per-request `isAvailable`). `supportedLanguages` stays cached (crash safety, apfel-gui#4). Field-reported by @motacola (#192).
+
 ### Changed
 
 - Integration tests run in two marker-partitioned phases (#374): the model-free, parallel-safe partition first (`-m "not model and not serial"`, parallelized with pytest-xdist one-worker-per-file when installed), then the serial on-device-model phase (`-m "model or serial"`). Every test still runs exactly once and `APFEL_REQUIRE_FULL=1` still forbids skips; cheap doc-drift gates now fail in seconds instead of after ~10 minutes of model tests. `make preflight` is light by default (build + unit + model-free phase, ~1.5 min warm; `FULL=1` restores the full qualification) because `make release` runs the complete suite against the stamped release binary anyway - one full model pass per release instead of two. Marker hygiene enforced by the new `test_marker_discipline.py` source-scan suite (runs on CI): whole-suite `pytestmark` declarations for the generation-driven files (incl. the previously unmarked `test_chat.py`), a single shared `require_model()` in `conftest.py`, and a new `serial` marker for suites that mutate machine-global state (`test_brew_service.py`). Benchmark medians default to 3 runs (`APFEL_BENCH_RUNS=5` to restore the #264-era count).

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -51,16 +51,15 @@ nonisolated(unsafe) var serverState: ServerState!
 func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async throws {
     serverState = ServerState(config: config, mcpManager: mcpManager)
 
-    // Pre-fetch static model properties BEFORE binding so:
-    // (a) the first /health or /v1/models request does not pay the cold-start
-    //     SDK cost (12-second GUI health-probe timeouts observed in apfel-gui#4),
-    // (b) any SDK-level crash inside SystemLanguageModel.supportedLanguages
-    //     fails visibly during startup instead of SIGSEGV on a routine health
-    //     probe (also apfel-gui#4).
-    // Availability stays a per-request read because it can flip at runtime
-    // (user toggles Apple Intelligence, assets re-download, etc.).
+    // Pre-fetch supportedLanguages BEFORE binding because repeated
+    // mid-flight access on Hummingbird's dispatch queue can crash the
+    // process on some macOS 26.4 environments (apfel-gui#4).
+    // contextSize is NOT cached: on macOS 27 the SDK returns 0 before
+    // the model is initialised, so a startup-cached value locks in 0
+    // for the lifetime of the process (#192). It is a synchronous
+    // property read with the same cost profile as isAvailable (already
+    // per-request), so per-request reads are safe.
     let tc = TokenCounter.shared
-    let cachedContextSize = await tc.contextSize
     let cachedLangs = await tc.supportedLanguages
 
     // Prewarm the model so the first chat completion does not pay the
@@ -75,17 +74,18 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     router.add(middleware: SecurityMiddleware<BasicRequestContext>(config: config))
 
     // Health - includes model availability from SDK.
-    // contextSize and supportedLanguages captured from startup to avoid
-    // per-request SDK calls (cold-start safety, apfel-gui#4).
+    // supportedLanguages captured from startup (crash safety, apfel-gui#4).
+    // contextSize is per-request (#192: returns 0 before prewarm on macOS 27).
     router.get("/health") { _, _ -> Response in
         let active = await serverState.logStore.activeRequests
         let available = await TokenCounter.shared.isAvailable
+        let currentContextSize = await TokenCounter.shared.contextSize
         let health: [String: Any] = [
             "status": available ? "ok" : "model_unavailable",
             "model": modelName,
             "version": version,
             "active_requests": active,
-            "context_window": cachedContextSize,
+            "context_window": currentContextSize,
             "model_available": available,
             "prewarmed": prewarmed,
             "supported_languages": cachedLangs
@@ -97,14 +97,14 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
         return jsonResponse("{\"status\":\"ok\"}")
     }
 
-    // Models — includes context_window and supported_languages from SDK.
-    // Uses the same startup-cached values as /health.
+    // Models - context_window per-request (#192), supportedLanguages cached.
     router.get("/v1/models") { _, _ -> Response in
+        let currentContextSize = await TokenCounter.shared.contextSize
         return jsonResponse(jsonString(ModelsListResponse(
             object: "list",
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
-                context_window: cachedContextSize,
+                context_window: currentContextSize,
                 supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
                 notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(cachedLangs.joined(separator: ", "))"

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -584,6 +584,32 @@ def test_health_schema():
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
 
 
+def test_health_context_window_positive():
+    """context_window must be > 0. Regression guard for #192: on macOS 27
+    the server cached model.contextSize before prewarm(), locking in 0
+    because the SDK returns 0 for an uninitialised model."""
+    resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+    assert resp.status_code == 200
+    cw = resp.json()["context_window"]
+    assert cw > 0, (
+        f"context_window is {cw}. The server likely read model.contextSize "
+        f"before the model was ready (pre-prewarm race, #192)."
+    )
+
+
+def test_models_context_window_positive():
+    """context_window in /v1/models must be > 0 (same race as /health, #192)."""
+    resp = httpx.get(f"{BASE_URL}/v1/models", timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) > 0
+    cw = data[0].get("context_window")
+    assert cw is not None and cw > 0, (
+        f"context_window is {cw} in /v1/models. Same pre-prewarm "
+        f"caching race as /health (#192)."
+    )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #192 (the `/health` reporting regression; the doc-audit half of #192 is a separate task).

## Summary

`/health` and `/v1/models` report `context_window: 0` on macOS 27. The server cached `model.contextSize` once at startup before `prewarm()`, and on macOS 27 the SDK returns 0 for an uninitialised model - locking in 0 for the lifetime of the process. `context_window` is now a per-request read, matching the already-per-request `isAvailable` pattern. `supportedLanguages` stays cached (crash safety, apfel-gui#4).

## Root cause

`Server.swift:63` read `await tc.contextSize` before `prewarm()` (line 70) and cached it in `cachedContextSize`. On macOS 26, `model.contextSize` always returned 4096 regardless of model readiness, so caching was harmless. On macOS 27, the SDK returns 0 when the model is not yet initialised. Since the read happened before prewarm, the server locked in 0 for both `/health` and `/v1/models`.

The CLI commands (`--model-info`, `--count-tokens`) were unaffected because they read `contextSize` at invocation time when the model is already ready. Generation was also unaffected - the completion handler reads `contextSize` dynamically via `TokenCounter.shared`.

## The fix

Removed the startup-cached `cachedContextSize`. Both `/health` and `/v1/models` now read `await TokenCounter.shared.contextSize` per-request. This is a synchronous property read on the actor with the same cost profile as `isAvailable` (already per-request on line 82). `supportedLanguages` remains cached at startup because repeated mid-flight SDK access can crash the process (apfel-gui#4).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- Added `test_health_context_window_positive` and `test_models_context_window_positive` in `openapi_spec_test.py` to lock the bug in place - both assert `context_window > 0`.
- Existing `test_health_schema`, `test_models_list_schema`, `test_health_returns_fast_without_cold_start`, and `test_health_endpoint` still cover schema shape and performance.

## What I verified (static only)

- The diff is limited to `Server.swift`, `openapi_spec_test.py`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- `model.contextSize` is a synchronous property on `SystemLanguageModel.default`, same cost class as `model.isAvailable` which is already per-request. The `test_health_returns_fast_without_cold_start` guard (20 requests in < 2s) should remain green.
- Swift 6 concurrency: no data races introduced. The actor-isolated `contextSize` is accessed via `await` in both handlers, which are already async.
- `supportedLanguages` stays cached per the apfel-gui#4 crash-safety rationale.
- CHANGELOG `[Unreleased]` entry added (changelog-gate CI requirement, #369).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The field report from @motacola is consistent with the known architecture and the macOS 27 SDK behaviour change. Franz's directive to fix came from his verified email account.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6HGNyah86y5rKKQwfuq7f)_