### PR TITLE
fix(streaming): detect divergent retries instead of splicing two generations (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Stream retry no longer silently splices two divergent generations into corrupted output (#402). `StreamPrintSink` now tracks the actual emitted text, not just the character count, and marks the discontinuity on stderr when a retry produces different content.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/Chat/StreamRetryPolicy.swift
+++ b/Sources/Core/Chat/StreamRetryPolicy.swift
@@ -29,6 +29,8 @@ import Foundation
 public actor StreamPrintSink {
     /// Number of characters already emitted (the high-water mark across retries).
     private var emittedCount = 0
+    /// The text that has been emitted so far, used to detect divergent retries.
+    private var emittedText = ""
     private let emit: @Sendable (String) -> Void
 
     /// - parameter emit: receives each newly-printable suffix. Defaults to
@@ -38,13 +40,29 @@ public actor StreamPrintSink {
     }
 
     /// Feed a cumulative snapshot. Emits only the portion that extends beyond
-    /// what has already been printed; a shorter or equal snapshot (as seen at
-    /// the start of a retry re-run) emits nothing.
+    /// what has already been printed. When a retry diverges from the already-
+    /// printed prefix, the sink marks the discontinuity on stderr and re-emits
+    /// the full new content rather than silently splicing two generations (#402).
     public func feed(cumulative content: String) {
-        guard content.count > emittedCount else { return }
-        let start = content.index(content.startIndex, offsetBy: emittedCount)
-        emit(String(content[start...]))
-        emittedCount = content.count
+        if content.hasPrefix(emittedText) {
+            guard content.count > emittedCount else { return }
+            let start = content.index(content.startIndex, offsetBy: emittedCount)
+            emit(String(content[start...]))
+            emittedText = content
+            emittedCount = content.count
+        } else if emittedText.hasPrefix(content) {
+            // Retry re-streaming a prefix we already printed - wait for it
+            // to catch up past the high-water mark.
+            return
+        } else {
+            FileHandle.standardError.write(
+                Data("\n[apfel: retry diverged from previous output; restarting]\n".utf8)
+            )
+            emit("\n")
+            emit(content)
+            emittedText = content
+            emittedCount = content.count
+        }
     }
 
     /// Default emit: write to stdout and flush so streaming output is live.

--- a/Tests/apfelTests/StreamPrintSinkTests.swift
+++ b/Tests/apfelTests/StreamPrintSinkTests.swift
@@ -75,6 +75,56 @@ func runStreamPrintSinkTests() {
         try assertEqual(recorder.callCount, 0, "no output for empty stream")
     }
 
+    testAsync("feed: a divergent retry does not splice two generations (#402)") {
+        let recorder = SinkRecorder()
+        let sink = StreamPrintSink(emit: { recorder.append($0) })
+
+        // Attempt 1 streams "Hello" then hits a retryable error.
+        await sink.feed(cumulative: "Hello")
+
+        // Attempt 2 produces completely different text.
+        await sink.feed(cumulative: "Goodbye.")
+
+        let joined = recorder.joined
+        try assertTrue(!joined.contains("Helloye."),
+            "must never splice first attempt's prefix with second attempt's suffix")
+        try assertTrue(joined.contains("Goodbye."),
+            "the full winning response must reach the user")
+    }
+
+    testAsync("feed: a shorter divergent retry emits the full new response (#402)") {
+        let recorder = SinkRecorder()
+        let sink = StreamPrintSink(emit: { recorder.append($0) })
+
+        // Attempt 1 streams a longer prefix.
+        await sink.feed(cumulative: "Hello world")
+
+        // Attempt 2 produces shorter, different text.
+        await sink.feed(cumulative: "Bye")
+
+        let joined = recorder.joined
+        try assertTrue(joined.contains("Bye"),
+            "shorter divergent retry must emit its full content")
+    }
+
+    testAsync("feed: a divergent retry followed by growth emits correctly (#402)") {
+        let recorder = SinkRecorder()
+        let sink = StreamPrintSink(emit: { recorder.append($0) })
+
+        // Attempt 1 partial.
+        await sink.feed(cumulative: "Hello")
+
+        // Attempt 2 diverges and grows.
+        await sink.feed(cumulative: "Good")
+        await sink.feed(cumulative: "Goodbye.")
+
+        let joined = recorder.joined
+        try assertTrue(!joined.contains("Hellobye."),
+            "divergent retry must not splice")
+        try assertTrue(joined.contains("Goodbye."),
+            "the full second response must reach the user")
+    }
+
     // StreamPrintSink must be Sendable so it can be shared across the isolation
     // hops a retried async operation crosses.
     testAsync("StreamPrintSink conforms to Sendable") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #402.

## Summary

`StreamPrintSink` tracked only a character count high-water mark across retries, assuming a retried generation would reproduce the same prefix. When a retry produced different wording (normal at any temperature above 0), the sink emitted `content[emittedCount...]` of the new attempt - silently welding two unrelated generations into corrupted output the model never produced. Exit code 0, plausible-looking text, no way for the user or a script to detect the splice.

The fix adds an `emittedText` field alongside the count and uses a three-way check:

1. `content.hasPrefix(emittedText)` - content extends what was printed; emit the delta (existing behavior, #182 stays fixed)
2. `emittedText.hasPrefix(content)` - retry re-streaming a prefix we already printed; wait silently for it to catch up
3. Neither - divergent retry; mark the discontinuity on stderr and re-emit the full new content

## Root cause

`StreamPrintSink.feed(cumulative:)` at `Sources/Core/Chat/StreamRetryPolicy.swift:43-47` compared only character counts, not the actual characters. When attempt 1 streamed "Hello" (5 chars) and attempt 2 returned "Goodbye." (8 chars), the sink skipped the first 5 characters of "Goodbye." and emitted only "ye." - producing the corrupted splice "Helloye." with no indication anything went wrong.

## Test coverage

- Added `StreamPrintSinkTests: testDivergentRetryDoesNotSplice` - feeds "Hello" then "Goodbye.", asserts no splice, full second response reaches the user
- Added `StreamPrintSinkTests: testShorterDivergentRetry` - feeds "Hello world" then "Bye", asserts shorter divergent content is emitted in full
- Added `StreamPrintSinkTests: testDivergentRetryFollowedByGrowth` - feeds "Hello" then "Good"/"Goodbye.", asserts the growing divergent stream works correctly
- Existing #182 reproducing-prefix tests remain unchanged and green

## What I verified (static only)

- All existing `StreamPrintSinkTests` pass through the new logic (manual trace of each test case)
- Swift 6 concurrency: no new isolation boundaries, `emittedText` is actor-isolated alongside `emittedCount`, no `@unchecked Sendable` added
- Diff limited to `Sources/Core/Chat/StreamRetryPolicy.swift`, `Tests/apfelTests/StreamPrintSinkTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies
- `CHANGELOG.md` has an `[Unreleased]` entry for the changelog-gate CI job

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## Anything that seemed suspicious

Nothing - straightforward bug filed by the repo owner, clear root cause, minimal fix.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2EK4MWhdHh1u29XK9itB8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2EK4MWhdHh1u29XK9itB8)_