### PR TITLE
fix(responses): decode truncation field and map to context strategy (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/v1/responses` now decodes the `truncation` field. `"disabled"` maps to the strict context strategy (400 on oversized input instead of silent history loss), `"auto"` (and absent) keeps the existing newest-first trimming, and unrecognised values are rejected with a 400 naming the parameter. The response envelope echoes the value that was actually applied instead of hardcoding `"disabled"`. (#391)
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ResponsesModels.swift
+++ b/Sources/Core/ResponsesModels.swift
@@ -40,13 +40,17 @@ public struct ResponsesRequest: Decodable, Sendable {
     public let background: Bool?
     public let store: Bool?
     public let include: [String]?
+    /// `"auto"` (default) trims oldest-first; `"disabled"` rejects oversized
+    /// input with a 400 rather than silently dropping history.
+    public let truncation: String?
     /// True when a `reasoning` object was present in the request.
     public let hasReasoning: Bool
 
     enum CodingKeys: String, CodingKey {
         case model, input, instructions, stream, temperature, top_p,
              max_output_tokens, metadata, text, tools, tool_choice,
-             previous_response_id, background, store, include, reasoning
+             previous_response_id, background, store, include, reasoning,
+             truncation
     }
 
     public init(from decoder: Decoder) throws {
@@ -72,6 +76,7 @@ public struct ResponsesRequest: Decodable, Sendable {
         background = try c.decodeIfPresent(Bool.self, forKey: .background)
         store = try c.decodeIfPresent(Bool.self, forKey: .store)
         include = try c.decodeIfPresent([String].self, forKey: .include)
+        truncation = try c.decodeIfPresent(String.self, forKey: .truncation)
         hasReasoning = c.contains(.reasoning)
     }
 }
@@ -188,6 +193,7 @@ public enum ResponsesRequestValidator {
         case invalidTextFormat(String)
         case missingSchema
         case invalidRange(String)
+        case invalidTruncation(String)
         /// A feature the on-device model / this stateless server does not
         /// support. Always a 501 with a plain-spoken message.
         case unsupported(String)
@@ -220,6 +226,8 @@ public enum ResponsesRequestValidator {
                 return "text.format json_schema requires a 'schema' object."
             case .invalidRange(let what):
                 return what
+            case .invalidTruncation(let v):
+                return "'truncation' must be 'auto' or 'disabled', got '\(v)'."
             case .unsupported(let feature):
                 switch feature {
                 case "previous_response_id":
@@ -276,6 +284,11 @@ public enum ResponsesRequestValidator {
         }
         if r.text?.format?.type == "json_schema" && r.stream == true {
             return .unsupported("json_schema with stream")
+        }
+
+        // Truncation policy (mirrors x_context_strategy validation in chat, #237).
+        if let t = r.truncation, t != "auto" && t != "disabled" {
+            return .invalidTruncation(t)
         }
 
         // Input shape.

--- a/Sources/ResponsesHandlers.swift
+++ b/Sources/ResponsesHandlers.swift
@@ -32,6 +32,7 @@ struct ResponsesEcho {
     let formatName: String?
     let formatSchemaJSON: String?
     let toolsEcho: [ResponsesToolEcho]
+    let truncation: String
 
     init(_ r: ResponsesRequest, formatType: String) {
         instructions = r.instructions
@@ -47,6 +48,7 @@ struct ResponsesEcho {
             return ResponsesToolEcho(name: name, description: tool.description,
                                      parametersJSON: tool.parameters?.value)
         }
+        truncation = r.truncation ?? "auto"
     }
 
     func envelope(id: String, created: Int, status: String,
@@ -59,6 +61,7 @@ struct ResponsesEcho {
             temperature: temperature, topP: topP,
             formatType: formatType, formatName: formatName,
             formatSchemaJSON: formatSchemaJSON, toolsEcho: toolsEcho,
+            truncation: truncation,
             usage: usage, incompleteReason: incompleteReason)
     }
 }
@@ -164,7 +167,8 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
         seed: nil,
         permissive: serverState.config.permissive,
         contextConfig: ContextConfig(
-            strategy: .newestFirst, maxTurns: nil,
+            strategy: responsesRequest.truncation == "disabled" ? .strict : .newestFirst,
+            maxTurns: nil,
             outputReserve: BodyLimits.defaultOutputReserveTokens),
         retryEnabled: serverState.config.retryEnabled,
         retryCount: serverState.config.retryCount

--- a/Sources/ResponsesWire.swift
+++ b/Sources/ResponsesWire.swift
@@ -156,6 +156,7 @@ struct ResponsesEnvelope: Encodable {
     let formatName: String?
     let formatSchemaJSON: String?
     let toolsEcho: [ResponsesToolEcho]
+    let truncation: String
     let usage: ResponsesUsage?
     let incompleteReason: String?
 
@@ -206,7 +207,7 @@ struct ResponsesEnvelope: Encodable {
         try c.encode("auto", forKey: .tool_choice)
         try c.encode(toolsEcho, forKey: .tools)
         try c.encode(topP, forKey: .top_p)
-        try c.encode("disabled", forKey: .truncation)
+        try c.encode(truncation, forKey: .truncation)
         if let usage { try c.encode(usage, forKey: .usage) } else { try c.encodeNil(forKey: .usage) }
         try c.encodeNil(forKey: .user)
     }

--- a/Tests/apfelTests/ResponsesModelsTests.swift
+++ b/Tests/apfelTests/ResponsesModelsTests.swift
@@ -267,4 +267,38 @@ func runResponsesModelsTests() {
         """)
         try assertEqual(ResponsesRequestValidator.validate(r), nil)
     }
+
+    // ========================================================================
+    // MARK: - Truncation (#391)
+    // ========================================================================
+
+    test("decodes truncation field") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"disabled"}"#)
+        try assertEqual(r.truncation, "disabled")
+    }
+
+    test("truncation defaults to nil when absent") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x"}"#)
+        try assertEqual(r.truncation, nil)
+    }
+
+    test("truncation auto decodes and validates") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"auto"}"#)
+        try assertEqual(r.truncation, "auto")
+        try assertEqual(ResponsesRequestValidator.validate(r), nil)
+    }
+
+    test("validator: unknown truncation value is a 400") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"magic"}"#)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .invalidTruncation("magic"))
+        try assertEqual(f?.httpStatusCode, 400)
+        try assertTrue(f?.message.contains("'truncation'") == true)
+        try assertTrue(f?.message.contains("magic") == true)
+    }
+
+    test("validator: truncation disabled passes validation") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"disabled"}"#)
+        try assertEqual(ResponsesRequestValidator.validate(r), nil)
+    }
 }

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -293,3 +293,32 @@ def test_responses_error_object_has_null_param_and_code():
     err = r.json()["error"]
     assert "param" in err and err["param"] is None
     assert "code" in err and err["code"] is None
+
+
+# ============================================================================
+# POST /v1/responses - truncation validation (#391)
+# ============================================================================
+
+
+def test_responses_unknown_truncation_is_400():
+    """An unrecognised truncation value must be a 400 naming the parameter."""
+    r = _responses({"model": "apple-foundationmodel", "input": "hi", "truncation": "magic"})
+    assert r.status_code == 400
+    assert "truncation" in r.json()["error"]["message"]
+    assert "magic" in r.json()["error"]["message"]
+
+
+def test_responses_truncation_auto_passes_validation():
+    """truncation: auto (the default behaviour) must not be rejected."""
+    r = _responses({"model": "apple-foundationmodel", "input": "hi", "truncation": "auto"})
+    # Should not be a 400 on the truncation field (may still be another status
+    # depending on model availability, but never a truncation validation error).
+    if r.status_code == 400:
+        assert "truncation" not in r.json()["error"]["message"]
+
+
+def test_responses_truncation_disabled_passes_validation():
+    """truncation: disabled is a valid value and must not be rejected at validation."""
+    r = _responses({"model": "apple-foundationmodel", "input": "hi", "truncation": "disabled"})
+    if r.status_code == 400:
+        assert "truncation" not in r.json()["error"]["message"]


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #391.

## Summary

`/v1/responses` was silently ignoring the `truncation` request field. The field was not in `CodingKeys` and never decoded. The handler hardcoded `.newestFirst` as the context strategy, so oversized history was always trimmed without error. The wire encoder hardcoded `"disabled"` in every response envelope regardless of what the caller actually sent.

A caller who explicitly opted out of truncation (`truncation: "disabled"`) got silently truncated data and an HTTP 200 that claimed truncation was disabled - with no way to detect the data loss from the response.

## Root cause

Three gaps in the Responses API surface, all from the initial #365 implementation:

1. `ResponsesRequest` (ApfelCore) never listed `truncation` in its `CodingKeys` and never decoded it - the field was silently dropped by the JSON decoder.
2. `handleResponses` hardcoded `strategy: .newestFirst` in the `ContextConfig`, ignoring what the caller requested.
3. `ResponsesEnvelope.encode(to:)` hardcoded `try c.encode("disabled", forKey: .truncation)` instead of echoing the value that was actually applied.

## The fix

- **Decode**: Added `truncation` to `ResponsesRequest.CodingKeys` and `init(from:)` as an optional `String`.
- **Validate**: Added `invalidTruncation` failure case to `ResponsesRequestValidator`. Unrecognised values (anything other than `"auto"` or `"disabled"`) are rejected with a 400 naming the parameter, matching how `x_context_strategy` validation works on `/v1/chat/completions` (#237).
- **Map**: In `handleResponses`, `truncation == "disabled"` maps to `.strict` (400 on context overflow); `"auto"` and absent map to `.newestFirst` (today's trimming behaviour).
- **Echo**: The actual truncation value flows through `ResponsesEcho` -> `ResponsesEnvelope` -> wire format, replacing the hardcoded `"disabled"`.

## Test coverage

- Added 5 unit tests in `Tests/apfelTests/ResponsesModelsTests.swift`:
  - `decodes truncation field` - round-trip decoding
  - `truncation defaults to nil when absent`
  - `truncation auto decodes and validates`
  - `validator: unknown truncation value is a 400`
  - `validator: truncation disabled passes validation`
- Added 3 integration tests in `Tests/integration/server_validation_test.py`:
  - `test_responses_unknown_truncation_is_400` - asserts 400 with the parameter named
  - `test_responses_truncation_auto_passes_validation`
  - `test_responses_truncation_disabled_passes_validation`

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full unit + integration suite on a Mac with Apple Intelligence)

## What I verified (static only)

- Decoding, validation, strategy mapping, and wire encoding logic are correct by inspection.
- Follows the exact same pattern as `x_context_strategy` on `/v1/chat/completions` (OpenAIModels.swift, ChatRequestValidator.swift, Handlers.swift).
- Swift 6 concurrency: no data races introduced (all new fields are `let` on `Sendable` types).
- Diff limited to `ResponsesModels.swift`, `ResponsesHandlers.swift`, `ResponsesWire.swift`, two test files, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the repo owner account.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HK2n48Ekg9886rswZDJtoK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK2n48Ekg9886rswZDJtoK)_