### PR TITLE
fix(count-tokens): include prompt in total when --mcp is used (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `--count-tokens --mcp` now includes the prompt in `total`, `fits`, and `--strict` verdicts. The MCP branch of `countTokens()` assigned raw entries from `ContextManager.makeSession()` without wrapping them via `sessionInputEntries()`, so the final prompt was never counted - making `total` constant regardless of prompt length and allowing over-budget prompts to false-pass `--strict` (#399).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -267,10 +267,12 @@ func countTokens(
         msgs.append(OpenAIMessage(role: "user", content: .text(mergedPrompt)))
         let (_, _, withTools) = try await ContextManager.makeSession(
             messages: msgs, tools: mcpTools, options: options, jsonMode: false, toolChoice: nil)
-        inputEntries = withTools
+        inputEntries = sessionInputEntries(
+            builtEntries: withTools, finalPrompt: mergedPrompt, options: options)
         let (_, _, withoutTools) = try await ContextManager.makeSession(
             messages: msgs, tools: nil, options: options, jsonMode: false, toolChoice: nil)
-        noToolEntries = withoutTools
+        noToolEntries = sessionInputEntries(
+            builtEntries: withoutTools, finalPrompt: mergedPrompt, options: options)
     } else {
         var builtEntries: [Transcript.Entry] = []
         if let sys = systemPrompt, !sys.isEmpty {

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -468,6 +468,62 @@ def test_count_tokens_strict_exit_over_budget():
     assert result.returncode == 4, f"expected exit 4, got {result.returncode}: {result.stderr}"
 
 
+@pytest.mark.model
+def test_count_tokens_mcp_total_includes_prompt():
+    """#399: --count-tokens --mcp must include the prompt in `total`.
+
+    A longer prompt must produce a larger total. Before the fix, the MCP
+    branch of countTokens() skipped sessionInputEntries(), so `total`
+    was constant regardless of prompt length.
+    """
+    mcp_server = str(ROOT / "mcp" / "calculator" / "server.py")
+    short = run_cli(
+        ["--count-tokens", "-o", "json", "--mcp", mcp_server, "hello"],
+        timeout=60,
+    )
+    assert short.returncode == 0, f"short stderr: {short.stderr}"
+    long_prompt = "hello " * 100
+    long = run_cli(
+        ["--count-tokens", "-o", "json", "--mcp", mcp_server, long_prompt],
+        timeout=60,
+    )
+    assert long.returncode == 0, f"long stderr: {long.stderr}"
+    short_data = json.loads(short.stdout.strip())
+    long_data = json.loads(long.stdout.strip())
+    assert long_data["total"] > short_data["total"], (
+        f"total must grow with prompt length: short={short_data['total']}, "
+        f"long={long_data['total']}"
+    )
+
+
+@pytest.mark.model
+def test_count_tokens_mcp_total_equals_plain_plus_tools():
+    """#399: total with --mcp must equal the plain total plus mcp_tool_tokens.
+
+    This arithmetic relationship proves the prompt is counted in both paths
+    and the tool-token subtraction is consistent.
+    """
+    mcp_server = str(ROOT / "mcp" / "calculator" / "server.py")
+    prompt = "what is 2 + 2"
+    mcp_result = run_cli(
+        ["--count-tokens", "-o", "json", "--mcp", mcp_server, prompt],
+        timeout=60,
+    )
+    assert mcp_result.returncode == 0, f"mcp stderr: {mcp_result.stderr}"
+    plain_result = run_cli(
+        ["--count-tokens", "-o", "json", prompt],
+        timeout=60,
+    )
+    assert plain_result.returncode == 0, f"plain stderr: {plain_result.stderr}"
+    mcp_data = json.loads(mcp_result.stdout.strip())
+    plain_data = json.loads(plain_result.stdout.strip())
+    expected = plain_data["total"] + mcp_data["mcp_tool_tokens"]
+    assert mcp_data["total"] == expected, (
+        f"mcp total ({mcp_data['total']}) != plain total ({plain_data['total']}) "
+        f"+ mcp_tool_tokens ({mcp_data['mcp_tool_tokens']})"
+    )
+
+
 def test_invalid_flag_exit_code():
     result = run_cli(["--definitely-not-a-real-flag"])
     assert result.returncode == 2


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #399.

## Summary

`--count-tokens --mcp` left the prompt out of `total`, so `fits` and `--strict` were wrong regardless of prompt length.

### Root cause

`ContextManager.makeSession()` deliberately excludes the final prompt from its returned transcript entries - generation sends it separately via `respond()`. Every other call site (`Handlers.swift:188`, `ResponsesHandlers.swift:192`, `Benchmark.swift:639`, and the non-MCP branch at `CLI.swift:279`) wraps the result through `sessionInputEntries(builtEntries:finalPrompt:options:)` to append the prompt entry. The MCP branch at `CLI.swift:264-273` assigned the raw entries directly, so the prompt was never counted toward `total`.

### The fix

Wrap both `withTools` and `noToolEntries` through `sessionInputEntries()`, matching every other call site. Two lines changed, both in the same function. `noToolEntries` needs the same treatment because it feeds the `mcp_tool_tokens` subtraction (`total - baselineCount`): both sides of the subtraction must include the prompt for the difference to stay correct.

### Test coverage

- Added `cli_e2e_test.py:test_count_tokens_mcp_total_includes_prompt` - asserts `total` grows with prompt length when `--mcp` is used.
- Added `cli_e2e_test.py:test_count_tokens_mcp_total_equals_plain_plus_tools` - asserts the arithmetic: `mcp_total == plain_total + mcp_tool_tokens`.
- Both tests are `@pytest.mark.model` (need FoundationModels for session construction).

### What I verified (static only)

- Read every call site of `sessionInputEntries` and confirmed the MCP branch was the only one missing the wrap.
- Confirmed `ContextManager.makeSession` returns entries without the final prompt (comment at `Session.swift:192-197` in `trimHistoryEntriesToBudget` explains why).
- Confirmed `noToolEntries` also needs wrapping for the subtraction to stay correct.
- Diff limited to `Sources/CLI.swift`, `Tests/integration/cli_e2e_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

### What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on the cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

### Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by `Arthur-Ficial` (repo owner).

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full unit + integration suite on Mac with Apple Intelligence)
- [ ] Verify the two new `@pytest.mark.model` tests pass locally

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZB9kFgVG9ioozatPaxuHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZB9kFgVG9ioozatPaxuHW)_