### PR TITLE
fix(validation): reject unknown message roles instead of silently dropping (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- An unknown message role on a non-final message (e.g. `"assistent"`, `"User"`, `"System"`) was silently dropped from the conversation instead of returning HTTP 400. The validator now checks every role against the known set (`system`, `developer`, `user`, `assistant`, `tool`) and rejects unknown roles with `error.param = "messages"` (#405).
+- `"developer"` role messages in `/v1/chat/completions` are now treated as instruction text (like `"system"`), matching the `/v1/responses` endpoint behavior. Previously they were silently discarded.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/ContextManager.swift
+++ b/Sources/ContextManager.swift
@@ -32,7 +32,7 @@ enum ContextManager {
         jsonMode: Bool = false,
         toolChoice: ToolChoice? = nil
     ) async throws -> (session: LanguageModelSession, finalPrompt: String, inputEntries: [Transcript.Entry]) {
-        let conversation = messages.filter { $0.role != "system" }
+        let conversation = messages.filter { $0.role != "system" && $0.role != "developer" }
         let effectiveTools: [OpenAITool]?
         if case .some(.none) = toolChoice {
             effectiveTools = nil
@@ -124,9 +124,12 @@ enum ContextManager {
             parts.append("You must respond with valid JSON only. No markdown code fences, no explanation text, no preamble. Output raw JSON.")
         }
 
-        // System prompt
+        // System prompt (system and developer roles are both instruction channels)
         if let sys = messages.first(where: { $0.role == "system" })?.textContent {
             parts.append(sys)
+        }
+        if let dev = messages.first(where: { $0.role == "developer" })?.textContent {
+            parts.append(dev)
         }
 
         if case .some(.none) = toolChoice {

--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -75,6 +75,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
     case unsupportedParameter(UnsupportedChatParameter)
     /// The final message role was not `user` or `tool`.
     case invalidLastRole
+    /// A message carried a role the server does not understand.
+    case unknownRole(String)
     /// The final non-tool message had empty or null content.
     case emptyLastMessageContent
     /// The request included image content.
@@ -93,6 +95,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
             return parameter.message
         case .invalidLastRole:
             return "Last message must have role 'user' or 'tool'"
+        case .unknownRole(let role):
+            return "Unknown message role '\(role)'. Supported roles: system, developer, user, assistant, tool"
         case .emptyLastMessageContent:
             return "The last message must have non-empty 'content'"
         case .imageContent:
@@ -113,6 +117,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
             return "validation failed: unsupported parameter \(parameter.name)"
         case .invalidLastRole:
             return "validation failed: last role != user/tool"
+        case .unknownRole(let role):
+            return "validation failed: unknown role \(role)"
         case .emptyLastMessageContent:
             return "validation failed: empty last message content"
         case .imageContent:
@@ -150,6 +156,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
         switch self {
         case .invalidModel:
             return "model"
+        case .unknownRole:
+            return "messages"
         default:
             return nil
         }
@@ -163,6 +171,9 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
 public enum ChatRequestValidator {
     /// The only model name this server accepts.
     public static let validModel = "apple-foundationmodel"
+    /// Roles the server understands. Must stay in sync with
+    /// `ContextManager.historyEntry` and `buildInstructions`.
+    public static let knownRoles: Set<String> = ["system", "developer", "user", "assistant", "tool"]
 
     /// Validates a decoded chat-completions request.
     ///
@@ -183,6 +194,10 @@ public enum ChatRequestValidator {
 
         guard let lastRole = request.messages.last?.role, ["user", "tool"].contains(lastRole) else {
             return .invalidLastRole
+        }
+
+        if let unknown = request.messages.first(where: { !knownRoles.contains($0.role) }) {
+            return .unknownRole(unknown.role)
         }
 
         if request.messages.contains(where: \.containsImageContent) {

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -548,6 +548,65 @@ func runChatRequestValidatorTests() {
             .invalidParameterValue("'x_context_max_turns' must be a positive integer, got 0")
         )
     }
+
+    // --- Unknown role validation (#405) ---
+
+    test("validator rejects unknown role in history (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"bogus","content":"ctx"},{"role":"user","content":"hi"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("bogus"))
+    }
+
+    test("validator rejects case-sensitive role mismatch (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"User","content":"ctx"},{"role":"user","content":"hi"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("User"))
+    }
+
+    test("validator accepts all known roles in history (#405)") {
+        for role in ["system", "developer", "assistant"] {
+            let request = try decode(
+                ChatCompletionRequest.self,
+                from: #"{"model":"\#(M)","messages":[{"role":"\#(role)","content":"ctx"},{"role":"user","content":"hi"}]}"#
+            )
+            try assertNil(ChatRequestValidator.validate(request))
+        }
+    }
+
+    test("unknownRole failure has correct metadata (#405)") {
+        let failure = ChatRequestValidationFailure.unknownRole("bogus")
+        try assertEqual(failure.httpStatusCode, 400)
+        try assertEqual(failure.errorParam, "messages")
+        try assertNil(failure.errorCode)
+        try assertTrue(failure.message.contains("bogus"))
+        try assertTrue(failure.message.contains("Supported roles"))
+        try assertTrue(failure.event.contains("unknown role bogus"))
+    }
+
+    test("knownRoles matches historyEntry handled roles plus system and developer (#405)") {
+        let expected: Set<String> = ["system", "developer", "user", "assistant", "tool"]
+        try assertEqual(ChatRequestValidator.knownRoles, expected)
+    }
+
+    test("validator prioritizes invalid last role before unknown role in history (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"bogus","content":"ctx"},{"role":"assistant","content":"hi"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .invalidLastRole)
+    }
+
+    test("validator prioritizes unknown role before image content (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"bogus","content":"ctx"},{"role":"user","content":[{"type":"image_url"}]}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("bogus"))
+    }
 }
 
 private func unwrap<T>(_ value: T?, _ message: String) throws -> T {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #405.

## Root cause

`ChatRequestValidator.validate` only checked the last message's role (`invalidLastRole`). All earlier messages flowed unchecked into `ContextManager.historyEntry`, which returns `nil` for any role outside its `switch` (`user`, `assistant`, `tool`). The caller's `compactMap` then silently removed those messages. A typo like `"assistent"`, `"System"`, or `"User"` deleted conversation history with no error and no indication in the response - the model answered against a conversation the caller never sent.

## The fix

Added a new `ChatRequestValidationFailure.unknownRole(String)` case and a validation pass in `ChatRequestValidator.validate` that checks every message's role against `knownRoles` (`system`, `developer`, `user`, `assistant`, `tool`). Unknown roles now return HTTP 400 with `error.param = "messages"` and a message naming the offending role and listing the supported set. The check runs after `invalidLastRole` so the more specific last-role error still surfaces when the last message is the problem.

Also wired `"developer"` into the chat completions path: it is now filtered out of the conversation (like `"system"`) and picked up by `buildInstructions` as instruction text. This matches the `/v1/responses` endpoint where `"developer"` was already mapped to `"system"`. Without this, adding `"developer"` to the known roles would have introduced a new silent-drop.

## Test coverage

- Added 7 tests in `Tests/apfelTests/OpenAIModelsTests.swift`:
  - `testUnknownRoleInHistoryIsRejected` - asserts `.unknownRole("bogus")`
  - `testCaseSensitiveRoleMismatch` - asserts `"User"` is rejected
  - `testAllKnownRolesPassValidation` - asserts `system`, `developer`, `assistant` all pass
  - `testUnknownRoleMetadata` - asserts `httpStatusCode=400`, `errorParam="messages"`, message content
  - `testKnownRolesMatchesExpectedSet` - locks the set against drift
  - `testPriorityInvalidLastRoleBeforeUnknownRole` - ordering guarantee
  - `testPriorityUnknownRoleBeforeImageContent` - ordering guarantee
- Existing `invalidLastRole` tests still cover the last-message path.

## What I verified (static only)

- Read `ChatRequestValidator.swift` end-to-end; all `switch` arms in `message`, `event`, `httpStatusCode`, `errorCode`, `errorParam` cover the new case.
- Confirmed `ContextManager.historyEntry` handles `user`, `assistant`, `tool`; `system` and `developer` are filtered before reaching it. The `knownRoles` set matches exactly.
- Confirmed `ResponsesRequestValidator` already has an `unknownRole` case with the same pattern (line 186); this mirrors it for chat completions.
- Diff limited to `ChatRequestValidator.swift`, `ContextManager.swift`, `OpenAIModelsTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no new mutable state, no actors, no `@unchecked Sendable`.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial (owner account) and the suggested fix aligns with the existing `ResponsesRequestValidator` pattern. No external code was copied.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01SdquXX8A4fX2nC7qK81WZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdquXX8A4fX2nC7qK81WZn)_