### PR TITLE
fix(tool-call): guard JSONSerialization against scalar arguments (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Scalar tool-call arguments (number, bool) no longer abort the process via an uncatchable `NSInvalidArgumentException` (#388). `JSONSerialization.data(withJSONObject:)` now uses `.fragmentsAllowed` and the result is routed through `ensureJSONArguments` so a bare scalar becomes a valid JSON object.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -369,10 +369,11 @@ public enum ToolCallHandler {
             let args: String
             if let s = rawArguments as? String {
                 args = ensureJSONArguments(s)
-            } else if let obj = rawArguments,
-                      let data = try? JSONSerialization.data(withJSONObject: obj),
+            } else if let obj = rawArguments, !(obj is NSNull),
+                      let data = try? JSONSerialization.data(withJSONObject: obj,
+                                                             options: [.fragmentsAllowed]),
                       let s = String(data: data, encoding: .utf8) {
-                args = s
+                args = ensureJSONArguments(s)
             } else {
                 args = "{}"
             }

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -145,6 +145,36 @@ func runToolCallHandlerTests() {
         try assertTrue(prompt.contains("fn"))
     }
 
+    // MARK: - Scalar arguments do not crash (#388)
+
+    test("scalar number arguments do not crash (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "add", "arguments": 7}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "add")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed, "scalar number arguments must produce valid JSON object, got: \(args)")
+    }
+
+    test("scalar bool arguments do not crash (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "toggle", "arguments": true}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "toggle")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed, "scalar bool arguments must produce valid JSON object, got: \(args)")
+    }
+
+    test("null arguments fall through to empty object (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "ping", "arguments": null}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "ping")
+        try assertEqual(result!.first?.argumentsString, "{}")
+    }
+
     // MARK: - Edge cases (bug fixes)
 
     test("detects tool call with missing closing bracket (#187)") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #388.

## Summary

`ToolCallHandler.parseToolCallJSON` aborts the entire process when the model emits a tool call with scalar `arguments` (a number like `7` or a boolean like `true`). `JSONSerialization.data(withJSONObject:)` requires a top-level array or dictionary - handed an `NSNumber` it raises an Objective-C `NSInvalidArgumentException` that `try?` cannot catch, killing the process with SIGABRT.

The fix adds `.fragmentsAllowed` so the serializer accepts a scalar, excludes `NSNull` so it falls through to `"{}"`, and routes the serialized result through `ensureJSONArguments` so a bare scalar becomes a valid JSON object (same wrapping already used for bare-string arguments).

## Root cause

`JSONSerialization.data(withJSONObject:)` at `Sources/Core/ToolCallHandler.swift:373` is called without `.fragmentsAllowed`. When `rawArguments` is an `NSNumber` (the Foundation type backing JSON numbers and booleans), the method raises an ObjC exception instead of throwing a Swift error. `try?` only catches Swift errors, so the `else { args = "{}" }` safety net is unreachable for scalars. The process dies.

## The fix

Three changes to the `else if` branch in `parseToolCallJSON`:
1. `!(obj is NSNull)` - null arguments skip serialization and fall through to `"{}"`
2. `.fragmentsAllowed` option - lets `JSONSerialization` serialize scalars instead of raising
3. `ensureJSONArguments(s)` instead of bare `s` - wraps a serialized scalar (`"7"`) into a valid JSON object (`{"value":"7"}`) the same way bare strings are already handled

Objects and arrays are unaffected: `ensureJSONArguments` passes through strings starting with `{` or `[` unchanged.

## Test plan

- Added `testScalarNumberArgumentsDoNotCrash` - asserts `detectToolCall` returns non-nil for `"arguments": 7` and the result parses as a JSON object
- Added `testScalarBoolArgumentsDoNotCrash` - same for `"arguments": true`
- Added `testNullArgumentsFallThroughToEmptyObject` - asserts `"arguments": null` produces `"{}"`
- Existing object and string argument tests cover the unchanged paths
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Read the full `parseToolCallJSON` method and all callers (`Handlers.swift:441`, `:572`, `ResponsesHandlers.swift:248`, `Session.swift:328,433,530`)
- Confirmed `ensureJSONArguments` passes through `{`/`[`-prefixed strings unchanged, so object arguments are unaffected
- Audited all other `JSONSerialization.data(withJSONObject:)` calls in the codebase - the remaining ones operate on internally-constructed dictionaries (`Server.swift:94`, `ToolCallHandler.swift:394`, `MCPProtocol.swift`), not model-controlled scalars
- Swift 6 concurrency: no data races introduced (static methods, value types only)
- Diff limited to `Sources/Core/ToolCallHandler.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by @Arthur-Ficial (us) and the suggested fix aligns with the standard approach for this class of ObjC/Swift interop issue.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_019YtubNmhcpoynZKqQcurrw

---
_Generated by [Claude Code](https://claude.ai/code/session_019YtubNmhcpoynZKqQcurrw)_