### PR TITLE
fix(mcp): bound stdin writes with poll+deadline so a stalled peer times out (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP `send()` now uses non-blocking I/O with `poll(POLLOUT)` under the same deadline as the read side, so a stdio peer that stops reading its stdin causes a timeout error instead of hanging apfel forever (#418). `sendLocked` (notification path) and `sendAndReceive` (request/response path, including inline ping replies) both share the configured `--mcp-timeout` budget.
+- `classifyIncoming` rejects ping requests whose `id` exceeds 4096 UTF-8 bytes, preventing a peer from sizing apfel's reply write arbitrarily (#418).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -217,6 +217,10 @@ public enum MCPProtocol {
         // notifications do not. Answer pings; skip everything else.
         if let method = obj["method"] as? String {
             if method == "ping", let pingId = obj["id"] {
+                // Cap: an oversized id decides how many bytes we write back (#418).
+                if let s = pingId as? String, s.utf8.count > 4096 {
+                    return .unrelated
+                }
                 let reply: [String: Any] = ["jsonrpc": "2.0", "id": pingId, "result": [:] as [String: Any]]
                 if JSONSerialization.isValidJSONObject(reply),
                    let replyData = try? JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys]),

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -74,6 +74,13 @@ final class MCPConnection: @unchecked Sendable {
         self.lineReader = BufferedLineReader(fileDescriptor: stdoutP.fileHandleForReading.fileDescriptor)
         self.tools = [] // placeholder, filled below
 
+        // Set stdin fd non-blocking so writes can be poll-bounded (#418).
+        let stdinFD = stdinP.fileHandleForWriting.fileDescriptor
+        let flags = fcntl(stdinFD, F_GETFL)
+        if flags != -1 {
+            _ = fcntl(stdinFD, F_SETFL, flags | O_NONBLOCK)
+        }
+
         try proc.run()
 
         do {
@@ -159,31 +166,55 @@ final class MCPConnection: @unchecked Sendable {
         return id
     }
 
-    private func send(_ message: String) throws {
+    /// Write `message` (plus trailing newline) to the child's stdin under a
+    /// deadline. Uses non-blocking I/O + `poll(POLLOUT)` so a peer that stops
+    /// reading its stdin can never hang apfel past the timeout (#418).
+    private func send(_ message: String, deadline: TimeInterval) throws {
         guard let data = (message + "\n").data(using: .utf8) else { return }
-        // Guard against writing to a crashed MCP server. Without this a closed
-        // read end raises SIGPIPE (fatal by default) or, with the legacy
-        // non-throwing FileHandle.write(_:), an uncatchable ObjC exception on
-        // EPIPE. The isRunning check catches the common case fast; the throwing
-        // write(contentsOf:) inside do/catch catches the crash-mid-write race
-        // and maps it to a recoverable MCPError (#215).
         guard process.isRunning else {
             throw MCPError.processError("MCP server process is not running (\(path))")
         }
-        do {
-            try stdinPipe.fileHandleForWriting.write(contentsOf: data)
-        } catch {
-            throw MCPError.processError("failed to write to MCP server stdin (\(path)): \(error.localizedDescription)")
+        let fd = stdinPipe.fileHandleForWriting.fileDescriptor
+        try data.withUnsafeBytes { rawBuf in
+            guard let base = rawBuf.baseAddress else { return }
+            var offset = 0
+            while offset < data.count {
+                let remainingMs = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
+                guard remainingMs > 0 else {
+                    throw MCPError.timedOut("Write to MCP server timed out (\(path))")
+                }
+                var pfd = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+                let ready = poll(&pfd, 1, Int32(clamping: remainingMs))
+                if ready == 0 {
+                    throw MCPError.timedOut("Write to MCP server timed out (\(path))")
+                }
+                if ready < 0 {
+                    if errno == EINTR { continue }
+                    throw MCPError.processError("Failed waiting to write to MCP server (\(path)): \(String(cString: strerror(errno)))")
+                }
+                if (pfd.revents & Int16(POLLERR | POLLHUP)) != 0 {
+                    throw MCPError.processError("MCP server stdin closed unexpectedly (\(path))")
+                }
+                let written = Darwin.write(fd, base + offset, data.count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    if errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                    throw MCPError.processError("Failed to write to MCP server stdin (\(path)): \(String(cString: strerror(errno)))")
+                }
+                offset += written
+            }
         }
     }
 
     /// Standalone write (notification path) serialized against in-flight
     /// exchanges so it cannot interleave with another request's stdin bytes
-    /// (#218). Never call while holding `ioLock` - NSLock is not reentrant.
+    /// (#218). Uses its own deadline from `timeoutMilliseconds` (#418).
+    /// Never call while holding `ioLock` - NSLock is not reentrant.
     private func sendLocked(_ message: String) throws {
         ioLock.lock()
         defer { ioLock.unlock() }
-        try send(message)
+        let deadline = Date().timeIntervalSinceReferenceDate + Double(timeoutMilliseconds) / 1000.0
+        try send(message, deadline: deadline)
     }
 
     /// Sends `message` and reads until the response whose JSON-RPC `"id"`
@@ -205,8 +236,8 @@ final class MCPConnection: @unchecked Sendable {
     ) throws -> String {
         ioLock.lock()
         defer { ioLock.unlock() }
-        try send(message)
         let deadline = Date().timeIntervalSinceReferenceDate + Double(timeoutMilliseconds) / 1000.0
+        try send(message, deadline: deadline)
         while true {
             let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
             guard remainingMilliseconds > 0 else {
@@ -220,7 +251,7 @@ final class MCPConnection: @unchecked Sendable {
             case .matchingResponse:
                 return line
             case .pingRequest(let reply):
-                try send(reply)
+                try send(reply, deadline: deadline)
             case .unrelated:
                 continue
             }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -445,6 +445,22 @@ func runMCPClientTests() {
         try assertEqual(MCPProtocol.classifyIncoming(#"{"jsonrpc":"2.0"}"#, awaitingId: 7), .unrelated)
     }
 
+    test("classifyIncoming rejects a ping with an oversized string id (#418)") {
+        let hugeId = String(repeating: "x", count: 262_144)
+        let line = #"{"jsonrpc":"2.0","id":"\#(hugeId)","method":"ping"}"#
+        try assertEqual(MCPProtocol.classifyIncoming(line, awaitingId: 7), .unrelated)
+    }
+
+    test("classifyIncoming still answers a ping with a 4096-byte string id (#418)") {
+        let okId = String(repeating: "y", count: 4096)
+        let line = #"{"jsonrpc":"2.0","id":"\#(okId)","method":"ping"}"#
+        guard case .pingRequest(let reply) = MCPProtocol.classifyIncoming(line, awaitingId: 7) else {
+            throw TestFailure("expected .pingRequest for a 4096-byte id")
+        }
+        let obj = try JSONSerialization.jsonObject(with: Data(reply.utf8)) as! [String: Any]
+        try assertEqual(obj["id"] as! String, okId)
+    }
+
     // MARK: - Malformed model-emitted arguments must fail loudly (#241)
     // The formatting fallback in toolsCallRequest silently replaced malformed
     // JSON with {}; the call sites must validate first and throw a typed error.


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #418.

## Summary

Two independent fixes for the MCP write-side hang, both in this PR:

1. **Bound the write** (`Sources/MCPClient.swift`). `send()` now uses non-blocking I/O with `poll(POLLOUT)` under the same deadline budget the read side already uses. The stdin fd is set to `O_NONBLOCK` in `init`, and the write loop mirrors the `BufferedLineReader.readLine` pattern: `poll` for writability, partial `Darwin.write`, check remaining deadline. `sendAndReceive` and `sendLocked` both pass their deadline through, so the entire exchange - write + read + any inline ping replies - shares one timeout.

2. **Cap the echoed ping id** (`Sources/Core/MCPProtocol.swift`). `classifyIncoming` now returns `.unrelated` for a ping whose string id exceeds 4096 UTF-8 bytes, so a peer cannot size apfel's reply write arbitrarily. Normal ping ids (integers, short strings) are unaffected.

## Root cause

`send()` did a blocking `write(2)` with no deadline. A stdio MCP server that stopped reading its stdin filled the pipe buffer (~64 KiB), at which point `write(2)` blocked forever. The ping path amplified this: the server chose the `id` (up to 256 KiB), and apfel echoed it back verbatim, guaranteeing the write exceeded the pipe capacity. `--mcp-timeout` only bounded the read side.

## The fix

Convert the stdin fd to non-blocking mode and replace the one-shot `FileHandle.write(contentsOf:)` with a `poll(POLLOUT)` + partial-write loop under a deadline. `SIGPIPE` is already ignored process-wide (issue #215), so the raw `Darwin.write()` safely returns `EPIPE` on a broken pipe. The ping id cap is defense in depth that closes the specific reproduction vector independently.

## Test coverage

- Added `MCPClientTests.swift`: `testClassifyIncomingRejectsOversizedPingId` - 262,144-byte id returns `.unrelated`.
- Added `MCPClientTests.swift`: `testClassifyIncomingStillAnswers4096BytePingId` - boundary case, 4096-byte id still works.
- Existing `classifyIncoming` tests cover the normal ping, string id, non-ping, notification, and noise paths.

## What I verified (static only)

- `send()` rewrite mirrors the `BufferedLineReader.readLine` poll-loop pattern.
- `SIGPIPE` already ignored process-wide (`Sources/main.swift:57`), so `EPIPE` from raw `write()` is caught, not fatal.
- All three call sites (`sendAndReceive` initial write, `sendAndReceive` ping reply, `sendLocked`) pass a deadline.
- `O_NONBLOCK` set on the stdin fd before `proc.run()`, so the fd is non-blocking from the first write.
- `POLLERR | POLLHUP` on the write side correctly detects a closed read end.
- `Int32(clamping:)` on the poll timeout avoids overflow on large remaining-ms values.
- `EINTR` and `EAGAIN/EWOULDBLOCK` handled correctly in the write loop.
- Swift 6 concurrency: no new data races. `send` is private, called only under `ioLock` or during `init`.
- Diff limited to `Sources/MCPClient.swift`, `Sources/Core/MCPProtocol.swift`, `Tests/apfelTests/MCPClientTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- The integration test scenarios suggested in #418 (`test_stdio_peer_that_stops_reading_times_out`, `test_calculator_still_works`) need a running binary - they should be added locally.

## Anything that seemed suspicious

Nothing - straightforward bug. The reporter is `Arthur-Ficial` (the project owner). The reproduction script is a minimal Python peer that demonstrates the hang. No hostile content detected.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Run the reproduction from #418 and confirm it now times out instead of hanging
- [ ] `make test` (full suite including MCP integration tests with the bundled calculator)

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ka8VyeLWwSkh9wX2UBVSJC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka8VyeLWwSkh9wX2UBVSJC)_