### PR TITLE
fix(responses): return 400 for malformed content, reject image parts (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/v1/responses` now returns 400 (not 500) for malformed content: empty strings, non-string scalars, and text parts with no `text` field. Image content parts are rejected with a 400 naming the unsupported content type instead of being silently dropped. Mirrors the existing `ChatRequestValidator` checks for `.emptyLastMessageContent` and `.imageContent` (#409).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ResponsesModels.swift
+++ b/Sources/Core/ResponsesModels.swift
@@ -85,6 +85,9 @@ public struct ResponsesInputItem: Decodable, Sendable {
     /// Flattened text of the content (string form, or `input_text` /
     /// `output_text` parts joined with newlines).
     public let textContent: String?
+    /// True when any content part has a type other than `input_text` /
+    /// `output_text` (e.g. `input_image`). The validator rejects these.
+    public let hasNonTextParts: Bool
 
     enum CodingKeys: String, CodingKey { case type, role, content }
 
@@ -93,16 +96,27 @@ public struct ResponsesInputItem: Decodable, Sendable {
         let text: String?
     }
 
+    private static let textPartTypes: Set<String> = ["input_text", "output_text"]
+
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         type = try c.decodeIfPresent(String.self, forKey: .type)
         role = try c.decodeIfPresent(String.self, forKey: .role)
-        if let s = try? c.decodeIfPresent(String.self, forKey: .content) {
-            textContent = s
-        } else if let parts = try? c.decodeIfPresent([Part].self, forKey: .content) {
-            textContent = parts.compactMap(\.text).joined(separator: "\n")
+        if c.contains(.content) {
+            if let s = try? c.decode(String.self, forKey: .content) {
+                textContent = s
+                hasNonTextParts = false
+            } else {
+                let parts = try c.decode([Part].self, forKey: .content)
+                textContent = parts.compactMap(\.text).joined(separator: "\n")
+                hasNonTextParts = parts.contains { part in
+                    guard let partType = part.type else { return false }
+                    return !Self.textPartTypes.contains(partType)
+                }
+            }
         } else {
             textContent = nil
+            hasNonTextParts = false
         }
     }
 }
@@ -185,6 +199,8 @@ public enum ResponsesRequestValidator {
         case emptyInput
         case unknownRole(String)
         case invalidLastRole(String)
+        case emptyLastMessageContent
+        case imageContent
         case invalidTextFormat(String)
         case missingSchema
         case invalidRange(String)
@@ -214,6 +230,10 @@ public enum ResponsesRequestValidator {
                 return "Unknown input role '\(r)' (allowed: system, developer, user, assistant)."
             case .invalidLastRole(let r):
                 return "The last input item must be a user turn, got role '\(r)'."
+            case .emptyLastMessageContent:
+                return "The last message must have non-empty 'content'"
+            case .imageContent:
+                return "Image content is not supported by the Apple on-device model"
             case .invalidTextFormat(let t):
                 return "Unsupported text.format.type '\(t)' (supported: text, json_object, json_schema)."
             case .missingSchema:
@@ -295,6 +315,11 @@ public enum ResponsesRequestValidator {
                 }
             }
             if last.role != "user" { return .invalidLastRole(last.role ?? "none") }
+            if items.contains(where: \.hasNonTextParts) { return .imageContent }
+            let lastText = last.textContent
+            if lastText == nil || lastText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+                return .emptyLastMessageContent
+            }
         }
 
         // Output format.

--- a/Tests/apfelTests/ResponsesModelsTests.swift
+++ b/Tests/apfelTests/ResponsesModelsTests.swift
@@ -267,4 +267,88 @@ func runResponsesModelsTests() {
         """)
         try assertEqual(ResponsesRequestValidator.validate(r), nil)
     }
+
+    // ========================================================================
+    // MARK: - Content validation (empty content + image parts, #409)
+    // ========================================================================
+
+    test("decode: scalar content (integer) throws a DecodingError") {
+        do {
+            _ = try decodeResponses("""
+            {"model":"apple-foundationmodel","input":[{"role":"user","content":37}]}
+            """)
+            throw TestFailure("expected a DecodingError for scalar content")
+        } catch is DecodingError {
+            // expected
+        }
+    }
+
+    test("decode: image part sets hasNonTextParts") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[
+            {"type":"input_image","image_url":"data:image/png;base64,AA=="},
+            {"type":"input_text","text":"describe"}]}]}
+        """)
+        guard case .items(let items)? = r.input else { throw TestFailure("expected .items") }
+        try assertTrue(items[0].hasNonTextParts)
+        try assertEqual(items[0].textContent, "describe")
+    }
+
+    test("decode: text-only parts do not set hasNonTextParts") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[
+            {"type":"input_text","text":"hello"},
+            {"type":"output_text","text":"world"}]}]}
+        """)
+        guard case .items(let items)? = r.input else { throw TestFailure("expected .items") }
+        try assertFalse(items[0].hasNonTextParts)
+    }
+
+    test("validator: empty string content on last user item is a 400") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[{"role":"user","content":""}]}
+        """)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .emptyLastMessageContent)
+        try assertEqual(f?.httpStatusCode, 400)
+    }
+
+    test("validator: text part without text on last user item is a 400") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[{"type":"input_text"}]}]}
+        """)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .emptyLastMessageContent)
+        try assertEqual(f?.httpStatusCode, 400)
+    }
+
+    test("validator: image part is rejected as a 400") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[
+            {"type":"input_image","image_url":"data:image/png;base64,AA=="},
+            {"type":"input_text","text":"Say OK"}]}]}
+        """)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .imageContent)
+        try assertEqual(f?.httpStatusCode, 400)
+        try assertTrue(f?.message.contains("Image content") == true)
+    }
+
+    test("validator: image content message matches chat completions") {
+        let responsesMsg = ResponsesRequestValidator.Failure.imageContent.message
+        let chatMsg = ChatRequestValidationFailure.imageContent.message
+        try assertEqual(responsesMsg, chatMsg)
+    }
+
+    test("validator: valid text content still passes") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[{"type":"input_text","text":"hello"}]}]}
+        """)
+        try assertEqual(ResponsesRequestValidator.validate(r), nil)
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #409.

## Summary

`/v1/responses` returned 500 for malformed content (empty strings, scalars, text parts without `text`) and silently dropped image parts with a 200. Chat completions already handles both correctly via `ChatRequestValidator.emptyLastMessageContent` and `.imageContent`.

**Root cause:** `ResponsesInputItem.init(from:)` used `try?` to decode `content`, swallowing decode errors (scalars became `textContent = nil`) and ignoring part types (`input_image` parts silently dropped). `ResponsesRequestValidator` never checked for empty content on the last user item or non-text part types.

**The fix:**
- Stop using `try?` for content decoding. If `content` is present but is neither a string nor a valid array of parts, the decode error propagates and the handler returns 400.
- Track `hasNonTextParts` on each `ResponsesInputItem` to detect image/non-text part types.
- Add `.emptyLastMessageContent` and `.imageContent` validation to `ResponsesRequestValidator`, mirroring the exact messages from `ChatRequestValidator` so both surfaces agree.

## Test coverage

- Added 8 unit tests in `Tests/apfelTests/ResponsesModelsTests.swift`:
  - `decode: scalar content (integer) throws a DecodingError`
  - `decode: image part sets hasNonTextParts`
  - `decode: text-only parts do not set hasNonTextParts`
  - `validator: empty string content on last user item is a 400`
  - `validator: text part without text on last user item is a 400`
  - `validator: image part is rejected as a 400`
  - `validator: image content message matches chat completions`
  - `validator: valid text content still passes`
- Existing ResponsesModelsTests cover the happy paths and other validation rules.

## What I verified (static only)

- Diff limited to `Sources/Core/ResponsesModels.swift`, `Tests/apfelTests/ResponsesModelsTests.swift`, and `CHANGELOG.md`.
- No touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced. `ResponsesInputItem` remains `Sendable` (all stored properties are immutable value types).
- New failure messages match `ChatRequestValidator` verbatim so both endpoints agree on wording.
- `hasNonTextParts` defaults to `false` for string content and absent content, so existing valid requests are unaffected.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Run the reproduction script from the issue to confirm all four cases return 400

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial's own automated review tooling and the analysis is accurate.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uhtVFV3vsCv4NVufopkTj

---
_Generated by [Claude Code](https://claude.ai/code/session_016uhtVFV3vsCv4NVufopkTj)_