### PR TITLE
fix(server): context_window 0 on macOS 27 - post-prewarm await + high-water-mark cache (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/health` and `/v1/models` no longer report `context_window: 0` on macOS 27. The server now waits (bounded, ~2s) after `prewarm()` for the SDK to report a non-zero `model.contextSize`, and per-request reads use a high-water-mark cache that never regresses to 0 once a real value has been observed. Previously, the value was cached once at startup before `prewarm()`, and on macOS 27 the SDK returns 0 for an uninitialised model - locking in 0 for the lifetime of the process. Field-reported by @motacola (#192).
+
 ### Changed
 
 - Integration tests run in two marker-partitioned phases (#374): the model-free, parallel-safe partition first (`-m "not model and not serial"`, parallelized with pytest-xdist one-worker-per-file when installed), then the serial on-device-model phase (`-m "model or serial"`). Every test still runs exactly once and `APFEL_REQUIRE_FULL=1` still forbids skips; cheap doc-drift gates now fail in seconds instead of after ~10 minutes of model tests. `make preflight` is light by default (build + unit + model-free phase, ~1.5 min warm; `FULL=1` restores the full qualification) because `make release` runs the complete suite against the stamped release binary anyway - one full model pass per release instead of two. Marker hygiene enforced by the new `test_marker_discipline.py` source-scan suite (runs on CI): whole-suite `pytestmark` declarations for the generation-driven files (incl. the previously unmarked `test_chat.py`), a single shared `require_model()` in `conftest.py`, and a new `serial` marker for suites that mutate machine-global state (`test_brew_service.py`). Benchmark medians default to 3 runs (`APFEL_BENCH_RUNS=5` to restore the #264-era count).

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -51,16 +51,10 @@ nonisolated(unsafe) var serverState: ServerState!
 func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async throws {
     serverState = ServerState(config: config, mcpManager: mcpManager)
 
-    // Pre-fetch static model properties BEFORE binding so:
-    // (a) the first /health or /v1/models request does not pay the cold-start
-    //     SDK cost (12-second GUI health-probe timeouts observed in apfel-gui#4),
-    // (b) any SDK-level crash inside SystemLanguageModel.supportedLanguages
-    //     fails visibly during startup instead of SIGSEGV on a routine health
-    //     probe (also apfel-gui#4).
-    // Availability stays a per-request read because it can flip at runtime
-    // (user toggles Apple Intelligence, assets re-download, etc.).
+    // Pre-fetch supportedLanguages BEFORE binding because repeated
+    // mid-flight access on Hummingbird's dispatch queue can crash the
+    // process on some macOS 26.4 environments (apfel-gui#4).
     let tc = TokenCounter.shared
-    let cachedContextSize = await tc.contextSize
     let cachedLangs = await tc.supportedLanguages
 
     // Prewarm the model so the first chat completion does not pay the
@@ -69,23 +63,33 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     // /health as "prewarmed" (#169).
     let prewarmed = await tc.prewarm()
 
+    // On macOS 27, model.contextSize returns 0 during initialization even
+    // after prewarm() returns (#192). Poll briefly (up to ~2s) to seed
+    // the high-water-mark cache before the first request arrives. The
+    // per-request reads below use resolvedContextSize which returns the
+    // cached value if the live SDK read regresses to 0.
+    await tc.awaitContextSize()
+
     let router = Router()
 
     // Security middleware: origin check, token auth, CORS headers
     router.add(middleware: SecurityMiddleware<BasicRequestContext>(config: config))
 
     // Health - includes model availability from SDK.
-    // contextSize and supportedLanguages captured from startup to avoid
-    // per-request SDK calls (cold-start safety, apfel-gui#4).
+    // supportedLanguages cached at startup (crash safety, apfel-gui#4).
+    // contextSize is per-request via resolvedContextSize (#192): on macOS 27
+    // the SDK returns 0 during initialization; the high-water-mark cache
+    // ensures we never regress to 0 once a real value has been observed.
     router.get("/health") { _, _ -> Response in
         let active = await serverState.logStore.activeRequests
         let available = await TokenCounter.shared.isAvailable
+        let contextSize = await TokenCounter.shared.resolvedContextSize
         let health: [String: Any] = [
             "status": available ? "ok" : "model_unavailable",
             "model": modelName,
             "version": version,
             "active_requests": active,
-            "context_window": cachedContextSize,
+            "context_window": contextSize,
             "model_available": available,
             "prewarmed": prewarmed,
             "supported_languages": cachedLangs
@@ -97,14 +101,15 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
         return jsonResponse("{\"status\":\"ok\"}")
     }
 
-    // Models — includes context_window and supported_languages from SDK.
-    // Uses the same startup-cached values as /health.
+    // Models - context_window per-request via resolvedContextSize (#192),
+    // supportedLanguages cached at startup (crash safety, apfel-gui#4).
     router.get("/v1/models") { _, _ -> Response in
+        let contextSize = await TokenCounter.shared.resolvedContextSize
         return jsonResponse(jsonString(ModelsListResponse(
             object: "list",
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
-                context_window: cachedContextSize,
+                context_window: contextSize,
                 supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
                 notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(cachedLangs.joined(separator: ", "))"

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -52,6 +52,37 @@ actor TokenCounter {
         model.contextSize
     }
 
+    /// Last non-zero context size observed. Once the model reports a real
+    /// value, this never regresses to 0 even if the model transiently
+    /// reports 0 during re-initialization (macOS 27, #192).
+    private var _resolvedContextSize: Int = 0
+
+    /// Context size with high-water-mark semantics: returns the live SDK
+    /// value when positive, otherwise the last known positive value.
+    /// Returns 0 only if the model has never reported a non-zero context
+    /// size in this process's lifetime.
+    var resolvedContextSize: Int {
+        let live = model.contextSize
+        if live > 0 {
+            _resolvedContextSize = live
+        }
+        return _resolvedContextSize
+    }
+
+    /// Poll until contextSize is positive or the attempt limit is reached.
+    /// On macOS 27, model.contextSize returns 0 during initialization even
+    /// after prewarm() returns (#192). Call after prewarm() so the first
+    /// /health request sees the real value.
+    @discardableResult
+    func awaitContextSize(maxAttempts: Int = 20, intervalNanoseconds: UInt64 = 100_000_000) async -> Int {
+        for _ in 0..<maxAttempts {
+            let size = resolvedContextSize
+            if size > 0 { return size }
+            try? await Task.sleep(nanoseconds: intervalNanoseconds)
+        }
+        return resolvedContextSize
+    }
+
     /// Tokens available for model input given a reserved output budget.
     func inputBudget(reservedForOutput: Int = 512) -> Int {
         contextSize - reservedForOutput

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -584,6 +584,41 @@ def test_health_schema():
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
 
 
+def test_health_context_window_positive():
+    """context_window must be > 0 when the model is available. Regression
+    guard for #192: on macOS 27 the SDK returns 0 for contextSize during
+    model initialization; the server must wait for a real value at startup
+    and use a high-water-mark cache for per-request reads."""
+    resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()
+    if not data.get("model_available", False):
+        pytest.skip("model unavailable - context_window 0 is expected")
+    cw = data["context_window"]
+    assert cw > 0, (
+        f"context_window is {cw} but model_available is true. "
+        f"The server likely read model.contextSize before the model "
+        f"was ready (initialization race, #192)."
+    )
+
+
+def test_models_context_window_positive():
+    """context_window in /v1/models must be > 0 when the model is available
+    (same initialization race as /health, #192)."""
+    health = httpx.get(f"{BASE_URL}/health", timeout=10).json()
+    if not health.get("model_available", False):
+        pytest.skip("model unavailable - context_window 0 is expected")
+    resp = httpx.get(f"{BASE_URL}/v1/models", timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) > 0
+    cw = data[0].get("context_window")
+    assert cw is not None and cw > 0, (
+        f"context_window is {cw} in /v1/models but model is available. "
+        f"Same initialization race as /health (#192)."
+    )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #192. Supersedes #377 (which was necessary but not sufficient - see below).

## Summary

`/health` and `/v1/models` report `context_window: 0` on macOS 27 because `model.contextSize` returns 0 during model initialization. PR #377 switched to per-request reads, but @motacola's [local testing](https://github.com/Arthur-Ficial/apfel/pull/377#issuecomment-5022602725) showed that per-request reads alone still return 0 during concurrent server starts (`make test` starts two servers simultaneously, reliably reproducing the race).

This PR adds two mechanisms on top of the per-request approach:

1. **`TokenCounter.awaitContextSize()`** - after `prewarm()`, polls briefly (up to ~2s in 100ms intervals) until `model.contextSize` reports a non-zero value. Seeds the cache before the first request arrives.
2. **`TokenCounter.resolvedContextSize`** - high-water-mark cache that remembers the last non-zero `contextSize`. Once the model reports a real value (e.g. 8192), subsequent reads never regress to 0 even if the SDK transiently returns 0 during re-initialization.

`/health` and `/v1/models` now use `resolvedContextSize` per-request instead of the startup-cached value.

## Root cause

On macOS 26, `model.contextSize` always returned 4096 regardless of model readiness, so caching at startup was harmless. On macOS 27, the SDK returns 0 for an uninitialised model. The original code (`Server.swift:63`) cached this value once before `prewarm()`, locking in 0 for the process lifetime.

PR #377 correctly identified that per-request reads were needed, but the initialization window on macOS 27 is longer than expected - `prewarm()` returns before `contextSize` is ready, and concurrent server starts extend this window further.

## The fix

- `Sources/TokenCounter.swift`: Added `resolvedContextSize` (high-water-mark property) and `awaitContextSize()` (bounded post-prewarm poll)
- `Sources/Server.swift`: Removed startup `contextSize` caching; calls `awaitContextSize()` after `prewarm()`; `/health` and `/v1/models` use `resolvedContextSize` per-request
- `supportedLanguages` stays cached at startup (crash safety, apfel-gui#4) - unchanged

## Test coverage

- Added `test_health_context_window_positive` and `test_models_context_window_positive` in `openapi_spec_test.py` - assert `context_window > 0` when `model_available` is true; gracefully skip when model is unavailable (CI-safe)
- Existing `test_health_schema` still covers the structural shape
- No model marker needed - tests skip via `model_available` check, matching the existing health test pattern

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (both servers, concurrent start - the scenario that reproduced the 0 in #377)
- [ ] Verify `/health` and `/v1/models` both report `context_window: 8192` on macOS 27

## What I verified (static only)

- Diff limited to `TokenCounter.swift`, `Server.swift`, `openapi_spec_test.py`, `CHANGELOG.md`
- No touches to release infrastructure, guardrails, CI, or dependencies
- Swift 6 concurrency: `_resolvedContextSize` is actor-isolated (inside `actor TokenCounter`), no data races
- `resolvedContextSize` is a synchronous computed property with the same cost profile as `isAvailable` (already per-request)
- `awaitContextSize()` bounded at 20 attempts x 100ms = 2s max; non-blocking (async sleep)
- `supportedLanguages` caching unchanged (crash safety preserved)

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code from this cloud runner. @motacola's testing infrastructure is ideal for validating the concurrent-start scenario.

## Anything that seemed suspicious

Nothing - straightforward timing bug with a clean root cause confirmed by field testing.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready. PR #377 can be closed once this lands (it was the right diagnosis, this builds on it).

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_0181Eb3WzZReZXjy2dM6SMKH)_