### PR TITLE
fix(stdin): reject invalid UTF-8 and unreadable stdin (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalid-UTF-8 or unreadable stdin is now rejected with a non-zero exit and a diagnostic message instead of being silently treated as empty (#397). The `--messages -` path gets the same fix.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -66,8 +66,13 @@ func stdinIsPipe() -> Bool {
 }
 
 /// Read all of stdin as raw bytes — works for piped text and piped binary files alike.
-func readStdinData() -> Data {
-    (try? FileHandle.standardInput.readToEnd()) ?? Data()
+/// Throws `CLIParseError` when the read fails (e.g. stdin redirected from a directory).
+func readStdinData() throws -> Data {
+    do {
+        return try FileHandle.standardInput.readToEnd() ?? Data()
+    } catch {
+        throw CLIParseError("could not read stdin: \(error.localizedDescription)")
+    }
 }
 
 /// Turn piped stdin into prompt text: a piped PDF or image is extracted via lesbar
@@ -79,8 +84,10 @@ func stdinPromptText(_ data: Data) throws -> String {
     if let extracted = try LesbarFileReader.extractPipedIfBinary(data) {
         return extracted
     }
-    return (String(data: data, encoding: .utf8) ?? "")
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let text = String(data: data, encoding: .utf8) else {
+        throw CLIParseError("stdin is not valid UTF-8 text (\(data.count) bytes read)")
+    }
+    return text.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 // MARK: - Argument Parsing
@@ -178,7 +185,17 @@ if parsed.messagesFromStdin {
         printError("--messages - requires a piped JSON conversation on stdin")
         exit(exitUsageError)
     }
-    let raw = String(data: readStdinData(), encoding: .utf8) ?? ""
+    let stdinData: Data
+    do {
+        stdinData = try readStdinData()
+    } catch let e as CLIParseError {
+        printError(e.message)
+        exit(exitUsageError)
+    }
+    guard let raw = String(data: stdinData, encoding: .utf8) else {
+        printError("--messages - requires UTF-8 JSON on stdin")
+        exit(exitUsageError)
+    }
     do {
         _ = try MessagesInput.decode(raw)
     } catch let e as MessagesInput.Error {
@@ -192,7 +209,7 @@ if parsed.messagesFromStdin {
 if messagesJSON == nil && parsed.mode.acceptsStdinInput && isatty(STDIN_FILENO) == 0 {
     let stdinContent: String
     do {
-        stdinContent = try stdinPromptText(readStdinData())
+        stdinContent = try stdinPromptText(try readStdinData())
     } catch let error as CLIParseError {
         printError(error.message)
         exit(exitUsageError)

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -52,6 +52,29 @@ def run_cli(args, input_text=None, env=None, timeout=60):
     )
 
 
+def run_cli_bytes(args, input_bytes, env=None, timeout=60):
+    """Like run_cli but pipes raw bytes (no text encoding)."""
+    merged_env = os.environ.copy()
+    for key in [
+        "NO_COLOR",
+        "APFEL_SYSTEM_PROMPT",
+        "APFEL_HOST",
+        "APFEL_PORT",
+        "APFEL_TEMPERATURE",
+        "APFEL_MAX_TOKENS",
+    ]:
+        merged_env.pop(key, None)
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        [str(BINARY), *args],
+        input=input_bytes,
+        capture_output=True,
+        env=merged_env,
+        timeout=timeout,
+    )
+
+
 def run_cli_tty(args, env=None, timeout=30):
     merged_env = os.environ.copy()
     for key in [
@@ -550,6 +573,48 @@ def test_empty_stdin_usage_error_keeps_stdout_empty():
     result = run_cli([], input_text="")
     assert result.returncode == 2
     assert result.stdout == "", f"stdout should be empty on usage error, got: {result.stdout!r}"
+
+
+def test_invalid_utf8_stdin_is_rejected():
+    """#397: invalid UTF-8 on stdin must exit non-zero, not silently discard."""
+    result = run_cli_bytes(
+        ["--count-tokens", "-o", "json", "Question"],
+        input_bytes=b"hello\xffworld",
+    )
+    assert result.returncode != 0, (
+        f"expected non-zero exit for invalid UTF-8 stdin, got {result.returncode}"
+    )
+    stderr = result.stderr.decode(errors="replace")
+    assert "empty" not in stderr.lower(), (
+        f"stderr must not claim input was empty: {stderr!r}"
+    )
+    assert "utf-8" in stderr.lower() or "utf8" in stderr.lower(), (
+        f"stderr should mention UTF-8: {stderr!r}"
+    )
+
+
+def test_invalid_utf8_stdin_messages_is_rejected():
+    """#397: --messages - with non-UTF-8 stdin must exit 2."""
+    result = run_cli_bytes(
+        ["--messages", "-"],
+        input_bytes=b'{"messages": [{"role":"user","content":"hi\xff"}]}',
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 for non-UTF-8 --messages stdin, got {result.returncode}"
+    )
+    stderr = result.stderr.decode(errors="replace")
+    assert "utf-8" in stderr.lower() or "utf8" in stderr.lower(), (
+        f"stderr should mention UTF-8: {stderr!r}"
+    )
+
+
+def test_empty_stdin_still_hints():
+    """#397: genuinely empty stdin still produces the existing hint."""
+    result = run_cli(["Question"], input_text="")
+    stderr = result.stderr
+    assert "piped input was empty" in stderr, (
+        f"empty stdin should still show the hint: {stderr!r}"
+    )
 
 
 def _run_no_args_tty_stdin(timeout=15):


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #397.

## Summary

`readStdinData()` swallowed read failures via `try?`, mapping any error to empty `Data()`. `stdinPromptText()` mapped a failed UTF-8 decode to `""` via `?? ""`. Together, invalid-UTF-8 or unreadable stdin was silently treated as empty, exiting 0 with a misleading "piped input was empty" hint. This is the failure mode a UNIX tool must never have - data loss with a success exit code.

Both helpers now throw `CLIParseError` with a diagnostic message. The `--messages -` path gets the same treatment: it now guards the UTF-8 decode explicitly and reports "requires UTF-8 JSON on stdin" on failure.

## Root cause

Two silent fallbacks in `Sources/main.swift`:
- `readStdinData()` used `(try? FileHandle.standardInput.readToEnd()) ?? Data()` - any read error became empty data
- `stdinPromptText()` used `String(data: data, encoding: .utf8) ?? ""` - invalid UTF-8 became an empty string
- The `--messages -` path had the same `?? ""` pattern on its own `readStdinData()` call

## The fix

- `readStdinData()` is now `throws` - a read failure surfaces as `CLIParseError("could not read stdin: ...")` instead of silent empty data
- `stdinPromptText()` uses `guard let` for the UTF-8 decode - invalid bytes throw `CLIParseError("stdin is not valid UTF-8 text (N bytes read)")`
- The `--messages -` path catches both the throwing `readStdinData()` and a separate `guard let` for UTF-8, exiting 2 with a clear message
- Genuinely empty stdin is unchanged - still produces the existing hint

## Test coverage

- Added `test_invalid_utf8_stdin_is_rejected` - pipes `b"hello\xffworld"` and asserts non-zero exit, no "empty" claim in stderr, UTF-8 mentioned in the diagnostic
- Added `test_invalid_utf8_stdin_messages_is_rejected` - pipes non-UTF-8 via `--messages -` and asserts exit 2 with a UTF-8 diagnostic
- Added `test_empty_stdin_still_hints` - confirms genuinely empty stdin still shows the existing "piped input was empty" hint
- Added `run_cli_bytes` test helper for piping raw bytes (existing `run_cli` uses `text=True`)
- Existing `test_empty_stdin_usage_error_keeps_stdout_empty` still covers the no-args empty-pipe path

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Read the full `readStdinData`, `stdinPromptText`, and `--messages` stdin paths
- Confirmed `CLIParseError` is already caught on every call site (the existing `do { ... } catch let error as CLIParseError` blocks)
- Confirmed empty `Data()` still returns `""` from `stdinPromptText` (the `data.isEmpty` early return is unchanged)
- Swift 6 concurrency: no data races introduced (no shared mutable state touched)
- Diff limited to `Sources/main.swift`, `Tests/integration/cli_e2e_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a clear root cause.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01NNXHqDD1mWFSsm5PmYb6zM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNXHqDD1mWFSsm5PmYb6zM)_