### PR TITLE
fix(mcp): bound write side of stdio transport with poll+deadline (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP `send()` now enforces a write deadline using `poll(POLLOUT)` + non-blocking I/O, sharing the same timeout budget as the read side (#418). A stdio MCP server that stops reading its stdin can no longer hang apfel forever.
+- `classifyIncoming` rejects ping requests whose string `id` exceeds 4096 bytes (#418). A peer can no longer force an arbitrarily large write by sending a ping with an oversized id.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -217,6 +217,9 @@ public enum MCPProtocol {
         // notifications do not. Answer pings; skip everything else.
         if let method = obj["method"] as? String {
             if method == "ping", let pingId = obj["id"] {
+                if let s = pingId as? String, s.utf8.count > 4096 {
+                    return .unrelated
+                }
                 let reply: [String: Any] = ["jsonrpc": "2.0", "id": pingId, "result": [:] as [String: Any]]
                 if JSONSerialization.isValidJSONObject(reply),
                    let replyData = try? JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys]),

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -35,6 +35,7 @@ final class MCPConnection: @unchecked Sendable {
     private let process: Process
     private let stdinPipe: Pipe
     private let stdoutPipe: Pipe
+    private let stdinFd: Int32
     private let lineReader: BufferedLineReader
     private let lock = NSLock()
     /// Serializes complete wire exchanges (send+receive) per connection (#218).
@@ -71,10 +72,15 @@ final class MCPConnection: @unchecked Sendable {
         self.process = proc
         self.stdinPipe = stdinP
         self.stdoutPipe = stdoutP
+        let fd = stdinP.fileHandleForWriting.fileDescriptor
+        self.stdinFd = fd
         self.lineReader = BufferedLineReader(fileDescriptor: stdoutP.fileHandleForReading.fileDescriptor)
         self.tools = [] // placeholder, filled below
 
         try proc.run()
+
+        let flags = fcntl(fd, F_GETFL)
+        if flags >= 0 { _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK) }
 
         do {
             // Initialize handshake
@@ -159,21 +165,43 @@ final class MCPConnection: @unchecked Sendable {
         return id
     }
 
-    private func send(_ message: String) throws {
+    private func send(_ message: String, deadline: Double) throws {
         guard let data = (message + "\n").data(using: .utf8) else { return }
-        // Guard against writing to a crashed MCP server. Without this a closed
-        // read end raises SIGPIPE (fatal by default) or, with the legacy
-        // non-throwing FileHandle.write(_:), an uncatchable ObjC exception on
-        // EPIPE. The isRunning check catches the common case fast; the throwing
-        // write(contentsOf:) inside do/catch catches the crash-mid-write race
-        // and maps it to a recoverable MCPError (#215).
         guard process.isRunning else {
             throw MCPError.processError("MCP server process is not running (\(path))")
         }
-        do {
-            try stdinPipe.fileHandleForWriting.write(contentsOf: data)
-        } catch {
-            throw MCPError.processError("failed to write to MCP server stdin (\(path)): \(error.localizedDescription)")
+        var bytesWritten = 0
+        let totalBytes = data.count
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            while bytesWritten < totalBytes {
+                let remainingMs = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
+                if remainingMs <= 0 {
+                    throw MCPError.timedOut("Write to MCP server timed out (\(path))")
+                }
+                var pfd = pollfd(fd: stdinFd, events: Int16(POLLOUT), revents: 0)
+                let ready = poll(&pfd, 1, Int32(clamping: remainingMs))
+                if ready == 0 {
+                    throw MCPError.timedOut("Write to MCP server timed out (\(path))")
+                }
+                if ready < 0 {
+                    if errno == EINTR { continue }
+                    throw MCPError.processError("Failed waiting to write to MCP server (\(path)): \(String(cString: strerror(errno)))")
+                }
+                if (pfd.revents & Int16(POLLERR)) != 0 {
+                    throw MCPError.processError("MCP server stdin reported an error (\(path))")
+                }
+                if (pfd.revents & Int16(POLLHUP)) != 0 && (pfd.revents & Int16(POLLOUT)) == 0 {
+                    throw MCPError.processError("MCP server closed its stdin (\(path))")
+                }
+                let n = Darwin.write(stdinFd, base.advanced(by: bytesWritten), totalBytes - bytesWritten)
+                if n < 0 {
+                    if errno == EINTR { continue }
+                    if errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                    throw MCPError.processError("failed to write to MCP server stdin (\(path)): \(String(cString: strerror(errno)))")
+                }
+                bytesWritten += n
+            }
         }
     }
 
@@ -183,7 +211,8 @@ final class MCPConnection: @unchecked Sendable {
     private func sendLocked(_ message: String) throws {
         ioLock.lock()
         defer { ioLock.unlock() }
-        try send(message)
+        let deadline = Date().timeIntervalSinceReferenceDate + Double(timeoutMilliseconds) / 1000.0
+        try send(message, deadline: deadline)
     }
 
     /// Sends `message` and reads until the response whose JSON-RPC `"id"`
@@ -205,8 +234,8 @@ final class MCPConnection: @unchecked Sendable {
     ) throws -> String {
         ioLock.lock()
         defer { ioLock.unlock() }
-        try send(message)
         let deadline = Date().timeIntervalSinceReferenceDate + Double(timeoutMilliseconds) / 1000.0
+        try send(message, deadline: deadline)
         while true {
             let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
             guard remainingMilliseconds > 0 else {
@@ -220,7 +249,7 @@ final class MCPConnection: @unchecked Sendable {
             case .matchingResponse:
                 return line
             case .pingRequest(let reply):
-                try send(reply)
+                try send(reply, deadline: deadline)
             case .unrelated:
                 continue
             }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -427,6 +427,28 @@ func runMCPClientTests() {
         try assertEqual(obj["id"] as! String, "ping-1")
     }
 
+    test("classifyIncoming rejects a ping with an oversized string id (#418)") {
+        let oversizedId = String(repeating: "x", count: 262144)
+        let line = #"{"jsonrpc":"2.0","id":"\#(oversizedId)","method":"ping"}"#
+        try assertEqual(MCPProtocol.classifyIncoming(line, awaitingId: 7), .unrelated)
+    }
+
+    test("classifyIncoming still echoes a ping with a 4096-byte string id (#418)") {
+        let maxId = String(repeating: "y", count: 4096)
+        let line = #"{"jsonrpc":"2.0","id":"\#(maxId)","method":"ping"}"#
+        guard case .pingRequest(let reply) = MCPProtocol.classifyIncoming(line, awaitingId: 7) else {
+            throw TestFailure("expected .pingRequest for a 4096-byte id")
+        }
+        let obj = try JSONSerialization.jsonObject(with: Data(reply.utf8)) as! [String: Any]
+        try assertEqual(obj["id"] as! String, maxId)
+    }
+
+    test("classifyIncoming rejects a ping whose string id is just over the cap (#418)") {
+        let overById1 = String(repeating: "z", count: 4097)
+        let line = #"{"jsonrpc":"2.0","id":"\#(overById1)","method":"ping"}"#
+        try assertEqual(MCPProtocol.classifyIncoming(line, awaitingId: 7), .unrelated)
+    }
+
     test("classifyIncoming skips a non-ping server request") {
         let line = #"{"jsonrpc":"2.0","id":9002,"method":"roots/list"}"#
         try assertEqual(MCPProtocol.classifyIncoming(line, awaitingId: 7), .unrelated)


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #418.

## Summary

`send()` used a blocking `write(2)` with no timeout. A stdio MCP server that stopped reading its stdin could hang apfel forever - the `--mcp-timeout` flag only bounded the read side. This converts the stdin fd to non-blocking and loops on `poll(POLLOUT)` under the same deadline that the read side already uses. `classifyIncoming` now also rejects ping requests whose string `id` exceeds 4096 bytes, closing the amplification vector.

## Root cause

`MCPConnection.send` wrote to the child's stdin pipe via `FileHandle.write(contentsOf:)`, a blocking call with no deadline. The `sendAndReceive` method maintained a deadline but only consulted it around reads (`lineReader.readLine`), never around writes. A malicious or buggy MCP server could exploit this by sending a `ping` with a 256 KiB `id` (forcing a ~256 KiB reply into a ~64 KiB pipe), then stopping reading its stdin. The `write(2)` blocked indefinitely, wedging the entire process.

## The fix

Two independent changes:

1. **Bounded writes** (`Sources/MCPClient.swift`): The stdin fd is set `O_NONBLOCK` after process launch. `send` now accepts a `deadline` parameter and loops on `poll(fd, POLLOUT, remainingMs)` + partial `Darwin.write(2)`, throwing `MCPError.timedOut` when the budget expires. `sendAndReceive` computes its deadline before the initial `send` (previously it was computed after), so one exchange shares one deadline across both write and read. `sendLocked` computes its own deadline from `timeoutMilliseconds`. The pattern mirrors `BufferedLineReader.readLine` (the existing read-side timeout).

2. **Capped ping id** (`Sources/Core/MCPProtocol.swift`): `classifyIncoming` returns `.unrelated` for a ping whose string `id` exceeds 4096 UTF-8 bytes. A ping id is an opaque correlation token; there is no protocol reason to echo an arbitrarily large one. Integer ids (the normal case) are unaffected.

## Test coverage

- Added `testOversizedPingIdIsNotEchoed` (262144-byte id returns `.unrelated`)
- Added `testPingWith4096ByteIdStillEchoed` (boundary: 4096-byte id is accepted)
- Added `testPingJustOverCapIsRejected` (4097-byte id returns `.unrelated`)
- Existing ping echo tests cover the happy path (integer ids, short string ids)

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] Run the reproduction from #418 and verify it times out instead of hanging
- [ ] Verify bundled calculator MCP still works: `apfel --mcp mcp/calculator/server.py "what is 6*7?"`

## What I verified (static only)

- Read path unchanged: `lineReader.readLine` and its timeout logic are untouched.
- The `poll`+`write` loop follows the same EINTR/EAGAIN/POLLHUP/POLLERR discipline as `BufferedLineReader.readLine`.
- SIGPIPE is `SIG_IGN`'d process-wide (`Sources/main.swift:57`), so raw `write(2)` to a dead pipe returns EPIPE instead of killing the process.
- Swift 6 concurrency: no new mutable shared state; `stdinFd` is a `let` binding set in `init`.
- Diff limited to `MCPClient.swift`, `MCPProtocol.swift`, `MCPClientTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on the cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue is filed by the repo owner and the report is a clean security finding with a reproducible test case.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01MrnZAux6ttDcD2VA6dgX5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrnZAux6ttDcD2VA6dgX5o)_