### PR TITLE
fix(stdin): reject invalid-UTF-8 and unreadable stdin instead of silently discarding (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalid-UTF-8 and unreadable stdin no longer silently exit 0 with misleading output. Both `readStdinData` and `stdinPromptText` now throw `CLIParseError` on failure instead of swallowing the error (#397).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -66,8 +66,12 @@ func stdinIsPipe() -> Bool {
 }
 
 /// Read all of stdin as raw bytes — works for piped text and piped binary files alike.
-func readStdinData() -> Data {
-    (try? FileHandle.standardInput.readToEnd()) ?? Data()
+func readStdinData() throws -> Data {
+    do {
+        return try FileHandle.standardInput.readToEnd() ?? Data()
+    } catch {
+        throw CLIParseError("could not read stdin: \(error.localizedDescription)")
+    }
 }
 
 /// Turn piped stdin into prompt text: a piped PDF or image is extracted via lesbar
@@ -79,8 +83,10 @@ func stdinPromptText(_ data: Data) throws -> String {
     if let extracted = try LesbarFileReader.extractPipedIfBinary(data) {
         return extracted
     }
-    return (String(data: data, encoding: .utf8) ?? "")
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let text = String(data: data, encoding: .utf8) else {
+        throw CLIParseError("stdin is not valid UTF-8 text (\(data.count) bytes read)")
+    }
+    return text.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 // MARK: - Argument Parsing
@@ -178,7 +184,17 @@ if parsed.messagesFromStdin {
         printError("--messages - requires a piped JSON conversation on stdin")
         exit(exitUsageError)
     }
-    let raw = String(data: readStdinData(), encoding: .utf8) ?? ""
+    let stdinData: Data
+    do {
+        stdinData = try readStdinData()
+    } catch let e as CLIParseError {
+        printError(e.message)
+        exit(exitUsageError)
+    }
+    guard let raw = String(data: stdinData, encoding: .utf8) else {
+        printError("--messages - requires UTF-8 JSON on stdin")
+        exit(exitUsageError)
+    }
     do {
         _ = try MessagesInput.decode(raw)
     } catch let e as MessagesInput.Error {
@@ -192,7 +208,7 @@ if parsed.messagesFromStdin {
 if messagesJSON == nil && parsed.mode.acceptsStdinInput && isatty(STDIN_FILENO) == 0 {
     let stdinContent: String
     do {
-        stdinContent = try stdinPromptText(readStdinData())
+        stdinContent = try stdinPromptText(try readStdinData())
     } catch let error as CLIParseError {
         printError(error.message)
         exit(exitUsageError)

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -1069,6 +1069,102 @@ def test_empty_file_redirect_no_hint(tmp_path):
     assert "piped input was empty" not in result.stderr
 
 
+# --- Invalid stdin rejection tests (GH-397) ---
+
+
+def test_invalid_utf8_stdin_is_rejected():
+    """Invalid UTF-8 stdin must exit non-zero with a clear error, not silently
+    discard the input and exit 0 (#397)."""
+    merged_env = os.environ.copy()
+    for key in ["NO_COLOR", "APFEL_SYSTEM_PROMPT", "APFEL_HOST", "APFEL_PORT",
+                "APFEL_TEMPERATURE", "APFEL_MAX_TOKENS"]:
+        merged_env.pop(key, None)
+    result = subprocess.run(
+        [str(BINARY), "--count-tokens", "-o", "json", "Question"],
+        input=b"hello\xffworld",
+        capture_output=True,
+        env=merged_env,
+        timeout=15,
+    )
+    assert result.returncode != 0, (
+        f"invalid UTF-8 stdin should fail, got rc={result.returncode}"
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert "UTF-8" in stderr or "utf-8" in stderr.lower(), (
+        f"error should mention UTF-8, got: {stderr!r}"
+    )
+    assert "piped input was empty" not in stderr, (
+        "must not falsely claim pipe was empty when input had invalid bytes"
+    )
+
+
+def test_invalid_utf8_stdin_with_bare_pipe():
+    """Invalid UTF-8 piped as the sole input (no args) must also fail (#397)."""
+    merged_env = os.environ.copy()
+    for key in ["NO_COLOR", "APFEL_SYSTEM_PROMPT", "APFEL_HOST", "APFEL_PORT",
+                "APFEL_TEMPERATURE", "APFEL_MAX_TOKENS"]:
+        merged_env.pop(key, None)
+    result = subprocess.run(
+        [str(BINARY)],
+        input=b"\x80\x81\x82",
+        capture_output=True,
+        env=merged_env,
+        timeout=15,
+    )
+    assert result.returncode != 0
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert "UTF-8" in stderr or "utf-8" in stderr.lower()
+
+
+def test_messages_stdin_invalid_utf8_exits_2():
+    """--messages - with non-UTF-8 stdin must exit 2 with a clear message,
+    not a misleading 'invalid JSON' error (#397)."""
+    merged_env = os.environ.copy()
+    for key in ["NO_COLOR", "APFEL_SYSTEM_PROMPT", "APFEL_HOST", "APFEL_PORT",
+                "APFEL_TEMPERATURE", "APFEL_MAX_TOKENS"]:
+        merged_env.pop(key, None)
+    result = subprocess.run(
+        [str(BINARY), "--messages", "-"],
+        input=b'[{"role":"user","content":"hi\xff"}]',
+        capture_output=True,
+        env=merged_env,
+        timeout=15,
+    )
+    assert result.returncode == 2
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert "UTF-8" in stderr or "utf-8" in stderr.lower()
+    assert "invalid" not in stderr.lower() or "json" not in stderr.lower(), (
+        "should blame UTF-8, not JSON parsing"
+    )
+
+
+def test_empty_stdin_still_hints():
+    """Genuinely empty stdin must still show the existing 'piped input was
+    empty' hint - the new validation must not break the happy path (#397)."""
+    result = run_cli(["What went wrong?"], input_text="", timeout=10)
+    assert "piped input was empty" in result.stderr
+    assert "2>&1" in result.stderr
+
+
+def test_valid_utf8_stdin_unchanged():
+    """Valid UTF-8 stdin must work exactly as before (#397)."""
+    merged_env = os.environ.copy()
+    for key in ["NO_COLOR", "APFEL_SYSTEM_PROMPT", "APFEL_HOST", "APFEL_PORT",
+                "APFEL_TEMPERATURE", "APFEL_MAX_TOKENS"]:
+        merged_env.pop(key, None)
+    result = subprocess.run(
+        [str(BINARY), "--count-tokens", "-o", "json", "Question"],
+        input="hello world".encode("utf-8"),
+        capture_output=True,
+        env=merged_env,
+        timeout=15,
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert "UTF-8" not in stderr and "utf-8" not in stderr.lower(), (
+        f"valid UTF-8 must not trigger the new rejection, got: {stderr!r}"
+    )
+
+
 # --- Release info tests ---
 
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #397.

## Root cause

`readStdinData()` wrapped its `FileHandle.standardInput.readToEnd()` call in `try?` and fell back to `Data()` on any error. Separately, `stdinPromptText()` decoded the bytes with `String(data:encoding:.utf8) ?? ""`, mapping a failed UTF-8 decode to an empty string. Together, these two silent fallbacks meant that piped input containing even one invalid byte was quietly discarded: apfel ran with an empty prompt, exited 0, and printed a misleading "piped input was empty" hint. The `--messages -` path had the same two problems inline.

## The fix

Both helpers now throw `CLIParseError` instead of swallowing the failure. `readStdinData()` propagates the underlying read error. `stdinPromptText()` uses a `guard let` for the UTF-8 decode and throws with the byte count when it fails. The `--messages -` path gets equivalent treatment: read errors and UTF-8 failures each exit 2 with a specific message before the JSON parser ever runs. Genuinely empty stdin is unaffected - `Data()` is the normal return for an empty pipe, and the existing "piped input was empty" hint fires as before.

## Test coverage

- Added `test_invalid_utf8_stdin_is_rejected` - pipes `b"hello\xffworld"` with `--count-tokens`, asserts non-zero exit and stderr mentioning UTF-8.
- Added `test_invalid_utf8_stdin_with_bare_pipe` - pipes pure invalid bytes with no args, asserts non-zero exit.
- Added `test_messages_stdin_invalid_utf8_exits_2` - pipes invalid UTF-8 via `--messages -`, asserts exit 2 and that stderr blames UTF-8, not JSON parsing.
- Added `test_empty_stdin_still_hints` - regression guard that genuinely empty stdin still shows the existing hint.
- Added `test_valid_utf8_stdin_unchanged` - regression guard that valid UTF-8 input does not trigger the new rejection.
- Existing empty-pipe tests (`test_empty_pipe_no_args_shows_stderr_hint`, `test_empty_pipe_with_prompt_shows_stderr_hint`) cover the preserved behavior.

## What I verified (static only)

- All three call sites of `readStdinData()` are updated to handle the new throwing signature.
- The `stdinPromptText` empty-data fast path (`if data.isEmpty { return "" }`) is preserved, so genuinely empty stdin still works.
- The `--messages -` path catches `CLIParseError` from `readStdinData()` and guards UTF-8 decode before reaching the JSON parser.
- Swift 6 concurrency: no data races introduced - all changes are in synchronous top-level code.
- Diff limited to `Sources/main.swift`, `Tests/integration/cli_e2e_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or build the binary. If the fix does not actually resolve the reported behavior, that is on me to refine - ping me in a review comment.
- The `test_unreadable_stdin_is_rejected` case from the issue (stdin redirected from a directory fd) is not included because its behavior is OS-dependent and harder to test portably; the underlying fix (propagating the read error via `try`) covers it.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by `Arthur-Ficial` (repo owner) and the analysis matches the code exactly.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01PQaMm4WLYjYSEtfFi71vBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQaMm4WLYjYSEtfFi71vBE)_