### PR TITLE
fix(server): context_window 0 on macOS 27 cold start (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/health` and `/v1/models` no longer report `context_window: 0` on macOS 27 cold start (#192). On macOS 27 the SDK's `model.contextSize` returns 0 during initialization (observed for 80+ seconds); the server previously cached this at startup and locked in 0 for the process lifetime. `TokenCounter.contextSize` now uses a high-water mark that never regresses to 0 once a positive value is observed, with a floor of 4096 (the known minimum for any Apple Intelligence model). Both `/health` and `/v1/models` read per-request instead of using a startup cache. This also fixes the generation deadlock where `inputBudget` returned -512, rejecting all requests before the model could warm up.
+
 ### Changed
 
 - Integration tests run in two marker-partitioned phases (#374): the model-free, parallel-safe partition first (`-m "not model and not serial"`, parallelized with pytest-xdist one-worker-per-file when installed), then the serial on-device-model phase (`-m "model or serial"`). Every test still runs exactly once and `APFEL_REQUIRE_FULL=1` still forbids skips; cheap doc-drift gates now fail in seconds instead of after ~10 minutes of model tests. `make preflight` is light by default (build + unit + model-free phase, ~1.5 min warm; `FULL=1` restores the full qualification) because `make release` runs the complete suite against the stamped release binary anyway - one full model pass per release instead of two. Marker hygiene enforced by the new `test_marker_discipline.py` source-scan suite (runs on CI): whole-suite `pytestmark` declarations for the generation-driven files (incl. the previously unmarked `test_chat.py`), a single shared `require_model()` in `conftest.py`, and a new `serial` marker for suites that mutate machine-global state (`test_brew_service.py`). Benchmark medians default to 3 runs (`APFEL_BENCH_RUNS=5` to restore the #264-era count).

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -51,16 +51,16 @@ nonisolated(unsafe) var serverState: ServerState!
 func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async throws {
     serverState = ServerState(config: config, mcpManager: mcpManager)
 
-    // Pre-fetch static model properties BEFORE binding so:
-    // (a) the first /health or /v1/models request does not pay the cold-start
-    //     SDK cost (12-second GUI health-probe timeouts observed in apfel-gui#4),
-    // (b) any SDK-level crash inside SystemLanguageModel.supportedLanguages
-    //     fails visibly during startup instead of SIGSEGV on a routine health
-    //     probe (also apfel-gui#4).
-    // Availability stays a per-request read because it can flip at runtime
-    // (user toggles Apple Intelligence, assets re-download, etc.).
+    // Pre-fetch supportedLanguages BEFORE binding so any SDK-level crash
+    // fails visibly during startup instead of SIGSEGV on a routine health
+    // probe (apfel-gui#4). supportedLanguages stays cached (crash safety).
+    //
+    // contextSize is read per-request (like isAvailable) because on
+    // macOS 27 the SDK returns 0 during initialization (~80s cold start)
+    // and caching that locks in a wrong value for the process lifetime.
+    // TokenCounter.contextSize applies a high-water mark + 4096 floor,
+    // so per-request reads are both safe and cheap (#192).
     let tc = TokenCounter.shared
-    let cachedContextSize = await tc.contextSize
     let cachedLangs = await tc.supportedLanguages
 
     // Prewarm the model so the first chat completion does not pay the
@@ -75,17 +75,18 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     router.add(middleware: SecurityMiddleware<BasicRequestContext>(config: config))
 
     // Health - includes model availability from SDK.
-    // contextSize and supportedLanguages captured from startup to avoid
-    // per-request SDK calls (cold-start safety, apfel-gui#4).
+    // supportedLanguages cached from startup (crash safety, apfel-gui#4).
+    // contextSize read per-request via TokenCounter (high-water + floor, #192).
     router.get("/health") { _, _ -> Response in
         let active = await serverState.logStore.activeRequests
         let available = await TokenCounter.shared.isAvailable
+        let contextWindow = await TokenCounter.shared.contextSize
         let health: [String: Any] = [
             "status": available ? "ok" : "model_unavailable",
             "model": modelName,
             "version": version,
             "active_requests": active,
-            "context_window": cachedContextSize,
+            "context_window": contextWindow,
             "model_available": available,
             "prewarmed": prewarmed,
             "supported_languages": cachedLangs
@@ -98,13 +99,15 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
     }
 
     // Models — includes context_window and supported_languages from SDK.
-    // Uses the same startup-cached values as /health.
+    // supportedLanguages cached from startup (crash safety, apfel-gui#4).
+    // contextSize read per-request via TokenCounter (high-water + floor, #192).
     router.get("/v1/models") { _, _ -> Response in
+        let contextWindow = await TokenCounter.shared.contextSize
         return jsonResponse(jsonString(ModelsListResponse(
             object: "list",
             data: [.init(
                 id: modelName, object: "model", created: 1719792000, owned_by: "apple",
-                context_window: cachedContextSize,
+                context_window: contextWindow,
                 supported_parameters: ["temperature", "max_tokens", "seed", "stream", "tools", "tool_choice", "response_format", "x_context_strategy", "x_context_max_turns", "x_context_output_reserve"],
                 unsupported_parameters: ["logprobs", "n", "stop", "presence_penalty", "frequency_penalty"],
                 notes: "Apple on-device model via FoundationModels framework. Unsupported parameters are rejected with 400 when present (except n=1 and logprobs=false). Supported languages: \(cachedLangs.joined(separator: ", "))"

--- a/Sources/TokenCounter.swift
+++ b/Sources/TokenCounter.swift
@@ -12,6 +12,11 @@ actor TokenCounter {
     static let shared = TokenCounter()
     private let model = SystemLanguageModel.default
 
+    /// Highest positive value ever observed from model.contextSize.
+    /// Guards against SDK regressions where contextSize flips back to 0
+    /// after reporting the real window (observed on macOS 27 cold start).
+    private var _highWaterContextSize: Int = 0
+
     /// True when any count call in this process actually fell back to chars/4
     /// at runtime - tokenCount(for:) threw, or availability flipped after the
     /// pre-flight `tokenCountFallback` check said the real API was usable.
@@ -47,9 +52,24 @@ actor TokenCounter {
         }
     }
 
-    /// Real context window size from the model.
+    /// Context window size from the model, with a floor of 4096.
+    ///
+    /// On macOS 27, model.contextSize returns 0 during SDK initialization
+    /// (observed for 80+ seconds on cold start). This property uses the
+    /// highest value ever observed (high-water mark) and falls back to
+    /// 4096 - the known minimum for any Apple Intelligence model - when
+    /// the SDK has not yet reported a positive value. Prevents the
+    /// deadlock where inputBudget returns -512, generation is rejected,
+    /// and the model never warms up (#192).
     var contextSize: Int {
-        model.contextSize
+        let raw = model.contextSize
+        if raw > _highWaterContextSize {
+            _highWaterContextSize = raw
+        }
+        if _highWaterContextSize > 0 {
+            return _highWaterContextSize
+        }
+        return 4096
     }
 
     /// Tokens available for model input given a reserved output budget.

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -584,6 +584,39 @@ def test_health_schema():
     validate(instance=resp.json(), schema=HEALTH_SCHEMA)
 
 
+def test_health_context_window_positive():
+    """/health context_window must never be 0 (#192).
+
+    On macOS 27 the SDK returns contextSize 0 during cold start; the
+    high-water-mark floor in TokenCounter prevents this from leaking
+    to clients. Model-free: the 4096 floor applies regardless of model
+    availability.
+    """
+    resp = httpx.get(f"{BASE_URL}/health", timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["context_window"] > 0, (
+        f"context_window is {data['context_window']}; expected > 0 (#192)"
+    )
+
+
+def test_models_context_window_positive():
+    """/v1/models context_window must never be 0 (#192).
+
+    Same root cause as the /health regression: startup-cached
+    contextSize locked in 0 on macOS 27. The per-request read with
+    high-water-mark floor prevents this.
+    """
+    resp = httpx.get(f"{BASE_URL}/v1/models", timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["data"]) > 0
+    model_entry = data["data"][0]
+    assert model_entry.get("context_window", 0) > 0, (
+        f"context_window is {model_entry.get('context_window')}; expected > 0 (#192)"
+    )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================

--- a/Tests/integration/openapi_spec_test.py
+++ b/Tests/integration/openapi_spec_test.py
@@ -617,6 +617,33 @@ def test_models_context_window_positive():
     )
 
 
+def test_completion_not_context_length_exceeded():
+    """A minimal completion must never fail with context_length_exceeded (#192).
+
+    Guards the generation path directly. On macOS 27 cold start,
+    contextSize 0 made inputBudget() return -512, rejecting every
+    request before generation could begin. The 4096 floor in
+    TokenCounter.contextSize breaks this deadlock. Model-free: the
+    budget check runs before generation, so an unavailable model
+    produces a different error (server_error/503), never
+    context_length_exceeded.
+    """
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Hi"}],
+    }
+    resp = httpx.post(
+        f"{BASE_URL}/v1/chat/completions", json=payload, timeout=30
+    )
+    if resp.status_code != 200:
+        body = resp.json()
+        error_type = body.get("error", {}).get("type", "")
+        assert error_type != "context_length_exceeded", (
+            "Minimal completion rejected with context_length_exceeded; "
+            "inputBudget is likely negative (#192)"
+        )
+
+
 # ============================================================================
 # Tests — CORS
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #192. Supersedes #377, #378, and #379 (all had the right diagnosis but incomplete fixes - see the iteration history below).

## Root cause

On macOS 27, `SystemLanguageModel.default.contextSize` returns 0 during SDK initialization (observed for 80+ seconds on cold start by @motacola). The server cached this value once at startup (`Server.swift:63`, before `prewarm()`), locking in 0 for `/health` and `/v1/models` for the process lifetime. On macOS 26 the value was always 4096 regardless of readiness, so caching was harmless.

The 0 propagated into `TokenCounter.inputBudget()` (0 - 512 = -512), causing all generation requests to fail with `context_length_exceeded`. This created a deadlock: generation could not happen because the budget was negative, but the model needed generation to warm up.

## The fix

Two changes, both in the data path rather than in timing heuristics:

1. **`TokenCounter.contextSize`** now applies a high-water mark (once a positive SDK value is observed, it never regresses to 0) with a floor of 4096 (the known minimum for any Apple Intelligence model). This single property is the resolved context source for both reporting (`/health`, `/v1/models`) and budgeting (`inputBudget()`), addressing @motacola's finding that #379's high-water cache protected reporting but not generation.

2. **`Server.swift`** reads `contextSize` per-request (like `isAvailable`) instead of caching at startup. `supportedLanguages` stays cached (crash safety, apfel-gui#4).

No background polling, no startup delay, no timing assumptions. The floor breaks the cold-start deadlock immediately: `inputBudget()` returns 3584 (4096 - 512) instead of -512, so generation works from the first request. Once the SDK reports the real value (8192 on macOS 27), the high-water mark locks it in permanently.

## Why this succeeds where #377-#379 failed

| PR | Approach | Why it failed |
|---|---|---|
| #377 | Per-request raw reads | Still returned 0 during init window |
| #378 | 2s post-prewarm blocking poll | Init takes ~20s, poll was too short |
| #379 | 60s background poll + high-water cache | Init can take 80s+; high-water only protected reporting, not `inputBudget()`; tests ran on warm model |
| **This** | **4096 floor + high-water mark on `contextSize` itself** | No timing dependency. Floor breaks the deadlock immediately. Single source for both reporting and budgeting. |

## Test coverage

- Added `test_health_context_window_positive` and `test_models_context_window_positive` in `openapi_spec_test.py` - assert `context_window > 0` on both endpoints. Model-free (the 4096 floor applies regardless of model availability), so they run on CI.
- Existing `test_health_schema` and `test_models_list_schema` still cover the structural shape.

## What I verified (static only)

- Swift 6 concurrency: `_highWaterContextSize` is actor-isolated (inside `actor TokenCounter`), no data races.
- `contextSize` is a synchronous computed property with the same cost profile as `isAvailable` (already per-request).
- `supportedLanguages` caching unchanged (crash safety preserved).
- Diff limited to `TokenCounter.swift`, `Server.swift`, `openapi_spec_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Test marker discipline: new tests are model-free (no `require_model()`), consistent with the file's mixed-marker pattern.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code from this cloud runner. @motacola's cold-start test setup (stop all Apfel processes, confirm `--model-info: context 0`, start a fresh server, poll `/health`) would validate the floor and high-water-mark behavior end-to-end.

## Anything that seemed suspicious

Nothing - straightforward timing bug with a clean root cause confirmed by field testing across #377, #378, and #379.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready. PRs #377, #378, and #379 can be closed once this lands.

_Generated by the apfel bug-solver routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKV5FHwi3Yg27MWUoT6dqh)_