### PR TITLE
fix(stream): handle EPIPE on closed stdout pipe (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Streaming to a closed stdout pipe (`apfel --stream ... | head -1`) no longer aborts with an uncatchable `NSFileHandleOperationException` (#389). The default stream emitter now uses the throwing `write(contentsOf:)` variant and exits cleanly with status 141 (128 + SIGPIPE) when the consumer closes the pipe.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/Chat/StreamRetryPolicy.swift
+++ b/Sources/Core/Chat/StreamRetryPolicy.swift
@@ -29,26 +29,48 @@ import Foundation
 public actor StreamPrintSink {
     /// Number of characters already emitted (the high-water mark across retries).
     private var emittedCount = 0
-    private let emit: @Sendable (String) -> Void
+    private let emit: @Sendable (String) throws -> Void
+    private var broken = false
 
     /// - parameter emit: receives each newly-printable suffix. Defaults to
-    ///   writing to stdout and flushing, so deltas appear live.
-    public init(emit: @escaping @Sendable (String) -> Void = StreamPrintSink.printAndFlush) {
+    ///   writing to stdout and flushing, so deltas appear live. A throwing
+    ///   emitter that fails marks the sink broken; subsequent feeds are no-ops.
+    public init(emit: @escaping @Sendable (String) throws -> Void = StreamPrintSink.printAndFlush) {
         self.emit = emit
     }
 
     /// Feed a cumulative snapshot. Emits only the portion that extends beyond
     /// what has already been printed; a shorter or equal snapshot (as seen at
-    /// the start of a retry re-run) emits nothing.
+    /// the start of a retry re-run) emits nothing. Once the emitter has
+    /// failed (broken pipe), all subsequent feeds are silent no-ops.
     public func feed(cumulative content: String) {
+        guard !broken else { return }
         guard content.count > emittedCount else { return }
         let start = content.index(content.startIndex, offsetBy: emittedCount)
-        emit(String(content[start...]))
+        do {
+            try emit(String(content[start...]))
+        } catch {
+            broken = true
+            return
+        }
         emittedCount = content.count
     }
 
+    /// True once the emitter has failed (e.g. EPIPE on a closed stdout pipe).
+    public var isBroken: Bool { broken }
+
     /// Default emit: write to stdout and flush so streaming output is live.
+    ///
+    /// Uses the throwing `write(contentsOf:)` variant. The legacy non-throwing
+    /// `write(_:)` raises an Objective-C `NSFileHandleOperationException` on
+    /// EPIPE (when SIGPIPE is SIG_IGN'd), which Swift cannot catch (#389).
+    /// On a broken pipe, exit 141 (128 + SIGPIPE) - the standard UNIX
+    /// convention for a consumer that closed the pipe.
     public static let printAndFlush: @Sendable (String) -> Void = { suffix in
-        FileHandle.standardOutput.write(Data(suffix.utf8))
+        do {
+            try FileHandle.standardOutput.write(contentsOf: Data(suffix.utf8))
+        } catch {
+            exit(141)
+        }
     }
 }

--- a/Tests/apfelTests/StreamPrintSinkTests.swift
+++ b/Tests/apfelTests/StreamPrintSinkTests.swift
@@ -75,6 +75,29 @@ func runStreamPrintSinkTests() {
         try assertEqual(recorder.callCount, 0, "no output for empty stream")
     }
 
+    testAsync("feed: a throwing emitter marks the sink broken and stops emission (#389)") {
+        struct BrokenPipe: Error {}
+        let recorder = SinkRecorder()
+        let sink = StreamPrintSink(emit: { suffix in
+            if recorder.callCount >= 1 { throw BrokenPipe() }
+            recorder.append(suffix)
+        })
+        // First feed succeeds.
+        await sink.feed(cumulative: "Hello")
+        try assertEqual(recorder.joined, "Hello", "first emit succeeds")
+        try assertFalse(await sink.isBroken, "not broken yet")
+
+        // Second feed triggers the throw inside the emitter.
+        await sink.feed(cumulative: "Hello, world")
+        try assertTrue(await sink.isBroken, "sink is broken after emitter throw")
+        try assertEqual(recorder.joined, "Hello", "no new output after break")
+
+        // Subsequent feeds are silent no-ops.
+        await sink.feed(cumulative: "Hello, world! More text.")
+        try assertEqual(recorder.joined, "Hello", "broken sink stays silent")
+        try assertTrue(await sink.isBroken, "still broken")
+    }
+
     // StreamPrintSink must be Sendable so it can be shared across the isolation
     // hops a retried async operation crosses.
     testAsync("StreamPrintSink conforms to Sendable") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #389.

## Root cause

`StreamPrintSink.printAndFlush` (Sources/Core/Chat/StreamRetryPolicy.swift:52) used the legacy non-throwing `FileHandle.write(_:)`. With SIGPIPE ignored process-wide (main.swift:57, #215), writing to a closed pipe gets EPIPE, which the legacy method converts into an Objective-C `NSFileHandleOperationException`. Swift cannot catch Objective-C exceptions, so `apfel --stream ... | head -1` aborted with SIGABRT and dumped a stack trace - the opposite of correct UNIX pipe behavior.

## The fix

Switched the default emitter to the throwing `write(contentsOf:)` variant. On EPIPE the emitter now catches the error and exits with status 141 (128 + SIGPIPE), the standard UNIX convention for a process whose consumer closed the pipe. This is exactly what SIGPIPE's default disposition would have done before #215 hardened it to SIG_IGN.

The emitter closure type is widened from `@Sendable (String) -> Void` to `@Sendable (String) throws -> Void` (source-compatible - non-throwing closures are a subtype of throwing). The sink tracks a `broken` flag and silences subsequent feeds after an emitter failure, so custom throwing emitters get the same graceful-stop behavior without calling `exit`.

## Test coverage

- Added `StreamPrintSinkTests: "feed: a throwing emitter marks the sink broken and stops emission (#389)"` - verifies that when a custom emitter throws, the sink sets `isBroken`, stops emitting on subsequent feeds, and does not crash.
- Existing `StreamPrintSinkTests` (5 tests) still cover the happy path (single stream, retry dedup, shorter snapshot, equal snapshot, empty snapshot).

## What I verified (static only)

- The legacy `FileHandle.write(_:)` call at line 52 is the only non-throwing stdout write on the streaming path.
- `write(contentsOf:)` is the Foundation throwing variant available since macOS 10.15.4 / Swift 5.2.
- The emitter type change is source-compatible: all existing callers pass non-throwing closures, which satisfy `throws` parameters.
- Swift 6 concurrency: no data races introduced. The `broken` flag is actor-isolated state. The test avoids capturing mutable locals in `@Sendable` closures.
- Diff limited to `Sources/Core/Chat/StreamRetryPolicy.swift`, `Tests/apfelTests/StreamPrintSinkTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on a cloud Linux runner. If the fix does not actually resolve the reported behavior, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the repo owner and the report is a well-documented edge case in Foundation's FileHandle API.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015moJbAs9M86PcRZ9YfMgWk

---
_Generated by [Claude Code](https://claude.ai/code/session_015moJbAs9M86PcRZ9YfMgWk)_