### PR TITLE
fix(cli): repeated --messages now follows last-flag-wins (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Repeated `--messages` now follows last-flag-wins (#416). Previously `--messages - --messages file.json` would ignore the file and read stdin because the stdin flag was never cleared; the result could carry both `messagesFromStdin` and `messagesJSON` simultaneously. Each branch now resets the other.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -558,6 +558,7 @@ extension CLIArguments {
                 if messagesPath == "-" {
                     // Conversation JSON arrives on stdin; the executable reads
                     // and validates it (parse() must stay free of I/O).
+                    result.messagesJSON = nil
                     result.messagesFromStdin = true
                 } else {
                     let messagesText: String
@@ -573,6 +574,7 @@ extension CLIArguments {
                     } catch let e as MessagesInput.Error {
                         throw CLIParseError("invalid --messages JSON in \(messagesPath): \(e.message)")
                     }
+                    result.messagesFromStdin = false
                     result.messagesJSON = messagesText
                 }
 

--- a/Tests/apfelTests/MessagesFlagTests.swift
+++ b/Tests/apfelTests/MessagesFlagTests.swift
@@ -221,4 +221,43 @@ func runMessagesFlagTests() {
     test("knownFlags contains --messages") {
         try assertTrue(CLIArguments.knownFlags.contains("--messages"))
     }
+
+    // ========================================================================
+    // MARK: - Repeated --messages: last flag wins (#416)
+    // ========================================================================
+
+    test("--messages - then --messages file uses the file (last wins)") {
+        let args = try CLIArguments.parse(
+            ["--messages", "-", "--messages", "conv.json"],
+            readFile: { path in
+                guard path == "conv.json" else { throw CLIParseError("unexpected path") }
+                return twoTurn
+            })
+        try assertEqual(args.messagesJSON, twoTurn)
+        try assertTrue(!args.messagesFromStdin)
+    }
+
+    test("--messages file then --messages - uses stdin (last wins)") {
+        let args = try CLIArguments.parse(
+            ["--messages", "conv.json", "--messages", "-"],
+            readFile: { path in
+                guard path == "conv.json" else { throw CLIParseError("unexpected path") }
+                return twoTurn
+            })
+        try assertTrue(args.messagesFromStdin)
+        try assertEqual(args.messagesJSON, nil)
+    }
+
+    test("--messages file1 then --messages file2 uses file2 (last wins)") {
+        let file2JSON = "[{\"role\":\"user\",\"content\":\"second file\"}]"
+        let args = try CLIArguments.parse(
+            ["--messages", "first.json", "--messages", "second.json"],
+            readFile: { path in
+                if path == "first.json" { return twoTurn }
+                if path == "second.json" { return file2JSON }
+                throw CLIParseError("unexpected path: \(path)")
+            })
+        try assertEqual(args.messagesJSON, file2JSON)
+        try assertTrue(!args.messagesFromStdin)
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #416.

## Root cause

The `--messages` flag parser in `CLIArguments.swift` has two branches: one for `--messages -` (stdin) and one for `--messages <file>`. Neither branch clears the other's state. When a user passes `--messages - --messages file.json`, the parser sets `messagesFromStdin = true` on the first pass, then sets `messagesJSON = <file contents>` on the second - but `messagesFromStdin` stays `true`. In `main.swift`, `messagesFromStdin` is checked first, so stdin always wins and the valid file is discarded. The error message points at stdin, which the user never asked for on that invocation.

## The fix

Two lines, one per branch. The `-` branch now clears `result.messagesJSON = nil` before setting `messagesFromStdin = true`. The file branch now sets `result.messagesFromStdin = false` before storing the file contents. This ensures the last `--messages` flag wins, consistent with every other repeated flag in the parser.

## Test coverage

- Added `MessagesFlagTests.swift`: `--messages - then --messages file uses the file (last wins)` - asserts `messagesJSON != nil` and `messagesFromStdin == false`.
- Added `MessagesFlagTests.swift`: `--messages file then --messages - uses stdin (last wins)` - asserts the inverse.
- Added `MessagesFlagTests.swift`: `--messages file1 then --messages file2 uses file2 (last wins)` - asserts the second file's contents.
- Existing single-`--messages` tests (`--messages reads the file and stores raw JSON`, `--messages - defers to stdin`) cover the unchanged single-flag paths.

## What I verified (static only)

- Read the full `--messages` parsing block (lines 554-577) and both branches.
- Read `main.swift` lines 175-189 confirming the stdin-first check order.
- Read all existing `MessagesFlagTests.swift` tests to confirm no regressions.
- Confirmed the fix touches only the two branches and adds no new code paths.
- Swift 6 concurrency: no data races introduced (both fields are plain stored properties on a value type set during sequential parsing).
- Diff limited to `Sources/CLI/CLIArguments.swift`, `Tests/apfelTests/MessagesFlagTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the owner account with a clear reproducer and accurate line references.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01AMY7igwLAsgprdFRPFdVet

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMY7igwLAsgprdFRPFdVet)_