### PR TITLE
fix(context): join all system messages into instructions (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- All system messages now reach the model instructions instead of silently dropping every message after the first (#390). Affects `/v1/chat/completions`, Responses `developer` messages, and CLI `--messages` combined with `-s`.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/ContextManager.swift
+++ b/Sources/ContextManager.swift
@@ -124,8 +124,8 @@ enum ContextManager {
             parts.append("You must respond with valid JSON only. No markdown code fences, no explanation text, no preamble. Output raw JSON.")
         }
 
-        // System prompt
-        if let sys = messages.first(where: { $0.role == "system" })?.textContent {
+        // System prompt - all system messages, not just the first (#390)
+        if let sys = messages.joinedSystemContent {
             parts.append(sys)
         }
 

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -198,6 +198,18 @@ public struct OpenAIMessage: Codable, Sendable, Equatable, Hashable {
     }
 }
 
+extension Array where Element == OpenAIMessage {
+    /// Text content of every system-role message, joined with double newlines.
+    /// Returns nil when no system messages carry non-empty text.
+    public var joinedSystemContent: String? {
+        let parts = self
+            .filter { $0.role == "system" }
+            .compactMap(\.textContent)
+            .filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
+    }
+}
+
 /// OpenAI-compatible message content.
 public enum MessageContent: Codable, Sendable, Equatable, Hashable {
     /// Plain text content.

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -124,6 +124,68 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?[1] as? String, "two")
         try assertEqual(parsed?[2] as? Bool, false)
     }
+
+    // MARK: - joinedSystemContent (#390)
+
+    test("joinedSystemContent returns nil when no system messages exist") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertNil(messages.joinedSystemContent)
+    }
+
+    test("joinedSystemContent returns single system message text") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Be concise.")),
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertEqual(messages.joinedSystemContent, "Be concise.")
+    }
+
+    test("joinedSystemContent joins multiple system messages with double newlines (#390)") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Be concise.")),
+            OpenAIMessage(role: "system", content: .text("Always answer in JSON.")),
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertEqual(messages.joinedSystemContent, "Be concise.\n\nAlways answer in JSON.")
+    }
+
+    test("joinedSystemContent skips system messages with empty text") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("Be concise.")),
+            OpenAIMessage(role: "system", content: .text("")),
+            OpenAIMessage(role: "system", content: .text("Answer in English.")),
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertEqual(messages.joinedSystemContent, "Be concise.\n\nAnswer in English.")
+    }
+
+    test("joinedSystemContent returns nil when all system messages are empty") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("")),
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertNil(messages.joinedSystemContent)
+    }
+
+    test("joinedSystemContent returns nil for nil content system message") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: nil),
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertNil(messages.joinedSystemContent)
+    }
+
+    test("joinedSystemContent preserves order of system messages") {
+        let messages: [OpenAIMessage] = [
+            OpenAIMessage(role: "system", content: .text("First.")),
+            OpenAIMessage(role: "user", content: .text("middle")),
+            OpenAIMessage(role: "system", content: .text("Second.")),
+            OpenAIMessage(role: "user", content: .text("hello")),
+        ]
+        try assertEqual(messages.joinedSystemContent, "First.\n\nSecond.")
+    }
 }
 
 func runChatRequestValidatorTests() {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #390.

## Summary

`ContextManager.buildInstructions` used `messages.first(where:)` to pick only the first system message. Since `makeSession` strips all system messages from the conversation array (line 35), every system message after the first was silently dropped - no error, no token accounting.

The fix adds `[OpenAIMessage].joinedSystemContent` in `ApfelCore` that filters, extracts, and joins all system-role text content with double newlines. `ContextManager` now calls this instead of `first(where:)`.

This affects all paths through `buildInstructions`: `/v1/chat/completions`, Responses `developer` messages (mapped to `system` by `ResponsesMapper`), and CLI `--messages` combined with `-s`.

## Root cause

`Sources/ContextManager.swift:128` called `messages.first(where: { $0.role == "system" })?.textContent` which returns only the first system message's text. Line 35 filters all system messages out of the conversation with `messages.filter { $0.role != "system" }`, so any system message not captured by `buildInstructions` vanishes completely - no token counting, no generation, no error.

## The fix

Added a public `joinedSystemContent` computed property on `[OpenAIMessage]` in `Sources/Core/OpenAIModels.swift` that collects all system messages, extracts their non-empty text content, and joins them with `\n\n`. `ContextManager.buildInstructions` now calls `messages.joinedSystemContent` instead of the single-message lookup. The logic lives in `ApfelCore` so it is unit-testable from the test runner.

## Test coverage

- Added 7 tests in `Tests/apfelTests/OpenAIModelsTests.swift` covering:
  - No system messages (nil)
  - Single system message (unchanged behavior)
  - Multiple system messages joined with `\n\n`
  - Empty-text system messages skipped
  - All-empty system messages (nil)
  - Nil-content system messages (nil)
  - Order preservation across interleaved roles

## What I verified (static only)

- Read `ContextManager.swift` end-to-end: the only consumer of system messages is `buildInstructions`, so the fix covers all paths.
- Read `ResponsesMapper.messages(from:)`: `developer` role maps to `system`, so Responses multi-developer conversations are fixed by the same change.
- Read `CLI.swift:messagesPrompt`: `-s` inserts a system message at index 0 before calling `makeSession`, so `--messages` + `-s` with an existing system message in the JSON is also fixed.
- Swift 6 concurrency: no data races introduced. The new extension is a pure computed property on a value type array.
- Diff limited to `Sources/ContextManager.swift`, `Sources/Core/OpenAIModels.swift`, `Tests/apfelTests/OpenAIModelsTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the repo owner account.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSZyVodoaRkSGvFiuaUeVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSZyVodoaRkSGvFiuaUeVn)_