### PR TITLE
fix(count-tokens): include prompt in total when --mcp is used (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `--count-tokens --mcp` now includes the prompt in the reported `total`, fixing incorrect `fits` verdicts and `--strict` pass-throughs (#399). The MCP branch of the token-counting path was assigning raw transcript entries from `ContextManager.makeSession` without wrapping them with `sessionInputEntries`, which every other call site does to append the final prompt entry.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -267,10 +267,12 @@ func countTokens(
         msgs.append(OpenAIMessage(role: "user", content: .text(mergedPrompt)))
         let (_, _, withTools) = try await ContextManager.makeSession(
             messages: msgs, tools: mcpTools, options: options, jsonMode: false, toolChoice: nil)
-        inputEntries = withTools
+        inputEntries = sessionInputEntries(
+            builtEntries: withTools, finalPrompt: mergedPrompt, options: options)
         let (_, _, withoutTools) = try await ContextManager.makeSession(
             messages: msgs, tools: nil, options: options, jsonMode: false, toolChoice: nil)
-        noToolEntries = withoutTools
+        noToolEntries = sessionInputEntries(
+            builtEntries: withoutTools, finalPrompt: mergedPrompt, options: options)
     } else {
         var builtEntries: [Transcript.Entry] = []
         if let sys = systemPrompt, !sys.isEmpty {

--- a/Tests/integration/cli_e2e_test.py
+++ b/Tests/integration/cli_e2e_test.py
@@ -468,6 +468,76 @@ def test_count_tokens_strict_exit_over_budget():
     assert result.returncode == 4, f"expected exit 4, got {result.returncode}: {result.stderr}"
 
 
+@pytest.mark.model
+def test_count_tokens_mcp_total_includes_prompt():
+    """#399: --count-tokens --mcp must include the prompt in the total.
+
+    A short and a long prompt must produce different totals. Before the fix,
+    total was the same regardless of prompt length because the final prompt
+    entry was never appended to the transcript entries on the MCP path.
+    """
+    require_model()
+    mcp_server = str(ROOT / "mcp" / "calculator" / "server.py")
+    short = run_cli(
+        ["--count-tokens", "-o", "json", "--mcp", mcp_server, "hello"],
+        timeout=60,
+    )
+    assert short.returncode == 0, f"stderr: {short.stderr}"
+    short_data = json.loads(short.stdout)
+
+    long_prompt = "hello " * 100
+    long = run_cli(
+        ["--count-tokens", "-o", "json", "--mcp", mcp_server, long_prompt],
+        timeout=60,
+    )
+    assert long.returncode == 0, f"stderr: {long.stderr}"
+    long_data = json.loads(long.stdout)
+
+    assert long_data["total"] > short_data["total"], (
+        f"total must grow with prompt length under --mcp (#399): "
+        f"short total={short_data['total']}, long total={long_data['total']}"
+    )
+    assert long_data["prompt_tokens"] > short_data["prompt_tokens"], (
+        f"prompt_tokens must differ: "
+        f"short={short_data['prompt_tokens']}, long={long_data['prompt_tokens']}"
+    )
+
+
+@pytest.mark.model
+def test_count_tokens_mcp_total_equals_plain_plus_tools():
+    """#399: total with --mcp must equal the plain total plus mcp_tool_tokens.
+
+    This verifies the arithmetic relationship: the MCP path adds tool
+    definitions on top of the same prompt, so the difference between the
+    with-tools and without-tools counts is exactly mcp_tool_tokens.
+    """
+    require_model()
+    mcp_server = str(ROOT / "mcp" / "calculator" / "server.py")
+    prompt = "What is 2 plus 3?"
+
+    with_mcp = run_cli(
+        ["--count-tokens", "-o", "json", "--mcp", mcp_server, prompt],
+        timeout=60,
+    )
+    assert with_mcp.returncode == 0, f"stderr: {with_mcp.stderr}"
+    mcp_data = json.loads(with_mcp.stdout)
+
+    without_mcp = run_cli(
+        ["--count-tokens", "-o", "json", prompt],
+        timeout=60,
+    )
+    assert without_mcp.returncode == 0, f"stderr: {without_mcp.stderr}"
+    plain_data = json.loads(without_mcp.stdout)
+
+    expected_total = plain_data["total"] + mcp_data["mcp_tool_tokens"]
+    assert mcp_data["total"] == expected_total, (
+        f"total with --mcp must equal plain total + mcp_tool_tokens (#399): "
+        f"mcp total={mcp_data['total']}, plain total={plain_data['total']}, "
+        f"mcp_tool_tokens={mcp_data['mcp_tool_tokens']}, "
+        f"expected={expected_total}"
+    )
+
+
 def test_invalid_flag_exit_code():
     result = run_cli(["--definitely-not-a-real-flag"])
     assert result.returncode == 2


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #399.

## Summary

`--count-tokens --mcp` omitted the prompt from the reported `total`, so `fits` and `--strict` gave wrong answers. A prompt that pushed past the context window could be reported as fitting.

`ContextManager.makeSession` deliberately excludes the final prompt from its returned transcript entries (callers send it separately via `respond()`). Every other call site wraps the result with `sessionInputEntries()` to add the prompt back for token counting. The `--mcp` branch of `countTokens` in `CLI.swift` assigned the raw entries directly, skipping this wrapping.

The fix wraps both the with-tools and without-tools entry sets with `sessionInputEntries(builtEntries:finalPrompt:options:)`, matching the non-MCP branch and the three other call sites (`Handlers.swift:188`, `ResponsesHandlers.swift:192`, `Benchmark.swift:639`). The `mcp_tool_tokens` subtraction stays correct because both sides now include the same prompt contribution, which cancels out.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Run the reproduction from #399 and verify `total` now tracks prompt length with `--mcp`
- [ ] `python3 -m pytest Tests/integration/cli_e2e_test.py::test_count_tokens_mcp_total_includes_prompt -v`
- [ ] `python3 -m pytest Tests/integration/cli_e2e_test.py::test_count_tokens_mcp_total_equals_plain_plus_tools -v`

## Root cause

`ContextManager.makeSession` returns transcript entries that exclude the final prompt entry - by design, because generation sends the prompt separately via `respond()`. The non-MCP branch of `countTokens` correctly wraps with `sessionInputEntries()` to add the prompt back for counting. The MCP branch at `CLI.swift:270,273` skipped this step, so `total` reflected only tool definitions and system prompt, never the user's actual prompt.

## The fix

Two-line change in `Sources/CLI.swift`: wrap both `inputEntries` and `noToolEntries` with `sessionInputEntries(builtEntries:finalPrompt:options:)` on the MCP path, exactly as the non-MCP branch and every other call site does.

## Test coverage

- Added `cli_e2e_test.py::test_count_tokens_mcp_total_includes_prompt` - asserts `total` differs between a short and a long prompt under `--mcp`.
- Added `cli_e2e_test.py::test_count_tokens_mcp_total_equals_plain_plus_tools` - asserts the arithmetic relationship `mcp_total == plain_total + mcp_tool_tokens`.
- Both marked `@pytest.mark.model` since the MCP token-counting path requires FoundationModels for session construction.

## What I verified (static only)

- All four call sites of `sessionInputEntries` now follow the same pattern.
- The `mcp_tool_tokens` subtraction (`total - baselineCount`) is unaffected because both `inputEntries` and `noToolEntries` gain the same prompt entry, which cancels in the difference.
- The `modelUnavailable` branch is untouched (it bypasses session construction entirely).
- Swift 6 concurrency: no data races introduced (no new shared state).
- Diff limited to `Sources/CLI.swift`, `Tests/integration/cli_e2e_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the repo owner account.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_014P6vFJm2Cs2aEw2sbxBKZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_014P6vFJm2Cs2aEw2sbxBKZ8)_