### PR TITLE
fix(responses): honour truncation field instead of silently trimming (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/v1/responses` now honours the `truncation` field: `"disabled"` rejects oversized input with a 400 instead of silently trimming history, `"auto"` (and absent) keeps the existing trimming behaviour, and unknown values are rejected with a 400 naming the parameter. The response envelope echoes the value that was actually applied instead of hardcoding `"disabled"` (#391).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ResponsesModels.swift
+++ b/Sources/Core/ResponsesModels.swift
@@ -40,13 +40,17 @@ public struct ResponsesRequest: Decodable, Sendable {
     public let background: Bool?
     public let store: Bool?
     public let include: [String]?
+    /// `"auto"` (default) trims oldest-first; `"disabled"` rejects oversized
+    /// input with a 400 rather than silently dropping history.
+    public let truncation: String?
     /// True when a `reasoning` object was present in the request.
     public let hasReasoning: Bool
 
     enum CodingKeys: String, CodingKey {
         case model, input, instructions, stream, temperature, top_p,
              max_output_tokens, metadata, text, tools, tool_choice,
-             previous_response_id, background, store, include, reasoning
+             previous_response_id, background, store, include, reasoning,
+             truncation
     }
 
     public init(from decoder: Decoder) throws {
@@ -72,6 +76,7 @@ public struct ResponsesRequest: Decodable, Sendable {
         background = try c.decodeIfPresent(Bool.self, forKey: .background)
         store = try c.decodeIfPresent(Bool.self, forKey: .store)
         include = try c.decodeIfPresent([String].self, forKey: .include)
+        truncation = try c.decodeIfPresent(String.self, forKey: .truncation)
         hasReasoning = c.contains(.reasoning)
     }
 }
@@ -178,6 +183,8 @@ public enum ResponsesRequestValidator {
     static let allowedRoles: Set<String> = ["system", "developer", "user", "assistant"]
     static let allowedFormats: Set<String> = ["text", "json_object", "json_schema"]
 
+    static let allowedTruncationValues: Set<String> = ["auto", "disabled"]
+
     public enum Failure: Equatable, Sendable {
         case missingModel
         case invalidModel(String)
@@ -188,6 +195,7 @@ public enum ResponsesRequestValidator {
         case invalidTextFormat(String)
         case missingSchema
         case invalidRange(String)
+        case invalidTruncation(String)
         /// A feature the on-device model / this stateless server does not
         /// support. Always a 501 with a plain-spoken message.
         case unsupported(String)
@@ -220,6 +228,8 @@ public enum ResponsesRequestValidator {
                 return "text.format json_schema requires a 'schema' object."
             case .invalidRange(let what):
                 return what
+            case .invalidTruncation(let value):
+                return "'truncation' must be 'auto' or 'disabled', got '\(value)'."
             case .unsupported(let feature):
                 switch feature {
                 case "previous_response_id":
@@ -268,6 +278,9 @@ public enum ResponsesRequestValidator {
         if r.hasReasoning { return .unsupported("reasoning") }
         if r.store == true { return .unsupported("store") }
         if let include = r.include, !include.isEmpty { return .unsupported("include") }
+        if let truncation = r.truncation, !allowedTruncationValues.contains(truncation) {
+            return .invalidTruncation(truncation)
+        }
         if let tools = r.tools {
             for tool in tools where tool.type != "function" {
                 return .unsupported("tools[].type=\(tool.type)")

--- a/Sources/ResponsesHandlers.swift
+++ b/Sources/ResponsesHandlers.swift
@@ -32,6 +32,7 @@ struct ResponsesEcho {
     let formatName: String?
     let formatSchemaJSON: String?
     let toolsEcho: [ResponsesToolEcho]
+    let truncation: String
 
     init(_ r: ResponsesRequest, formatType: String) {
         instructions = r.instructions
@@ -47,6 +48,7 @@ struct ResponsesEcho {
             return ResponsesToolEcho(name: name, description: tool.description,
                                      parametersJSON: tool.parameters?.value)
         }
+        truncation = r.truncation ?? "auto"
     }
 
     func envelope(id: String, created: Int, status: String,
@@ -59,6 +61,7 @@ struct ResponsesEcho {
             temperature: temperature, topP: topP,
             formatType: formatType, formatName: formatName,
             formatSchemaJSON: formatSchemaJSON, toolsEcho: toolsEcho,
+            truncation: truncation,
             usage: usage, incompleteReason: incompleteReason)
     }
 }
@@ -157,6 +160,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
     let tools = ResponsesMapper.tools(from: responsesRequest)
     events.append("decoded input messages=\(messages.count) stream=\(isStreaming) format=\(formatType) tools=\(tools?.count ?? 0)")
 
+    let truncationStrategy: ContextStrategy = responsesRequest.truncation == "disabled" ? .strict : .newestFirst
     let sessionOpts = SessionOptions(
         temperature: responsesRequest.temperature,
         topP: responsesRequest.top_p,
@@ -164,7 +168,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
         seed: nil,
         permissive: serverState.config.permissive,
         contextConfig: ContextConfig(
-            strategy: .newestFirst, maxTurns: nil,
+            strategy: truncationStrategy, maxTurns: nil,
             outputReserve: BodyLimits.defaultOutputReserveTokens),
         retryEnabled: serverState.config.retryEnabled,
         retryCount: serverState.config.retryCount

--- a/Sources/ResponsesWire.swift
+++ b/Sources/ResponsesWire.swift
@@ -156,6 +156,7 @@ struct ResponsesEnvelope: Encodable {
     let formatName: String?
     let formatSchemaJSON: String?
     let toolsEcho: [ResponsesToolEcho]
+    let truncation: String             // "auto" | "disabled"
     let usage: ResponsesUsage?
     let incompleteReason: String?
 
@@ -206,7 +207,7 @@ struct ResponsesEnvelope: Encodable {
         try c.encode("auto", forKey: .tool_choice)
         try c.encode(toolsEcho, forKey: .tools)
         try c.encode(topP, forKey: .top_p)
-        try c.encode("disabled", forKey: .truncation)
+        try c.encode(truncation, forKey: .truncation)
         if let usage { try c.encode(usage, forKey: .usage) } else { try c.encodeNil(forKey: .usage) }
         try c.encodeNil(forKey: .user)
     }

--- a/Tests/apfelTests/ResponsesModelsTests.swift
+++ b/Tests/apfelTests/ResponsesModelsTests.swift
@@ -78,6 +78,15 @@ func runResponsesModelsTests() {
         try assertEqual(r.tools?[0].name, "add")
     }
 
+    test("decodes truncation field") {
+        let auto = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"auto"}"#)
+        try assertEqual(auto.truncation, "auto")
+        let disabled = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"disabled"}"#)
+        try assertEqual(disabled.truncation, "disabled")
+        let absent = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x"}"#)
+        try assertEqual(absent.truncation, nil)
+    }
+
     test("decodes 501-relevant fields") {
         let r = try decodeResponses("""
         {"model":"apple-foundationmodel","input":"x",
@@ -258,6 +267,25 @@ func runResponsesModelsTests() {
           {"type":"function_call_output","call_id":"c1","output":"42"}]}
         """)
         try assertEqual(ResponsesRequestValidator.validate(r), .unsupported("input[].type=function_call_output"))
+    }
+
+    test("validator: unknown truncation value is a 400") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"none"}"#)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .invalidTruncation("none"))
+        try assertEqual(f?.httpStatusCode, 400)
+        try assertTrue(f?.message.contains("truncation") == true)
+        try assertTrue(f?.message.contains("none") == true)
+    }
+
+    test("validator: truncation auto passes validation") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"auto"}"#)
+        try assertEqual(ResponsesRequestValidator.validate(r), nil)
+    }
+
+    test("validator: truncation disabled passes validation") {
+        let r = try decodeResponses(#"{"model":"apple-foundationmodel","input":"x","truncation":"disabled"}"#)
+        try assertEqual(ResponsesRequestValidator.validate(r), nil)
     }
 
     test("validator: a plain valid request passes") {

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -293,3 +293,27 @@ def test_responses_error_object_has_null_param_and_code():
     err = r.json()["error"]
     assert "param" in err and err["param"] is None
     assert "code" in err and err["code"] is None
+
+
+def test_responses_unknown_truncation_is_400():
+    """Unknown truncation value must be rejected with a 400 naming the parameter (#391)."""
+    r = _responses({"model": "apple-foundationmodel", "input": "hi", "truncation": "none"})
+    assert r.status_code == 400
+    err = r.json()["error"]
+    assert "truncation" in err["message"]
+    assert "none" in err["message"]
+
+
+def test_responses_truncation_auto_accepted():
+    """truncation: auto is the default trimming behaviour and must not be rejected (#391)."""
+    r = _responses({"model": "apple-foundationmodel", "input": "hi", "truncation": "auto"})
+    # auto is valid - should not be a 400 (it reaches the model, so may be 200 or 500
+    # depending on whether Apple Intelligence is available, but never 400).
+    assert r.status_code != 400
+
+
+def test_responses_truncation_disabled_accepted():
+    """truncation: disabled is valid and must not be rejected as unknown (#391)."""
+    r = _responses({"model": "apple-foundationmodel", "input": "hi", "truncation": "disabled"})
+    # disabled is valid - should not be a 400.
+    assert r.status_code != 400


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #391.

## Summary

`/v1/responses` was ignoring the `truncation` field entirely: it was never decoded, the handler hardcoded `.newestFirst` trimming, and the response always echoed `"disabled"` regardless of what was requested or applied. A caller who explicitly opted out of truncation (`truncation: "disabled"`) got silently truncated data and an HTTP 200 claiming truncation was disabled.

This PR decodes the field, maps it onto the existing context strategy machinery, validates unknown values, and echoes back what was actually applied.

## Root cause

Three gaps, all from the initial Responses API implementation (#365):

1. `ResponsesRequest.CodingKeys` did not include `truncation`, so `init(from:)` never decoded it.
2. `handleResponses` hardcoded `strategy: .newestFirst` in the `ContextConfig`, ignoring the caller's intent.
3. `ResponsesEnvelope.encode(to:)` hardcoded `try c.encode("disabled", forKey: .truncation)` instead of echoing the actual value.

## The fix

- Added `truncation` to `ResponsesRequest` (decode + CodingKeys).
- Added `invalidTruncation` validation in `ResponsesRequestValidator` - unknown values get a 400 naming the parameter, matching how `x_context_strategy` is validated on chat completions (#237).
- `truncation: "disabled"` maps to `.strict` (400 on oversized input); `"auto"` and absent map to `.newestFirst` (existing behaviour).
- `ResponsesEcho` carries the resolved truncation value (`r.truncation ?? "auto"`) through to `ResponsesEnvelope`, which now encodes the actual value.

## Test coverage

- Added `ResponsesModelsTests.swift`: `testTruncationDecodes` (field round-trips for auto/disabled/absent), `testUnknownTruncation400`, `testTruncationAutoPassesValidation`, `testTruncationDisabledPassesValidation`.
- Added `server_validation_test.py`: `test_responses_unknown_truncation_is_400`, `test_responses_truncation_auto_accepted`, `test_responses_truncation_disabled_accepted`.
- Existing Responses validator and handler tests still cover the happy path.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Diff limited to `ResponsesModels.swift`, `ResponsesHandlers.swift`, `ResponsesWire.swift`, tests, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced (all new fields are `let` on `Sendable` types).
- Pattern matches the existing `x_context_strategy` validation in `ChatRequestValidator`.
- `ContextStrategy.strict` already exists and is exercised by the chat completions path.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a well-scoped fix. The issue body contained a suggested diff but I wrote the implementation independently following existing codebase patterns.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_013KMPQFt2DnYwb3YBmshSqp

---
_Generated by [Claude Code](https://claude.ai/code/session_013KMPQFt2DnYwb3YBmshSqp)_