### PR TITLE
fix(server): reject json_schema when MCP tools are attached (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `response_format: json_schema` is now explicitly rejected with a 400 when the server has MCP tools attached (`--mcp`). Previously the schema was silently ignored and the model answered in free text, breaking the structured-output guarantee documented in #167. The error message names the conflict and suggests starting a server without `--mcp` (#392).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -193,6 +193,18 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     // MCP auto-execute: when tools were server-injected, run model, execute tool calls,
     // re-prompt for final answer, then deliver as JSON or SSE.
     if toolsAreMCPInjected {
+        if structuredSchema != nil {
+            return chatFailure(
+                status: .badRequest,
+                message: "response_format type 'json_schema' is not supported when the server has MCP tools attached (--mcp). Start a server without --mcp for guaranteed structured output, or omit response_format.",
+                type: "invalid_request_error",
+                stream: isStreaming,
+                requestBody: requestBodyString,
+                events: events,
+                event: "json_schema + mcp auto-execute rejected",
+                param: "response_format"
+            )
+        }
         let userPrompt = chatRequest.messages.last(where: { $0.role == "user" })?.textContent ?? finalPrompt
         let result = try await mcpAutoExecuteResponse(
             session: session, prompt: finalPrompt, userPrompt: userPrompt,

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -152,6 +152,120 @@ def test_undecodable_tool_choice_object_returns_400():
 
 
 # ============================================================================
+# #392 - response_format json_schema rejected when server has --mcp
+# ============================================================================
+
+MCP_BASE_URL = "http://localhost:11435"
+
+
+def _post_mcp(payload, headers=None, timeout=15):
+    return httpx.post(
+        f"{MCP_BASE_URL}/v1/chat/completions",
+        json=payload,
+        headers=headers or {},
+        timeout=timeout,
+    )
+
+
+def test_json_schema_with_mcp_is_rejected():
+    """json_schema + --mcp must return 400 naming response_format (#392)."""
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello."}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"greeting": {"type": "string"}},
+                    "required": ["greeting"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    }
+    resp = _post_mcp(payload)
+    assert resp.status_code == 400, (resp.status_code, resp.text)
+    err = _assert_openai_error(resp, expected_type="invalid_request_error")
+    assert "response_format" in err["message"].lower() or "json_schema" in err["message"].lower(), err
+    assert err["param"] == "response_format", err
+
+
+def test_json_schema_with_mcp_rejected_streaming():
+    """The rejection fires for streaming requests too (#392)."""
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello."}],
+        "stream": True,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"greeting": {"type": "string"}},
+                    "required": ["greeting"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    }
+    resp = _post_mcp(payload)
+    assert resp.status_code == 400, (resp.status_code, resp.text)
+    err = _assert_openai_error(resp, expected_type="invalid_request_error")
+    assert err["param"] == "response_format", err
+
+
+def test_json_object_with_mcp_still_accepted():
+    """json_object mode must NOT be rejected when --mcp is active (#392)."""
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello."}],
+        "response_format": {"type": "json_object"},
+    }
+    resp = _post_mcp(payload)
+    assert resp.status_code != 400 or "json_schema" not in resp.text.lower(), \
+        f"json_object should not be rejected: {resp.text}"
+
+
+def test_no_response_format_with_mcp_still_accepted():
+    """Requests without response_format must still work with --mcp (#392)."""
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello."}],
+    }
+    resp = _post_mcp(payload)
+    assert resp.status_code != 400, f"No response_format should not be rejected: {resp.text}"
+
+
+def test_json_schema_without_mcp_still_accepted():
+    """json_schema on the plain (non-MCP) server must not be rejected (#392)."""
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello."}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"greeting": {"type": "string"}},
+                    "required": ["greeting"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    }
+    resp = _post(payload)
+    assert resp.status_code != 400 or "mcp" not in resp.text.lower(), \
+        f"json_schema on non-MCP server should not mention MCP: {resp.text}"
+
+
+# ============================================================================
 # #238a - stream_options.include_usage emits usage:null on non-final chunks
 # (model-dependent: needs Apple Intelligence, run by the controller)
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #392.

## Summary

`handleChatCompletion`'s `toolsAreMCPInjected` branch returned before the schema-guided generation path was reached, silently dropping the `response_format: json_schema` guarantee. The `mcpAutoExecuteResponse` helper uses unconstrained generation and takes no schema parameter, so callers relying on structured output got free text with no error and no warning.

### Root cause

The control flow in `Handlers.swift` checks `toolsAreMCPInjected` (line 195) and early-returns with the MCP auto-execute result. The `structuredSchema` branch (line 208) is never reached. Since `mcpAutoExecuteResponse` doesn't accept a schema, the documented json_schema guarantee (#167) is silently violated.

### The fix

Added a guard inside the `toolsAreMCPInjected` block that checks for `structuredSchema != nil` and returns a 400 (`invalid_request_error`, `param: response_format`) before touching the model. This matches the existing `chatFailure` pattern used by the other validation guards in the same function. `json_object` mode and requests without `response_format` are unaffected.

## Test coverage

- Added `test_json_schema_with_mcp_is_rejected` - asserts 400 and that the error names `response_format`.
- Added `test_json_schema_with_mcp_rejected_streaming` - same for streaming requests.
- Added `test_json_object_with_mcp_still_accepted` - no regression for json_object mode.
- Added `test_no_response_format_with_mcp_still_accepted` - no regression for plain requests.
- Added `test_json_schema_without_mcp_still_accepted` - no regression on the non-MCP server.

All five tests are model-free (the 400 fires before generation) and target the MCP server on port 11435 which is already started in CI, so they run in the existing `server_validation_test.py` CI suite.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/server_validation_test.py -v` (with both servers running)

## What I verified (static only)

- `chatFailure` argument labels match the function signature (verified at line 1038).
- `structuredSchema` is set before the `toolsAreMCPInjected` block (set at lines 103-130, MCP block starts at 195).
- `json_object` mode uses `jsonMode` (line 81), not `structuredSchema`, so it passes through the guard.
- Existing tests and validation paths are not affected.
- Swift 6 concurrency: no data races introduced (no new shared state).
- Diff limited to `Sources/Handlers.swift`, `Tests/integration/server_validation_test.py`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward validation bug with a clear code path.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB2msBUKvGpHNqzrz1QuJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01FB2msBUKvGpHNqzrz1QuJv)_