### PR TITLE
fix(server): reject json_schema + MCP with 400 (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `response_format: json_schema` against an `--mcp` server now returns 400 instead of silently ignoring the schema and generating unconstrained text (#392).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -193,6 +193,21 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     // MCP auto-execute: when tools were server-injected, run model, execute tool calls,
     // re-prompt for final answer, then deliver as JSON or SSE.
     if toolsAreMCPInjected {
+        // json_schema is a documented guarantee (#167) but mcpAutoExecuteResponse
+        // uses unconstrained generation - reject loudly instead of silently
+        // dropping the schema (#392).
+        if structuredSchema != nil {
+            return chatFailure(
+                status: .badRequest,
+                message: "response_format.json_schema is not supported while the server has MCP tools attached (--mcp). Start a server without --mcp for guaranteed structured output.",
+                type: "invalid_request_error",
+                stream: isStreaming,
+                requestBody: requestBodyString,
+                events: events,
+                event: "json_schema + mcp auto-execute rejected",
+                param: "response_format"
+            )
+        }
         let userPrompt = chatRequest.messages.last(where: { $0.role == "user" })?.textContent ?? finalPrompt
         let result = try await mcpAutoExecuteResponse(
             session: session, prompt: finalPrompt, userPrompt: userPrompt,

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -293,3 +293,68 @@ def test_responses_error_object_has_null_param_and_code():
     err = r.json()["error"]
     assert "param" in err and err["param"] is None
     assert "code" in err and err["code"] is None
+
+
+# ============================================================================
+# #392 - json_schema + MCP must be rejected, not silently ignored
+# ============================================================================
+
+MCP_BASE_URL = "http://localhost:11435"
+
+
+def _post_mcp(payload, timeout=15):
+    return httpx.post(
+        f"{MCP_BASE_URL}/v1/chat/completions",
+        json=payload,
+        timeout=timeout,
+    )
+
+
+def test_json_schema_with_mcp_is_rejected():
+    """response_format json_schema against an --mcp server returns 400 (#392).
+
+    json_schema is a documented guarantee (#167). The MCP auto-execute path
+    uses unconstrained generation and cannot honour the schema, so the
+    combination must fail loudly rather than silently dropping the constraint.
+    Model-free: the rejection fires before the model is touched.
+    """
+    resp = _post_mcp({
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello."}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"count": {"type": "integer"}},
+                    "required": ["count"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    })
+    assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text[:300]}"
+    err = _assert_openai_error(resp, expected_type="invalid_request_error")
+    assert "response_format" in err["message"].lower() or "json_schema" in err["message"].lower(), \
+        f"Error message must name the conflict: {err['message']}"
+    assert err["param"] == "response_format"
+
+
+def test_json_object_with_mcp_still_works():
+    """response_format json_object against an --mcp server is unaffected (#392).
+
+    Only json_schema is rejected; json_object (unconstrained JSON mode) works
+    fine with the MCP path because it does not promise schema adherence.
+    Model-free: a 200 proves the request was accepted (the model call itself
+    may or may not succeed depending on Apple Intelligence availability, but
+    a 400 would prove a false rejection).
+    """
+    resp = _post_mcp({
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Return JSON with key 'answer' and value 42."}],
+        "response_format": {"type": "json_object"},
+    })
+    assert resp.status_code != 400, \
+        f"json_object must not be rejected on MCP server: {resp.text[:300]}"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #392.

## Summary

`response_format: json_schema` against an `--mcp` server was silently ignored - the MCP auto-execute branch in `handleChatCompletion` returned before the schema-guided generation branch was reached, so `mcpAutoExecuteResponse` ran unconstrained generation while the client expected guaranteed structured output.

Since `mcpAutoExecuteResponse` has no schema parameter, the combination now returns a 400 `invalid_request_error` naming the conflict instead of silently downgrading a documented guarantee (#167). `response_format: json_object` is unaffected - it already works with the MCP path because it does not promise schema adherence.

## Root cause

In `Sources/Handlers.swift`, the `toolsAreMCPInjected` branch (line 195) returned early before the `structuredSchema` check (line 209). The `structuredSchema` was built correctly from the request, but the MCP code path never used it.

## The fix

Added a guard inside the `toolsAreMCPInjected` block that checks `structuredSchema != nil` and returns a `chatFailure` with status 400, type `invalid_request_error`, and `param: response_format`. The error message names both `json_schema` and `--mcp` so the caller knows exactly what to change.

## Test coverage

- Added `server_validation_test.py::test_json_schema_with_mcp_is_rejected` - asserts 400 with `invalid_request_error` and that the message names `response_format`/`json_schema`.
- Added `server_validation_test.py::test_json_object_with_mcp_still_works` - asserts `json_object` is not rejected on the MCP server.
- Both tests are model-free (the rejection fires before touching the model) and will run in CI.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/server_validation_test.py::test_json_schema_with_mcp_is_rejected Tests/integration/server_validation_test.py::test_json_object_with_mcp_still_works -v`

## What I verified (static only)

- `chatFailure` argument labels match other call sites in `Handlers.swift`.
- The guard sits inside the `toolsAreMCPInjected` block, after `structuredSchema` is built and before `mcpAutoExecuteResponse` is called.
- `json_object` mode (`jsonMode`) flows through a different variable and is already passed to `mcpAutoExecuteResponse` - not affected.
- Swift 6 concurrency: no data races introduced (no new shared state).
- Diff limited to `Handlers.swift`, `server_validation_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a clear code path. The issue was filed by the owner account.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2cwrXXZKFzff1nXM8Nda6

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2cwrXXZKFzff1nXM8Nda6)_