### PR TITLE
fix(responses): emit response.incomplete for truncated streams (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Truncated `/v1/responses` streams now emit `event: response.incomplete` instead of `event: response.completed` when `status` is `"incomplete"` (#412). Both the normal finish-reason path and the output-overflow path are corrected. The SSE event name and nested `response.status` now always agree, matching the OpenAI spec's `response.incomplete` event definition.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/ResponsesHandlers.swift
+++ b/Sources/ResponsesHandlers.swift
@@ -418,8 +418,9 @@ private func responsesStreamingResponse(
                     id: id, created: created, status: status, output: [doneItem],
                     usage: ResponsesUsage(input_tokens: promptTokens, output_tokens: completionTokens),
                     incompleteReason: status == "incomplete" ? "max_output_tokens" : nil)
-                emit("response.completed", ResponsesLifecycleEvent(
-                    type: "response.completed", sequence_number: nextSeq(), response: final))
+                let terminalEvent = status == "incomplete" ? "response.incomplete" : "response.completed"
+                emit(terminalEvent, ResponsesLifecycleEvent(
+                    type: terminalEvent, sequence_number: nextSeq(), response: final))
                 await eventBox.append("responses stream complete chars=\(finalText.count) status=\(status)")
             } catch is CancellationError {
                 streamCancelled = true
@@ -440,8 +441,8 @@ private func responsesStreamingResponse(
                         id: id, created: created, status: "incomplete", output: [doneItem],
                         usage: ResponsesUsage(input_tokens: promptTokens, output_tokens: completionTokens),
                         incompleteReason: "max_output_tokens")
-                    emit("response.completed", ResponsesLifecycleEvent(
-                        type: "response.completed", sequence_number: nextSeq(), response: final))
+                    emit("response.incomplete", ResponsesLifecycleEvent(
+                        type: "response.incomplete", sequence_number: nextSeq(), response: final))
                     await eventBox.append("responses stream truncated -> incomplete")
                 } else {
                     emit("error", ResponsesErrorEvent(sequence_number: nextSeq(), message: classified.openAIMessage))

--- a/Tests/integration/openapi_conformance_test.py
+++ b/Tests/integration/openapi_conformance_test.py
@@ -262,3 +262,106 @@ class TestErrorConformance:
         data = resp.json()
         assert "error" in data
         assert "message" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# Responses streaming terminal event (#412)
+# ---------------------------------------------------------------------------
+
+def _parse_sse_events(lines):
+    """Parse raw SSE lines into (event_name, data_dict) pairs."""
+    events = []
+    current_event = None
+    for line in lines:
+        if line.startswith("event: "):
+            current_event = line[7:].strip()
+        elif line.startswith("data: "):
+            data = line[6:].strip()
+            if data and current_event:
+                events.append((current_event, json.loads(data)))
+                current_event = None
+    return events
+
+
+class TestResponsesStreamTerminalEvent:
+    """The terminal SSE event name must match the nested response.status (#412).
+
+    The OpenAI spec defines response.incomplete as a distinct event
+    (openapi.yaml:30544-30569). A truncated stream must end with
+    event: response.incomplete, not event: response.completed.
+    """
+
+    def test_responses_stream_truncated_emits_incomplete(self):
+        """A stream truncated by max_output_tokens ends with response.incomplete."""
+        with httpx.stream(
+            "POST",
+            f"{BASE_URL}/v1/responses",
+            json={
+                "model": MODEL,
+                "input": "List the numbers from one to one hundred.",
+                "stream": True,
+                "max_output_tokens": 1,
+            },
+            timeout=TIMEOUT,
+        ) as resp:
+            lines = list(resp.iter_lines())
+
+        events = _parse_sse_events(lines)
+        assert len(events) >= 1, "expected at least one SSE event"
+        terminal_name, terminal_data = events[-1]
+        assert terminal_name == "response.incomplete", (
+            f"truncated stream should end with response.incomplete, got {terminal_name}"
+        )
+        assert terminal_data["type"] == "response.incomplete"
+        assert terminal_data["response"]["status"] == "incomplete"
+        assert terminal_data["response"]["incomplete_details"]["reason"] == "max_output_tokens"
+
+    def test_responses_stream_complete_emits_completed(self):
+        """A stream that finishes normally ends with response.completed."""
+        with httpx.stream(
+            "POST",
+            f"{BASE_URL}/v1/responses",
+            json={
+                "model": MODEL,
+                "input": "Say hi.",
+                "stream": True,
+            },
+            timeout=TIMEOUT,
+        ) as resp:
+            lines = list(resp.iter_lines())
+
+        events = _parse_sse_events(lines)
+        assert len(events) >= 1, "expected at least one SSE event"
+        terminal_name, terminal_data = events[-1]
+        assert terminal_name == "response.completed", (
+            f"complete stream should end with response.completed, got {terminal_name}"
+        )
+        assert terminal_data["type"] == "response.completed"
+        assert terminal_data["response"]["status"] == "completed"
+
+    def test_responses_terminal_event_matches_status(self):
+        """The SSE event name and nested response.status always agree."""
+        for label, payload, expected_event, expected_status in [
+            (
+                "truncated",
+                {"model": MODEL, "input": "List numbers from one to one hundred.", "stream": True, "max_output_tokens": 1},
+                "response.incomplete",
+                "incomplete",
+            ),
+            (
+                "complete",
+                {"model": MODEL, "input": "Say hello.", "stream": True},
+                "response.completed",
+                "completed",
+            ),
+        ]:
+            with httpx.stream("POST", f"{BASE_URL}/v1/responses", json=payload, timeout=TIMEOUT) as resp:
+                lines = list(resp.iter_lines())
+            events = _parse_sse_events(lines)
+            terminal_name, terminal_data = events[-1]
+            assert terminal_name == expected_event, (
+                f"[{label}] event name mismatch: {terminal_name} != {expected_event}"
+            )
+            assert terminal_data["response"]["status"] == expected_status, (
+                f"[{label}] status mismatch: {terminal_data['response']['status']} != {expected_status}"
+            )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #412.

## Root cause

Both terminal emit sites in `Sources/ResponsesHandlers.swift` hardcoded `"response.completed"` as the SSE event name, ignoring the already-computed `status` variable. When `FinishReasonResolver` resolved to `.length` (truncation by `max_output_tokens`), the envelope correctly carried `status: "incomplete"` and `incomplete_details.reason: "max_output_tokens"`, but the SSE `event:` line and the nested `type` field both said `"response.completed"`. The contradiction meant SDK stream handlers dispatching on the event name would treat a truncated answer as complete.

The output-overflow catch path (line 443-444) had the same issue, hardcoding `"response.completed"` despite always setting `status: "incomplete"`.

## The fix

**Normal path (line 421-422):** derive the terminal event name from the status - `"response.incomplete"` when `status == "incomplete"`, `"response.completed"` otherwise. Both the SSE `event:` line and the `type` field in the `ResponsesLifecycleEvent` payload now use this derived name.

**Output-overflow path (line 443-444):** use the constant `"response.incomplete"` directly, since this path always sets `status: "incomplete"`.

## Test coverage

- Added `Tests/integration/openapi_conformance_test.py::TestResponsesStreamTerminalEvent::test_responses_stream_truncated_emits_incomplete` - asserts a `max_output_tokens: 1` stream ends with `event: response.incomplete`, status `"incomplete"`, and `incomplete_details.reason == "max_output_tokens"`.
- Added `test_responses_stream_complete_emits_completed` - guards the normal path still ends with `event: response.completed` and status `"completed"`.
- Added `test_responses_terminal_event_matches_status` - parametrized check that the SSE event name and nested `response.status` agree for both truncated and complete cases.

## What I verified (static only)

- Read both emit sites and confirmed the event name now matches the status in every code path.
- Confirmed `ResponsesLifecycleEvent` takes a string `type` field, so `"response.incomplete"` is valid.
- Confirmed the OpenAI spec defines `response.incomplete` as a distinct event at `openapi.yaml:30544-30569`.
- Confirmed `grep -rn "response.incomplete" Sources/` now returns the two corrected sites.
- Swift 6 concurrency: no data races introduced (the fix is string assignment, no shared mutable state).
- Diff limited to `Sources/ResponsesHandlers.swift`, `Tests/integration/openapi_conformance_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial (us) from automated review tooling.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_016vKStmwcvdmBWKHi1B2kJy

---
_Generated by [Claude Code](https://claude.ai/code/session_016vKStmwcvdmBWKHi1B2kJy)_