### PR TITLE
fix(tool-call): guard JSONSerialization against scalar arguments (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ToolCallHandler.detectToolCall` no longer aborts the process when model output contains scalar `arguments` (a number or bool instead of a string or object). `JSONSerialization.data(withJSONObject:)` raises an uncatchable ObjC `NSInvalidArgumentException` on scalars; the fix adds `.fragmentsAllowed` and an `NSNull` guard so scalars are wrapped via `ensureJSONArguments` and nulls fall through to `{}` (#388).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -369,10 +369,11 @@ public enum ToolCallHandler {
             let args: String
             if let s = rawArguments as? String {
                 args = ensureJSONArguments(s)
-            } else if let obj = rawArguments,
-                      let data = try? JSONSerialization.data(withJSONObject: obj),
+            } else if let obj = rawArguments, !(obj is NSNull),
+                      let data = try? JSONSerialization.data(
+                          withJSONObject: obj, options: [.fragmentsAllowed]),
                       let s = String(data: data, encoding: .utf8) {
-                args = s
+                args = ensureJSONArguments(s)
             } else {
                 args = "{}"
             }

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -455,6 +455,53 @@ func runToolCallHandlerTests() {
         try assertTrue(instr.contains("search"), "must list tool names")
     }
 
+    // MARK: - Scalar arguments do not crash (#388)
+
+    test("scalar number arguments do not crash and return non-nil (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "add", "arguments": 7}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 1)
+        try assertEqual(result!.first?.name, "add")
+    }
+
+    test("scalar bool arguments do not crash and return non-nil (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "toggle", "arguments": true}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "toggle")
+    }
+
+    test("null arguments do not crash and default to empty object (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "ping", "arguments": null}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.argumentsString, "{}")
+    }
+
+    test("scalar arguments produce valid JSON object (#388)") {
+        let response = #"{"tool_calls": [{"id": "x", "type": "function", "function": {"name": "add", "arguments": 7}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        let argsStr = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(argsStr.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+    }
+
+    test("object arguments unchanged after scalar fix (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn", "arguments": {"city": "Vienna"}}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertTrue(result!.first!.argumentsString.contains("Vienna"))
+    }
+
+    test("string arguments unchanged after scalar fix (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn", "arguments": "{\"key\":\"val\"}"}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.argumentsString, #"{"key":"val"}"#)
+    }
+
     // MARK: - ToolLogEntry
 
     test("ToolLogEntry stores tool execution result") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #388.

## Root cause

`ToolCallHandler.parseToolCallJSON` calls `JSONSerialization.data(withJSONObject:)` on whatever the model emits as `arguments`. Without the `.fragmentsAllowed` option, that method only accepts top-level arrays or dictionaries. A JSON scalar (number like `7`, or a bool like `true`) arrives as an `NSNumber`, which causes `JSONSerialization` to raise an Objective-C `NSInvalidArgumentException`. Swift's `try?` only catches Swift-native errors, not ObjC exceptions, so the exception propagates uncaught and the process dies with SIGABRT. This kills the entire server (every in-flight request) or aborts a one-shot CLI invocation. No tools or MCP server are required to trigger it - any client that can steer the model into emitting `"arguments": 7` hits the crash path.

## The fix

Three changes to the `else if` branch in `parseToolCallJSON` (line 372):

1. **`!(obj is NSNull)` guard** - JSON `null` deserializes as `NSNull`, which also isn't a valid top-level JSON object. The guard routes it to the existing `args = "{}"` fallback.
2. **`.fragmentsAllowed` option** - tells `JSONSerialization.data(withJSONObject:options:)` to accept any JSON value, not just arrays and dictionaries. Scalars serialize safely (`7` to `"7"`, `true` to `"true"`).
3. **`ensureJSONArguments(s)` instead of raw `s`** - the serialized scalar string is piped through `ensureJSONArguments`, which wraps bare non-object/non-array values as `{"value":"..."}`. For dictionaries and arrays this is a no-op (they already start with `{` or `[`).

Net effect: numbers become `{"value":"7"}`, bools become `{"value":"true"}`, null becomes `{}`, and existing object/string arguments are unchanged.

## Test coverage

- Added 6 tests to `Tests/apfelTests/ToolCallHandlerTests.swift`:
  - `scalar number arguments do not crash and return non-nil (#388)` - `"arguments": 7`
  - `scalar bool arguments do not crash and return non-nil (#388)` - `"arguments": true`
  - `null arguments do not crash and default to empty object (#388)` - `"arguments": null`
  - `scalar arguments produce valid JSON object (#388)` - asserts `argumentsString` parses as a JSON object
  - `object arguments unchanged after scalar fix (#388)` - regression guard
  - `string arguments unchanged after scalar fix (#388)` - regression guard
- Existing tests cover the happy path for string and object arguments.

## What I verified (static only)

- Read every `JSONSerialization.data(withJSONObject:)` call in the codebase (8 sites). Only `ToolCallHandler.swift:373` operates on model-controlled data; the others use internally constructed dictionaries (health endpoint, MCP protocol messages, tool schema serialization, `jsonObjectString` helper with `[String: String]`).
- The `ensureJSONArguments` pass-through for objects/arrays is safe: it checks `hasPrefix("{")` / `hasPrefix("[")` and returns `s` unchanged.
- Swift 6 concurrency: no data races introduced. The fix is in a static method on a stateless enum.
- Diff limited to `Sources/Core/ToolCallHandler.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward crash bug. The issue was filed by the owner account (`Arthur-Ficial`) and the report is technically sound with a clear reproducer. The suggested fix in the issue body converges with my independent analysis, which is expected for a bug this mechanical.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01E3gReKvuxbxEb3i7ykFfh3

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3gReKvuxbxEb3i7ykFfh3)_