### PR TITLE
fix(server): context_window 0 on macOS 27 - background poll + high-water-mark (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/health` and `/v1/models` no longer report `context_window: 0` on macOS 27. The server now launches a background poll after `prewarm()` that fills a high-water-mark cache as soon as the SDK reports a non-zero `model.contextSize` (up to 60s), and per-request reads never regress to 0 once a real value has been observed. Previously, the value was cached once at startup before `prewarm()`, and on macOS 27 the SDK returns 0 for an uninitialised model - locking in 0 for the lifetime of the process. The background approach avoids blocking server startup for the ~20s the SDK needs on cold boot. Field-reported by @motacola (#192).
+
 ### Changed
 
 - Integration tests run in two marker-partitioned phases (#374): the model-free, parallel-safe partition first (`-m "not model and not serial"`, parallelized with pytest-xdist one-worker-per-file when installed), then the serial on-device-model phase (`-m "model or serial"`). Every test still runs exactly once and `APFEL_REQUIRE_FULL=1` still forbids skips; cheap doc-drift gates now fail in seconds instead of after ~10 minutes of model tests. `make preflight` is light by default (build + unit + model-free phase, ~1.5 min warm; `FULL=1` restores the full qualification) because `make release` runs the complete suite against the stamped release binary anyway - one full model pass per release instead of two. Marker hygiene enforced by the new `test_marker_discipline.py` source-scan suite (runs on CI): whole-suite `pytestmark` declarations for the generation-driven files (incl. the previously unmarked `test_chat.py`), a single shared `require_model()` in `conftest.py`, and a new `serial` marker for suites that mutate machine-global state (`test_brew_service.py`). Benchmark medians default to 3 runs (`APFEL_BENCH_RUNS=5` to restore the #264-era count).

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -51,16 +51,10 @@ nonisolated(unsafe) var serverState: ServerState!
 func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async throws {
     serverState = ServerState(config: config, mcpManager: mcpManager)
 
-    // Pre-fetch static model properties BEFORE binding so:
-    // (a) the first /health or /v1/models request does not pay the cold-start
-    //     SDK cost (12-second GUI health-probe timeouts observed in apfel-gui#4),
-    // (b) any SDK-level crash inside SystemLanguageModel.supportedLanguages
-    //     fails visibly during startup instead of SIGSEGV on a routine health
-    //     probe (also apfel-gui#4).
-    // Availability stays a per-request read because it can flip at runtime
-    // (user toggles Apple Intelligence, assets re-download, etc.).
+    // Pre-fetch supportedLanguages BEFORE binding because repeated
+    // mid-flight access on Hummingbird's dispatch queue can crash the
+    // process on some macOS 26.4 environments (apfel-gui#4).
     let tc = TokenCounter.shared
-    let cachedContextSize = await tc.contextSize
     let cachedLangs = await tc.supportedLanguages
 
     // Prewarm the model so the first chat completion does not pay the
@@ -69,23 +63,34 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     // /health as "prewarmed" (#169).
     let prewarmed = await tc.prewarm()
 
+    // On macOS 27, model.contextSize returns 0 for up to ~20s after
+    // prewarm() (#192). Launch a background poll that fills the
+    // high-water-mark cache as soon as the SDK reports a real value.
+    // Does not block startup; /health and /v1/models read per-request
+    // via resolvedContextSize which returns 0 only until the first
+    // positive observation.
+    await tc.startContextSizePolling()
+
     let router = Router()
 
     // Security middleware: origin check, token auth, CORS headers
     router.add(middleware: SecurityMiddleware<BasicRequestContext>(config: config))
 
     // Health - includes model availability from SDK.
-    // contextSize and supportedLanguages captured from startup to avoid
-    // per-request SDK calls (cold-start safety, apfel-gui#4).
+    // supportedLanguages cached at startup (crash safety, apfel-gui#4).
+    // contextSize is per-request via resolvedContextSize (#192): on macOS 27
+    // the SDK returns 0 during initialization; the high-water-mark cache
+    // ensures we never regress to 0 once a real value has been observed.
     router.get("/health") { _, _ -> Response in
         let active = await serverState.logStore.activeRequests
         let available = await TokenCounter.shared.isAvailable
+        let contextSize = await TokenCounter.shared.resolvedContextSize
         let health: [String: Any] = [
             "status": available ? "ok" : "model_unavailable",
             "model": modelName,
             "version": version,
             "active_requests": active,
-            "context_window": cachedContextSize,
+            "context_window": contextSize,
             "model_available": available,
             "prewarmed": prewarmed,
             "supported_languages": cachedLangs
@@ -97,14 +102,15 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
         return jsonResponse("{\"status\":\"ok\"}")
     }
 
-    // Models — includes context_window and supported_languages from SDK.
-    // Uses the same startup-cached values as /health.
+    // Models - context_window per-request via resolvedContextSize (#192),
+    // supportedLanguages cached at startup (crash safety, apfel-gui#4).
     router.get("/v1/models") { _, _ -> Response in
+        let contextSize = await TokenCounter.shared.resolvedContextSize
         return jsonResponse(jsonString(ModelsListResponse(
             object: "list",
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
-                context_window: cachedContextSize,
+                context_window: contextSize,
                 supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
                 notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(cachedLangs.joined(separator: ", "))"

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -52,6 +52,33 @@ actor TokenCounter {
         model.contextSize
     }
 
+    private var _resolvedContextSize: Int = 0
+
+    /// Context size with high-water-mark semantics: returns the live SDK
+    /// value when positive, otherwise the last known positive value.
+    /// Returns 0 only if the model has never reported a non-zero context
+    /// size in this process's lifetime (macOS 27 initialization window, #192).
+    var resolvedContextSize: Int {
+        let live = model.contextSize
+        if live > 0 {
+            _resolvedContextSize = live
+        }
+        return _resolvedContextSize
+    }
+
+    /// Launch a background poll that updates resolvedContextSize as soon as
+    /// the SDK reports a non-zero value. On macOS 27, model.contextSize
+    /// returns 0 for up to ~20s after prewarm(); this task fills the
+    /// high-water-mark cache without blocking server startup (#192).
+    func startContextSizePolling() {
+        Task {
+            for _ in 0..<120 {
+                if resolvedContextSize > 0 { return }
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
+    }
+
     /// Tokens available for model input given a reserved output budget.
     func inputBudget(reservedForOutput: Int = 512) -> Int {
         contextSize - reservedForOutput

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -15,6 +15,7 @@ Run: python3 -m pytest Tests/integration/openapi_spec_test.py -v
 """
 
 import json
+import time
 import pytest
 import httpx
 from jsonschema import validate, ValidationError
@@ -582,6 +583,50 @@ def test_health_schema():
     resp = httpx.get(f"{BASE_URL}/health", timeout=10)
     assert resp.status_code == 200
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
+
+
+@pytest.mark.model
+def test_health_context_window_positive():
+    """context_window must become > 0 when the model is available. On macOS 27
+    the SDK returns 0 for up to ~20s after prewarm(); the server polls in the
+    background so we retry here to allow for the initialization window (#192)."""
+    from conftest import require_model
+    require_model()
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        cw = data.get("context_window", 0)
+        if cw > 0:
+            return
+        time.sleep(1)
+    pytest.fail(
+        f"context_window stayed 0 for 30s despite model being available. "
+        f"The background context-size polling may not be working (#192)."
+    )
+
+
+@pytest.mark.model
+def test_models_context_window_positive():
+    """context_window in /v1/models must become > 0 when the model is
+    available (same initialization window as /health, #192)."""
+    from conftest import require_model
+    require_model()
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        resp = httpx.get(f"{BASE_URL}/v1/models", timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert len(data) > 0
+        cw = data[0].get("context_window", 0)
+        if cw > 0:
+            return
+        time.sleep(1)
+    pytest.fail(
+        f"context_window stayed 0 for 30s in /v1/models despite model "
+        f"being available. Same initialization race as /health (#192)."
+    )
 
 
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #192. Supersedes #377 and #378 (both had the right diagnosis; #378's 2s startup poll was too short for the ~20s macOS 27 SDK initialization window confirmed by @motacola's testing).

## Summary

- `/health` and `/v1/models` report `context_window: 0` on macOS 27 because `model.contextSize` returns 0 during SDK initialization (~20s after `prewarm()`).
- On macOS 26 the value was always 4096 regardless of readiness, so the startup cache was harmless. On macOS 27, caching before initialization locks in 0 for the process lifetime.
- This PR replaces the startup-cached approach with a **non-blocking background poll** + **per-request reads** through a high-water-mark cache.

**What changed vs #378:** The blocking 2s `awaitContextSize()` call is replaced by `startContextSizePolling()` which launches a background `Task` polling every 500ms for up to 60s. The server binds immediately - no startup delay. The regression tests now poll for up to 30s (matching the real initialization window) instead of asserting once.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (both servers, concurrent cold start - the scenario that reproduced the 0 in #377 and #378)
- [ ] Verify `/health` and `/v1/models` both report `context_window: 8192` on macOS 27

## Root cause

On macOS 27, `SystemLanguageModel.default.contextSize` returns 0 while the SDK initializes the model. `prewarm()` returns before `contextSize` is ready. The original `Server.swift:63` cached this value once at startup (before `prewarm()`), locking in 0 for the lifetime of the process. PR #377's per-request reads still returned 0 during the window. PR #378's 2s post-prewarm poll was far too short - @motacola's testing showed the SDK needs ~17-20 seconds on cold boot.

## The fix

- `Sources/TokenCounter.swift`: Added `resolvedContextSize` (high-water-mark property that never regresses to 0 once a real value is observed) and `startContextSizePolling()` (background Task, 120 iterations x 500ms = 60s max, non-blocking)
- `Sources/Server.swift`: Removed startup `contextSize` caching; calls `startContextSizePolling()` after `prewarm()`; `/health` and `/v1/models` use `resolvedContextSize` per-request
- `supportedLanguages` stays cached at startup (crash safety, apfel-gui#4) - unchanged

## Test coverage

- Added `test_health_context_window_positive` and `test_models_context_window_positive` in `openapi_spec_test.py` - poll for up to 30s for `context_window > 0`, marked `@pytest.mark.model` (only meaningful with Apple Intelligence)
- Existing `test_health_schema` still covers the structural shape

## What I verified (static only)

- Diff limited to `TokenCounter.swift`, `Server.swift`, `openapi_spec_test.py`, `CHANGELOG.md`
- No touches to release infrastructure, guardrails, CI, or dependencies
- Swift 6 concurrency: `_resolvedContextSize` is actor-isolated (inside `actor TokenCounter`), no data races. The background `Task` inherits actor isolation; `Task.sleep` suspends without blocking the actor.
- `resolvedContextSize` is a synchronous computed property with the same cost profile as `isAvailable` (already per-request)
- `supportedLanguages` caching unchanged (crash safety preserved)
- Test marker discipline: new tests are `@pytest.mark.model` and call `require_model()`, matching the file's existing pattern

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code from this cloud runner. @motacola's testing setup reliably reproduces the cold-start race and would validate this fix.

## Anything that seemed suspicious

Nothing - straightforward timing bug with a clean root cause confirmed by field testing across #377 and #378.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready. PRs #377 and #378 can be closed once this lands.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_016dmZWynS5xmCswixhHxP6R)_