### PR TITLE
fix(context): join all system messages instead of taking only the first (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Every system message after the first was silently discarded before token counting and generation; `buildInstructions` now joins all system messages into the instructions block (#390).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/ContextManager.swift
+++ b/Sources/ContextManager.swift
@@ -124,8 +124,8 @@ enum ContextManager {
             parts.append("You must respond with valid JSON only. No markdown code fences, no explanation text, no preamble. Output raw JSON.")
         }
 
-        // System prompt
-        if let sys = messages.first(where: { $0.role == "system" })?.textContent {
+        // System prompt - join ALL system messages, not just the first (#390)
+        if let sys = OpenAIMessage.joinedSystemContent(from: messages) {
             parts.append(sys)
         }
 

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -196,6 +196,17 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
         guard case .parts(let parts) = content else { return false }
         return parts.contains(where: { $0.type == "image_url" })
     }
+
+    /// Joins the text content of every system-role message in `messages`,
+    /// preserving order and separating with double newlines. Returns nil
+    /// when no system message carries non-empty text.
+    public static func joinedSystemContent(from messages: [OpenAIMessage]) -> String? {
+        let parts = messages
+            .filter { $0.role == "system" }
+            .compactMap(\.textContent)
+            .filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
+    }
 }
 
 /// OpenAI-compatible message content.

--- a/Tests/apfelTests/SystemMessageJoinTests.swift
+++ b/Tests/apfelTests/SystemMessageJoinTests.swift
@@ -1,0 +1,89 @@
+// SystemMessageJoinTests - joinedSystemContent (#390)
+
+import Foundation
+import ApfelCore
+
+func runSystemMessageJoinTests() {
+
+    test("single system message returns its content unchanged") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Be concise.")),
+            OpenAIMessage(role: "user", content: .text("Hi")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertEqual(result, "Be concise.")
+    }
+
+    test("two system messages are joined with double newline") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Be concise.")),
+            OpenAIMessage(role: "system", content: .text("Reply in French.")),
+            OpenAIMessage(role: "user", content: .text("Hi")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertEqual(result, "Be concise.\n\nReply in French.")
+    }
+
+    test("three system messages preserve order and all content") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("First.")),
+            OpenAIMessage(role: "user", content: .text("ignored")),
+            OpenAIMessage(role: "system", content: .text("Second.")),
+            OpenAIMessage(role: "system", content: .text("Third.")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertEqual(result, "First.\n\nSecond.\n\nThird.")
+    }
+
+    test("no system messages returns nil") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "user", content: .text("Hi")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertNil(result)
+    }
+
+    test("empty messages array returns nil") {
+        let result = OpenAIMessage.joinedSystemContent(from: [])
+        try assertNil(result)
+    }
+
+    test("system messages with empty content are skipped") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Keep this.")),
+            OpenAIMessage(role: "system", content: .text("")),
+            OpenAIMessage(role: "system", content: .text("And this.")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertEqual(result, "Keep this.\n\nAnd this.")
+    }
+
+    test("system message with nil content is skipped") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Real.")),
+            OpenAIMessage(role: "system", content: nil),
+            OpenAIMessage(role: "user", content: .text("Hi")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertEqual(result, "Real.")
+    }
+
+    test("only empty system messages returns nil") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("")),
+            OpenAIMessage(role: "system", content: nil),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertNil(result)
+    }
+
+    test("developer-mapped system messages from Responses path are joined") {
+        let msgs: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Instructions from request.")),
+            OpenAIMessage(role: "system", content: .text("Developer policy.")),
+            OpenAIMessage(role: "user", content: .text("Go")),
+        ]
+        let result = OpenAIMessage.joinedSystemContent(from: msgs)
+        try assertEqual(result, "Instructions from request.\n\nDeveloper policy.")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -129,6 +129,7 @@ suite("MessagesFlagTests") { runMessagesFlagTests() }
 suite("CodeFlagTests") { runCodeFlagTests() }
 suite("PrewarmDecisionTests") { runPrewarmDecisionTests() }
 suite("ResponsesModelsTests") { runResponsesModelsTests() }
+suite("SystemMessageJoinTests") { runSystemMessageJoinTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #390.

## Root cause

`ContextManager.buildInstructions` (line 128) used `.first(where: { $0.role == "system" })` to extract the system prompt, picking up only the first system message and silently discarding every subsequent one. Meanwhile `makeSession` (line 35) filters all system messages out of the conversation array, so any system message not copied into the instructions block by `buildInstructions` vanishes entirely - no warning, no error, no token accounting.

Multi-system-message conversations are ordinary: SDKs and frameworks routinely stack a base system prompt with task-specific ones, and the Responses API `developer` role maps to `system` via `ResponsesMapper`, compounding the problem when `instructions` is also set.

## The fix

Added `OpenAIMessage.joinedSystemContent(from:)` as a public static method in `ApfelCore` (`Sources/Core/OpenAIModels.swift`). It collects every system-role message's text content (preserving order, skipping empty/nil), and joins them with `\n\n`. Returns nil when no system message carries non-empty text.

`ContextManager.buildInstructions` now calls this helper instead of `.first(where:)`, so every system message reaches the instructions block and is counted in prompt tokens.

## Test coverage

- Added `Tests/apfelTests/SystemMessageJoinTests.swift` with 8 unit tests:
  - `testSingleSystemMessageReturnsContentUnchanged`
  - `testTwoSystemMessagesJoinedWithDoubleNewline`
  - `testThreeSystemMessagesPreserveOrder`
  - `testNoSystemMessagesReturnsNil`
  - `testEmptyMessagesArrayReturnsNil`
  - `testSystemMessagesWithEmptyContentSkipped`
  - `testSystemMessageWithNilContentSkipped`
  - `testOnlyEmptySystemMessagesReturnsNil`
  - `testDeveloperMappedSystemMessagesJoined` (Responses path)
- Existing `OpenAIModelsTests` and `ResponsesModelsTests` cover the types used.

## What I verified (static only)

- The fix correctly replaces the `.first(where:)` call with a collect-all-and-join approach.
- The helper is a pure function with no concurrency implications.
- The empty/nil/single-message paths behave identically to today's code.
- `ResponsesMapper.messages(from:)` maps `developer` role to `system`, so the fix covers the Responses path automatically.
- No `@unchecked Sendable`, no data races.
- Diff limited to `Sources/Core/OpenAIModels.swift`, `Sources/ContextManager.swift`, `Tests/apfelTests/SystemMessageJoinTests.swift`, `Tests/apfelTests/main.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue is filed by the owner account (`Arthur-Ficial`), the report includes a clear reproducer, and the root cause is a simple `.first(where:)` that should be a `.filter`.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuWnEGFHqvz9qQX4DLzQRL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuWnEGFHqvz9qQX4DLzQRL)_