### PR TITLE
fix(responses): emit response.incomplete for truncated streams (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Truncated `/v1/responses` streams now emit `event: response.incomplete` instead of `event: response.completed` when `status` is `"incomplete"` (#412). The output-overflow path is also corrected. Non-streaming responses are unchanged.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/ResponsesHandlers.swift
+++ b/Sources/ResponsesHandlers.swift
@@ -418,8 +418,9 @@ private func responsesStreamingResponse(
                     id: id, created: created, status: status, output: [doneItem],
                     usage: ResponsesUsage(input_tokens: promptTokens, output_tokens: completionTokens),
                     incompleteReason: status == "incomplete" ? "max_output_tokens" : nil)
-                emit("response.completed", ResponsesLifecycleEvent(
-                    type: "response.completed", sequence_number: nextSeq(), response: final))
+                let terminalEvent = status == "incomplete" ? "response.incomplete" : "response.completed"
+                emit(terminalEvent, ResponsesLifecycleEvent(
+                    type: terminalEvent, sequence_number: nextSeq(), response: final))
                 await eventBox.append("responses stream complete chars=\(finalText.count) status=\(status)")
             } catch is CancellationError {
                 streamCancelled = true
@@ -440,8 +441,8 @@ private func responsesStreamingResponse(
                         id: id, created: created, status: "incomplete", output: [doneItem],
                         usage: ResponsesUsage(input_tokens: promptTokens, output_tokens: completionTokens),
                         incompleteReason: "max_output_tokens")
-                    emit("response.completed", ResponsesLifecycleEvent(
-                        type: "response.completed", sequence_number: nextSeq(), response: final))
+                    emit("response.incomplete", ResponsesLifecycleEvent(
+                        type: "response.incomplete", sequence_number: nextSeq(), response: final))
                     await eventBox.append("responses stream truncated -> incomplete")
                 } else {
                     emit("error", ResponsesErrorEvent(sequence_number: nextSeq(), message: classified.openAIMessage))

--- a/Tests/integration/openapi_conformance_test.py
+++ b/Tests/integration/openapi_conformance_test.py
@@ -262,3 +262,93 @@ class TestErrorConformance:
         data = resp.json()
         assert "error" in data
         assert "message" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# Responses streaming terminal event (#412)
+# ---------------------------------------------------------------------------
+
+def _collect_responses_sse(url, body, timeout=TIMEOUT):
+    """Stream a /v1/responses request and return (events, last_event_name).
+
+    Each entry in events is (event_name, parsed_data_dict).
+    """
+    events = []
+    with httpx.stream("POST", url, json=body, timeout=timeout) as resp:
+        current_event = None
+        for line in resp.iter_lines():
+            if line.startswith("event: "):
+                current_event = line[7:].strip()
+            elif line.startswith("data: "):
+                data = json.loads(line[6:])
+                events.append((current_event or "message", data))
+    return events
+
+
+class TestResponsesStreamTerminalEvent:
+    """The terminal SSE event name must match the response status (#412).
+
+    A truncated stream must end with event: response.incomplete.
+    A complete stream must end with event: response.completed.
+    The event name and the nested response.status must always agree.
+    """
+
+    def test_responses_stream_truncated_emits_incomplete(self):
+        """A stream truncated by max_output_tokens ends with response.incomplete."""
+        events = _collect_responses_sse(
+            f"{BASE_URL}/v1/responses",
+            {
+                "model": MODEL,
+                "input": "List the numbers from one to one thousand.",
+                "stream": True,
+                "max_output_tokens": 1,
+            },
+        )
+        terminal = [(name, data) for name, data in events if name in ("response.completed", "response.incomplete")]
+        assert len(terminal) == 1, f"expected exactly one terminal event, got {len(terminal)}"
+        event_name, payload = terminal[0]
+        assert event_name == "response.incomplete", (
+            f"truncated stream must emit response.incomplete, got {event_name}"
+        )
+        assert payload["type"] == "response.incomplete"
+        assert payload["response"]["status"] == "incomplete"
+        assert payload["response"]["incomplete_details"]["reason"] == "max_output_tokens"
+
+    def test_responses_stream_complete_emits_completed(self):
+        """A stream that finishes normally ends with response.completed."""
+        events = _collect_responses_sse(
+            f"{BASE_URL}/v1/responses",
+            {
+                "model": MODEL,
+                "input": "Say hi.",
+                "stream": True,
+            },
+        )
+        terminal = [(name, data) for name, data in events if name in ("response.completed", "response.incomplete")]
+        assert len(terminal) == 1, f"expected exactly one terminal event, got {len(terminal)}"
+        event_name, payload = terminal[0]
+        assert event_name == "response.completed", (
+            f"complete stream must emit response.completed, got {event_name}"
+        )
+        assert payload["type"] == "response.completed"
+        assert payload["response"]["status"] == "completed"
+
+    def test_responses_terminal_event_matches_status(self):
+        """The SSE event name and the nested response.status always agree."""
+        for body, expected_status in [
+            ({"model": MODEL, "input": "Say hi.", "stream": True, "max_output_tokens": 1}, "incomplete"),
+            ({"model": MODEL, "input": "Say hi.", "stream": True}, "completed"),
+        ]:
+            events = _collect_responses_sse(f"{BASE_URL}/v1/responses", body)
+            terminal = [(n, d) for n, d in events if n in ("response.completed", "response.incomplete")]
+            assert len(terminal) == 1
+            event_name, payload = terminal[0]
+            nested_status = payload["response"]["status"]
+            expected_event = f"response.{expected_status}"
+            assert event_name == expected_event, (
+                f"event name {event_name} does not match expected {expected_event}"
+            )
+            assert nested_status == expected_status, (
+                f"nested status {nested_status} does not match expected {expected_status}"
+            )
+            assert payload["type"] == expected_event


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #412.

## Root cause

Both terminal paths in the `/v1/responses` streaming handler hardcode the SSE event name to `"response.completed"` even when the payload's `status` field is `"incomplete"`. The OpenAI spec defines `response.incomplete` as a distinct terminal event (vendored at `Tests/integration/openai_spec/openapi.yaml:30544-30569`), and SDK stream handlers dispatch on the event name - so a truncated answer arrives looking like a completed one, giving clients no signal to continue, retry, or raise the token cap.

The normal completion path at `Sources/ResponsesHandlers.swift:421-422` computes `status` correctly via `FinishReasonResolver` but then ignores it when naming the event. The output-overflow catch path at `:443-444` hardcodes `status: "incomplete"` in the envelope but also hardcodes `"response.completed"` as the event name.

## The fix

The normal path now derives the terminal event name from the already-computed `status` (`"response.incomplete"` when `status == "incomplete"`, `"response.completed"` otherwise). The output-overflow path uses the constant `"response.incomplete"` directly, matching its hardcoded `"incomplete"` status. Both the SSE `event:` line and the `type` field inside the `ResponsesLifecycleEvent` payload now agree with the nested `response.status`.

## Test coverage

- Added `TestResponsesStreamTerminalEvent::test_responses_stream_truncated_emits_incomplete` - asserts truncated streams end with `event: response.incomplete` and the nested status/type/incomplete_details all match.
- Added `TestResponsesStreamTerminalEvent::test_responses_stream_complete_emits_completed` - guards the normal path still ends with `event: response.completed`.
- Added `TestResponsesStreamTerminalEvent::test_responses_terminal_event_matches_status` - parametric check that event name and nested `response.status` always agree for both cases.
- Existing `test_responses_streaming_events` in `openai_client_test.py` covers the happy-path completed case and is unaffected.

## What I verified (static only)

- Read both terminal paths in `ResponsesHandlers.swift` and confirmed the event name now tracks the status in every branch.
- Confirmed `response.incomplete` is defined in the vendored OpenAI spec (`openapi.yaml:30544-30569`).
- Confirmed `grep -rn "response.incomplete" Sources/` now returns the two corrected emit sites.
- Confirmed the existing `openai_client_test.py:test_responses_streaming_events` uses a normal prompt (no `max_output_tokens` cap), so it still expects `response.completed` and is unaffected.
- Swift 6 concurrency: no data races introduced - the change is purely to string literals passed to an existing emit helper.
- Diff limited to `Sources/ResponsesHandlers.swift`, `Tests/integration/openapi_conformance_test.py`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on the cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the Arthur-Ficial account via automated review and the analysis is accurate.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01Xxzxrd1d5u3twursB3xM9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xxzxrd1d5u3twursB3xM9f)_