### PR TITLE
fix(validator): reject unknown message roles instead of silently dropping (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- An unknown message role (e.g. `"bogus"`, `"assistent"`, `"User"`) on a non-final message was silently dropped from the conversation instead of returning a 400 error. The model generated against a mutilated history with no indication to the caller. `ChatRequestValidator` now validates every role against the set the server handles (`system`, `user`, `assistant`, `tool`) and returns `unknownRole` with `error.param = "messages"` for any unrecognised value (#405).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -75,6 +75,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
     case unsupportedParameter(UnsupportedChatParameter)
     /// The final message role was not `user` or `tool`.
     case invalidLastRole
+    /// A message carried a role the server does not understand.
+    case unknownRole(String)
     /// The final non-tool message had empty or null content.
     case emptyLastMessageContent
     /// The request included image content.
@@ -93,6 +95,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
             return parameter.message
         case .invalidLastRole:
             return "Last message must have role 'user' or 'tool'"
+        case .unknownRole(let role):
+            return "Unknown message role '\(role)'. Supported roles: system, user, assistant, tool"
         case .emptyLastMessageContent:
             return "The last message must have non-empty 'content'"
         case .imageContent:
@@ -113,6 +117,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
             return "validation failed: unsupported parameter \(parameter.name)"
         case .invalidLastRole:
             return "validation failed: last role != user/tool"
+        case .unknownRole(let role):
+            return "validation failed: unknown role \(role)"
         case .emptyLastMessageContent:
             return "validation failed: empty last message content"
         case .imageContent:
@@ -150,6 +156,8 @@ public enum ChatRequestValidationFailure: Sendable, Equatable, Hashable, CustomS
         switch self {
         case .invalidModel:
             return "model"
+        case .unknownRole:
+            return "messages"
         default:
             return nil
         }
@@ -179,6 +187,11 @@ public enum ChatRequestValidator {
 
         if let unsupported = UnsupportedChatParameter.detect(in: request) {
             return .unsupportedParameter(unsupported)
+        }
+
+        let knownRoles: Set<String> = ["system", "user", "assistant", "tool"]
+        if let unknown = request.messages.first(where: { !knownRoles.contains($0.role) }) {
+            return .unknownRole(unknown.role)
         }
 
         guard let lastRole = request.messages.last?.role, ["user", "tool"].contains(lastRole) else {

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -259,6 +259,7 @@ func runApfelCorePublicAPIUsageTests() {
             .emptyMessages,
             .unsupportedParameter(.logprobs),
             .invalidLastRole,
+            .unknownRole("bogus"),
             .imageContent,
             .invalidParameterValue("why"),
             .invalidModel("gpt-5"),

--- a/Tests/apfelTests/ApfelErrorMessageTests.swift
+++ b/Tests/apfelTests/ApfelErrorMessageTests.swift
@@ -188,6 +188,10 @@ func runApfelErrorMessageTests() {
             "Last message must have role 'user' or 'tool'"
         )
         try assertEqual(
+            ChatRequestValidationFailure.unknownRole("bogus").message,
+            "Unknown message role 'bogus'. Supported roles: system, user, assistant, tool"
+        )
+        try assertEqual(
             ChatRequestValidationFailure.imageContent.message,
             "Image content is not supported by the Apple on-device model"
         )
@@ -221,6 +225,10 @@ func runApfelErrorMessageTests() {
         try assertEqual(
             ChatRequestValidationFailure.invalidLastRole.event,
             "validation failed: last role != user/tool"
+        )
+        try assertEqual(
+            ChatRequestValidationFailure.unknownRole("bogus").event,
+            "validation failed: unknown role bogus"
         )
         try assertEqual(
             ChatRequestValidationFailure.imageContent.event,

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -538,6 +538,84 @@ func runChatRequestValidatorTests() {
         )
     }
 
+    test("unknown role in history is rejected (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"bogus","content":"The number is 123."},{"role":"user","content":"Say OK"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("bogus"))
+    }
+
+    test("case-sensitive role mismatch is rejected (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"User","content":"hi"},{"role":"user","content":"ok"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("User"))
+    }
+
+    test("unknown role as last message returns unknownRole not invalidLastRole (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"assistent","content":"hi"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("assistent"))
+    }
+
+    test("all known roles pass validation when conversation is valid (#405)") {
+        let systemOnly = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"system","content":"You help."},{"role":"user","content":"hi"}]}"#
+        )
+        try assertNil(ChatRequestValidator.validate(systemOnly))
+
+        let withAssistant = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"assistant","content":"hello"},{"role":"user","content":"hi"}]}"#
+        )
+        try assertNil(ChatRequestValidator.validate(withAssistant))
+
+        let withTool = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"tool","tool_call_id":"c1","name":"x","content":"result"}]}"#
+        )
+        try assertNil(ChatRequestValidator.validate(withTool))
+    }
+
+    test("unknownRole failure maps to 400 with param messages (#405)") {
+        let failure = ChatRequestValidationFailure.unknownRole("bogus")
+        try assertEqual(failure.httpStatusCode, 400)
+        try assertNil(failure.errorCode)
+        try assertEqual(failure.errorParam, "messages")
+    }
+
+    test("unknownRole stable metadata (#405)") {
+        try assertEqual(
+            ChatRequestValidationFailure.unknownRole("bogus").message,
+            "Unknown message role 'bogus'. Supported roles: system, user, assistant, tool"
+        )
+        try assertEqual(
+            ChatRequestValidationFailure.unknownRole("bogus").event,
+            "validation failed: unknown role bogus"
+        )
+    }
+
+    test("validator prioritizes unknown role before invalid last role (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"bogus","content":"x"}]}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unknownRole("bogus"))
+    }
+
+    test("validator prioritizes unsupported parameters before unknown role (#405)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"bogus","content":"x"}],"logprobs":true}"#
+        )
+        try assertEqual(ChatRequestValidator.validate(request), .unsupportedParameter(.logprobs))
+    }
+
     test("validator reports x_context_max_turns before x_context_output_reserve") {
         let request = try decode(
             ChatCompletionRequest.self,


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #405.

## Summary

### Root cause

`ChatRequestValidator.validate` only checked the role of `request.messages.last`. Earlier messages flowed unchecked into `ContextManager.historyEntry`, which returns `nil` for any role outside its `switch` (`user`, `assistant`, `tool`), and the caller's `compactMap` silently removed the entry. A typo like `"assistent"`, `"System"`, or `"User"` deleted conversation history with no error and no indication in the response.

### The fix

Added a new `unknownRole(String)` case to `ChatRequestValidationFailure` and a validation pass in `ChatRequestValidator.validate` that checks every message role against the set the code actually handles: `{system, user, assistant, tool}`. The check runs before `invalidLastRole` so a typo on the last message gets the more specific `unknownRole` error rather than the generic "must be user or tool". Returns HTTP 400 with `error.param = "messages"`, matching OpenAI's behaviour for invalid roles.

The known-role set was derived from what the code handles - `system` is filtered and used for instructions, `user`/`assistant`/`tool` are handled by `historyEntry` - so validation and conversion cannot drift apart. Note: the `developer` role is not in this set because the chat completions code path does not handle it (only the Responses path maps it to `system`). Sending `developer` to chat completions will now return a clear 400 instead of being silently dropped. Adding `developer` support to the chat path would be a separate enhancement.

## Test coverage

- Added `OpenAIModelsTests.swift`: `testUnknownRoleInHistoryIsRejected` - asserts `.unknownRole("bogus")` for an unknown role in a non-final message
- Added `OpenAIModelsTests.swift`: `testCaseSensitiveRoleMismatchIsRejected` - asserts `"User"` is rejected (case-sensitive)
- Added `OpenAIModelsTests.swift`: `testUnknownRoleAsLastMessage` - asserts unknownRole fires instead of invalidLastRole
- Added `OpenAIModelsTests.swift`: `testAllKnownRolesAccepted` - system, user, assistant, tool all pass
- Added `OpenAIModelsTests.swift`: `testUnknownRoleFailureMetadata` - httpStatusCode 400, errorParam "messages"
- Added `OpenAIModelsTests.swift`: `testUnknownRoleStableMetadata` - message and event strings
- Added `OpenAIModelsTests.swift`: priority ordering tests (unknownRole before invalidLastRole, unsupportedParameter before unknownRole)
- Updated `ApfelErrorMessageTests.swift` with message/event coverage for the new case
- Updated `ApfelCorePublicAPIUsageTests.swift` with the new enum case

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full unit + integration suite on a Mac with Apple Intelligence)

## What I verified (static only)

- `ChatRequestValidator.validate` now rejects unknown roles before they reach `historyEntry`
- The known-role set matches what `ContextManager.historyEntry` and `buildInstructions` handle
- Swift 6 concurrency: no data races introduced (pure value-type enum case, no shared state)
- Diff limited to `ChatRequestValidator.swift` + test files + `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies
- All existing priority-ordering tests remain correct (they use known roles like `assistant`)

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward validation gap. The issue was filed by the repo owner's automated review tooling and the analysis matched the code exactly.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnWNex399oH3a9gJgA1QYs

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnWNex399oH3a9gJgA1QYs)_