### PR TITLE
fix(toolcall): guard JSONSerialization against scalar arguments (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ToolCallHandler.detectToolCall` no longer aborts the process when a model-emitted tool call carries scalar `arguments` (number, bool). `JSONSerialization.data(withJSONObject:)` raises an uncatchable ObjC `NSInvalidArgumentException` on scalars; added an `isValidJSONObject` guard and a scalar-to-wrapped-JSON fallback (#388).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -369,10 +369,13 @@ public enum ToolCallHandler {
             let args: String
             if let s = rawArguments as? String {
                 args = ensureJSONArguments(s)
-            } else if let obj = rawArguments,
+            } else if let obj = rawArguments, !(obj is NSNull),
+                      JSONSerialization.isValidJSONObject(obj),
                       let data = try? JSONSerialization.data(withJSONObject: obj),
                       let s = String(data: data, encoding: .utf8) {
                 args = s
+            } else if let obj = rawArguments, !(obj is NSNull) {
+                args = ensureJSONArguments("\(obj)")
             } else {
                 args = "{}"
             }

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -396,6 +396,48 @@ func runToolCallHandlerTests() {
         try assertNil(parsed)
     }
 
+    // MARK: - Scalar arguments do not crash (#388)
+
+    test("scalar number arguments do not crash and produce valid JSON (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "add", "arguments": 7}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.count, 1)
+        try assertEqual(result!.first?.name, "add")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+    }
+
+    test("scalar bool arguments do not crash and produce valid JSON (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "toggle", "arguments": true}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "toggle")
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+    }
+
+    test("null arguments fall through to empty object (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "ping", "arguments": null}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        try assertEqual(result!.first?.name, "ping")
+        try assertEqual(result!.first?.argumentsString, "{}")
+    }
+
+    test("object arguments still serialize correctly after scalar fix (#388)") {
+        let response = #"{"tool_calls": [{"id": "c1", "type": "function", "function": {"name": "fn", "arguments": {"a": 1, "b": 2}}}]}"#
+        let result = ToolCallHandler.detectToolCall(in: response)
+        try assertNotNil(result)
+        let args = result!.first!.argumentsString
+        let parsed = try? JSONSerialization.jsonObject(with: Data(args.utf8)) as? [String: Any]
+        try assertNotNil(parsed)
+        try assertEqual(parsed?["a"] as? Int, 1)
+        try assertEqual(parsed?["b"] as? Int, 2)
+    }
+
     // MARK: - Split prompt methods
 
     test("buildOutputFormatInstructions contains tool names") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #388.

## Summary

`ToolCallHandler.parseToolCallJSON` crashes the entire process when a model-emitted tool call carries scalar `arguments` (a JSON number like `7` or a boolean like `true`). `JSONSerialization.data(withJSONObject:)` requires a top-level array or dictionary; handed an `NSNumber` it raises an Objective-C `NSInvalidArgumentException` that Swift's `try?` cannot catch. The process dies with SIGABRT.

This is reachable from every chat completion path - CLI, server (streaming and non-streaming), and the Responses API handler - without any tools configured. A crafted prompt can steer the model into emitting this shape, taking the entire server process down.

## Root cause

Line 372-375 of `Sources/Core/ToolCallHandler.swift` passes `rawArguments` (an `Any?` from `JSONSerialization.jsonObject`) directly to `JSONSerialization.data(withJSONObject:)`. When the deserialized value is an `NSNumber` (from a JSON scalar), this raises an ObjC exception. The `else { args = "{}" }` fallback that looks like a safety net is unreachable for scalars because the ObjC exception kills the process before Swift control flow can reach it.

## The fix

Added an `isValidJSONObject` guard before the `data(withJSONObject:)` call so it only fires on dictionaries and arrays. A new branch handles scalars (numbers, bools) by converting to their string representation and wrapping via the existing `ensureJSONArguments`, which produces a valid JSON object like `{"value":"7"}`. NSNull is excluded from both branches and falls through to the existing `args = "{}"` default.

## Test coverage

- Added 4 tests in `Tests/apfelTests/ToolCallHandlerTests.swift`:
  - `scalar number arguments do not crash and produce valid JSON (#388)` - number `7` as arguments
  - `scalar bool arguments do not crash and produce valid JSON (#388)` - boolean `true` as arguments
  - `null arguments fall through to empty object (#388)` - null becomes `{}`
  - `object arguments still serialize correctly after scalar fix (#388)` - regression guard for the existing object path

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] End-to-end: start `apfel --serve`, send the repro payload from #388, verify the server stays up and responds

## What I verified (static only)

- `isValidJSONObject` returns false for `NSNumber` and `NSNull`, true for arrays and dictionaries - prevents the ObjC exception entirely.
- `ensureJSONArguments` wraps a bare string like `"7"` into `{"value":"7"}` - already tested and proven in the existing suite.
- String interpolation of `NSNumber` produces the expected representation (`7`, `1` for true, `0` for false).
- The existing object and string argument paths are structurally unchanged.
- No other `JSONSerialization.data(withJSONObject:)` call in `Sources/` operates on model-controlled values without a container guarantee.
- Swift 6 concurrency: no data races introduced (pure static method, no shared state).
- Diff limited to `Sources/Core/ToolCallHandler.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug from the repo owner with a clean reproduction case.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMvWG7wcsPcxmGWBMtCYfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMvWG7wcsPcxmGWBMtCYfD)_