### PR TITLE
fix(tool-call): handle scalar arguments without crashing (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Scalar tool-call arguments (e.g. `"arguments": 7`) no longer crash the process via an uncatchable ObjC `NSInvalidArgumentException` (#388). `JSONSerialization.data(withJSONObject:)` now uses `.fragmentsAllowed` and the result is fed through `ensureJSONArguments` to produce a valid JSON object.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -369,10 +369,11 @@ public enum ToolCallHandler {
             let args: String
             if let s = rawArguments as? String {
                 args = ensureJSONArguments(s)
-            } else if let obj = rawArguments,
-                      let data = try? JSONSerialization.data(withJSONObject: obj),
+            } else if let obj = rawArguments, !(obj is NSNull),
+                      let data = try? JSONSerialization.data(
+                          withJSONObject: obj, options: [.fragmentsAllowed]),
                       let s = String(data: data, encoding: .utf8) {
-                args = s
+                args = ensureJSONArguments(s)
             } else {
                 args = "{}"
             }

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -265,6 +265,54 @@ func runToolCallHandlerTests() {
         try assertEqual(result!.first?.argumentsString, "{}")
     }
 
+    // MARK: - Scalar arguments do not crash (#388)
+
+    test("scalar number arguments do not crash and produce valid JSON (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "add", "arguments": 7}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 1)
+        try assertEqual(result!.first?.name, "add")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed, "scalar number arguments must produce parseable JSON, got: \(args)")
+    }
+
+    test("scalar boolean arguments do not crash and produce valid JSON (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "toggle", "arguments": true}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "toggle")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed, "scalar boolean arguments must produce parseable JSON, got: \(args)")
+    }
+
+    test("null arguments fall through to empty object (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "ping", "arguments": null}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "ping")
+        try assertEqual(result!.first?.argumentsString, "{}")
+    }
+
+    test("object arguments unchanged after scalar fix (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn", "arguments": {"a": 1}}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+        try assertEqual(parsed?["a"] as? Int, 1)
+    }
+
+    test("string arguments unchanged after scalar fix (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn", "arguments": "{\"key\":\"val\"}"}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.argumentsString, #"{"key":"val"}"#)
+    }
+
     // MARK: - Synthesized id for calls missing "id" (#244)
 
     test("synthesizes an id when the tool call omits \"id\" (#244)") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #388.

## Summary

`ToolCallHandler.parseToolCallJSON` crashes the entire process when a model-emitted tool call carries a scalar `arguments` value (e.g. `"arguments": 7` or `"arguments": true`). `JSONSerialization.data(withJSONObject:)` requires a top-level array or dictionary; handed an `NSNumber` it raises an ObjC `NSInvalidArgumentException` that `try?` cannot catch, so the process dies with SIGABRT. The `else { args = "{}" }` fallback is unreachable for this case.

### Root cause

At `Sources/Core/ToolCallHandler.swift:372-374`, the `rawArguments` value from parsed JSON can be any JSON type. The code handled `String` and `[String: Any]`/`[[String: Any]]` (via `JSONSerialization`), but a scalar `NSNumber` (from JSON `7`, `true`) passed straight to `data(withJSONObject:)` without the `.fragmentsAllowed` option. Without that option, the call raises an ObjC exception instead of a Swift error, bypassing `try?`.

### The fix

Three changes to the `else if` branch in `parseToolCallJSON`:

1. **`!(obj is NSNull)` guard** - routes JSON `null` to the `else` branch where it becomes `"{}"`, matching the existing behavior for missing arguments.
2. **`.fragmentsAllowed` option** - lets `data(withJSONObject:)` serialize a scalar as a JSON fragment (e.g. `"7"`) instead of raising an ObjC exception.
3. **`ensureJSONArguments(s)` on the result** - wraps a bare scalar like `"7"` into `{"value":"7"}`, exactly as it already wraps a bare string like `"desktop"`. Object arguments pass through `ensureJSONArguments` unchanged (they start with `{`).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

### Test coverage

- Added 5 tests in `Tests/apfelTests/ToolCallHandlerTests.swift` under "Scalar arguments do not crash (#388)":
  - `testScalarNumberArguments` - `"arguments": 7` produces parseable JSON, no crash
  - `testScalarBooleanArguments` - `"arguments": true` produces parseable JSON, no crash
  - `testNullArguments` - `"arguments": null` falls through to `"{}"`
  - `testObjectArgumentsUnchanged` - `"arguments": {"a": 1}` still works identically
  - `testStringArgumentsUnchanged` - `"arguments": "{\"key\":\"val\"}"` still works identically

### What I verified (static only)

- Read `Sources/Core/ToolCallHandler.swift` end to end.
- Audited every other `JSONSerialization.data(withJSONObject:)` call in the codebase - all others operate on known dictionaries/arrays or are guarded by `isValidJSONObject`. Only the one at the bug site takes model-controlled `Any?`.
- Confirmed the existing `ensureJSONArguments` handles all the shapes the scalar path can produce.
- Swift 6 concurrency: no data races introduced (pure static function, no shared state).
- Diff limited to `Sources/Core/ToolCallHandler.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

### What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner. If the fix does not actually resolve the reported behavior, that is on me to refine - ping me in a review comment.

### Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the project's own automated review and confirmed by the triage routine. The reproduction steps are consistent with the code path.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017687PARmrNxkojxcuqYmZE

---
_Generated by [Claude Code](https://claude.ai/code/session_017687PARmrNxkojxcuqYmZE)_