### PR TITLE
fix(cli): repeated --messages now follows last-flag-wins (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Repeated `--messages` now follows last-flag-wins (#416). Previously `--messages - --messages file.json` kept the stdin flag set and ignored the file; each branch now clears the other source so the last `--messages` argument wins, consistent with every other repeated flag.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -558,6 +558,7 @@ extension CLIArguments {
                 if messagesPath == "-" {
                     // Conversation JSON arrives on stdin; the executable reads
                     // and validates it (parse() must stay free of I/O).
+                    result.messagesJSON = nil
                     result.messagesFromStdin = true
                 } else {
                     let messagesText: String
@@ -573,6 +574,7 @@ extension CLIArguments {
                     } catch let e as MessagesInput.Error {
                         throw CLIParseError("invalid --messages JSON in \(messagesPath): \(e.message)")
                     }
+                    result.messagesFromStdin = false
                     result.messagesJSON = messagesText
                 }
 

--- a/Tests/apfelTests/MessagesFlagTests.swift
+++ b/Tests/apfelTests/MessagesFlagTests.swift
@@ -221,4 +221,43 @@ func runMessagesFlagTests() {
     test("knownFlags contains --messages") {
         try assertTrue(CLIArguments.knownFlags.contains("--messages"))
     }
+
+    // ========================================================================
+    // MARK: - Repeated --messages: last-flag-wins (#416)
+    // ========================================================================
+
+    test("--messages - then --messages file uses the file") {
+        let args = try CLIArguments.parse(
+            ["--messages", "-", "--messages", "conv.json"],
+            readFile: { path in
+                guard path == "conv.json" else { throw CLIParseError("unexpected path") }
+                return twoTurn
+            })
+        try assertEqual(args.messagesJSON, twoTurn)
+        try assertTrue(!args.messagesFromStdin)
+    }
+
+    test("--messages file then --messages - uses stdin") {
+        let args = try CLIArguments.parse(
+            ["--messages", "conv.json", "--messages", "-"],
+            readFile: { path in
+                guard path == "conv.json" else { throw CLIParseError("unexpected path") }
+                return twoTurn
+            })
+        try assertTrue(args.messagesFromStdin)
+        try assertEqual(args.messagesJSON, nil)
+    }
+
+    test("--messages file1 then --messages file2 uses file2") {
+        let file1 = "[{\"role\":\"user\",\"content\":\"first\"}]"
+        let args = try CLIArguments.parse(
+            ["--messages", "a.json", "--messages", "b.json"],
+            readFile: { path in
+                if path == "a.json" { return file1 }
+                if path == "b.json" { return twoTurn }
+                throw CLIParseError("unexpected path")
+            })
+        try assertEqual(args.messagesJSON, twoTurn)
+        try assertTrue(!args.messagesFromStdin)
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #416.

## Summary

The `--messages` parser branch set `messagesFromStdin` without clearing `messagesJSON`, and vice versa. When both were set, `main.swift` checked the stdin flag first and discarded the validated file. Each branch now resets the other source so the last `--messages` argument wins, matching every other repeated flag in the parser.

## Root cause

`CLIArguments.swift:558-577` has two branches for `--messages`: one for `-` (stdin) and one for a file path. Neither branch cleared the other's state. When a user passed `--messages - --messages file.json`, the parser set `messagesFromStdin = true` on the first pass and `messagesJSON = <file>` on the second, but left `messagesFromStdin` as `true`. In `main.swift:176`, the stdin flag is checked first, so the valid file was silently discarded and apfel read empty stdin instead, reporting an unhelpful validation error.

## The fix

Two lines added to `Sources/CLI/CLIArguments.swift`:
- The stdin branch (`messagesPath == "-"`) now sets `result.messagesJSON = nil`
- The file branch now sets `result.messagesFromStdin = false`

This ensures the result never carries both sources, and the last `--messages` wins.

## Test coverage

- Added `MessagesFlagTests.swift`: `--messages - then --messages file uses the file` - asserts `messagesJSON != nil` and `messagesFromStdin == false`
- Added `MessagesFlagTests.swift`: `--messages file then --messages - uses stdin` - asserts the inverse
- Added `MessagesFlagTests.swift`: `--messages file1 then --messages file2 uses file2` - asserts the second file's contents

## What I verified (static only)

- Read both `CLIArguments.swift` and `main.swift` to confirm the root cause matches the report
- Confirmed existing tests for single `--messages -` and single `--messages file` still pass the same assertions
- Diff limited to `Sources/CLI/CLIArguments.swift`, `Tests/apfelTests/MessagesFlagTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies
- Swift 6 concurrency: no data races introduced (pure parsing code, no shared state)

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## Anything that seemed suspicious

Nothing - straightforward parser bug. The issue is filed by Arthur-Ficial and the report is accurate.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVnDHxvcTEZ5CdZpyceXJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVnDHxvcTEZ5CdZpyceXJG)_