### PR TITLE
fix(responses): return 400 for malformed content and reject image parts (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `/v1/responses` now returns 400 (not 500) for empty, scalar, or text-part-without-text content in the last user input item, and rejects `input_image` parts with a 400 instead of silently dropping them (#409).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ResponsesModels.swift
+++ b/Sources/Core/ResponsesModels.swift
@@ -85,6 +85,8 @@ public struct ResponsesInputItem: Decodable, Sendable {
     /// Flattened text of the content (string form, or `input_text` /
     /// `output_text` parts joined with newlines).
     public let textContent: String?
+    /// True when content contains a non-text part (e.g. `input_image`).
+    public let hasNonTextPart: Bool
 
     enum CodingKeys: String, CodingKey { case type, role, content }
 
@@ -93,16 +95,24 @@ public struct ResponsesInputItem: Decodable, Sendable {
         let text: String?
     }
 
+    private static let textPartTypes: Set<String> = ["input_text", "output_text"]
+
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         type = try c.decodeIfPresent(String.self, forKey: .type)
         role = try c.decodeIfPresent(String.self, forKey: .role)
         if let s = try? c.decodeIfPresent(String.self, forKey: .content) {
             textContent = s
-        } else if let parts = try? c.decodeIfPresent([Part].self, forKey: .content) {
+            hasNonTextPart = false
+        } else if let parts = try c.decodeIfPresent([Part].self, forKey: .content) {
             textContent = parts.compactMap(\.text).joined(separator: "\n")
+            hasNonTextPart = parts.contains { part in
+                guard let t = part.type else { return false }
+                return !Self.textPartTypes.contains(t)
+            }
         } else {
             textContent = nil
+            hasNonTextPart = false
         }
     }
 }
@@ -185,6 +195,8 @@ public enum ResponsesRequestValidator {
         case emptyInput
         case unknownRole(String)
         case invalidLastRole(String)
+        case emptyLastUserContent
+        case imageContent
         case invalidTextFormat(String)
         case missingSchema
         case invalidRange(String)
@@ -214,6 +226,10 @@ public enum ResponsesRequestValidator {
                 return "Unknown input role '\(r)' (allowed: system, developer, user, assistant)."
             case .invalidLastRole(let r):
                 return "The last input item must be a user turn, got role '\(r)'."
+            case .emptyLastUserContent:
+                return "The last input item must have non-empty text content."
+            case .imageContent:
+                return "Image content is not supported by the Apple on-device model."
             case .invalidTextFormat(let t):
                 return "Unsupported text.format.type '\(t)' (supported: text, json_object, json_schema)."
             case .missingSchema:
@@ -295,6 +311,9 @@ public enum ResponsesRequestValidator {
                 }
             }
             if last.role != "user" { return .invalidLastRole(last.role ?? "none") }
+            if items.contains(where: \.hasNonTextPart) { return .imageContent }
+            let lastText = last.textContent?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if lastText.isEmpty { return .emptyLastUserContent }
         }
 
         // Output format.

--- a/Tests/apfelTests/ResponsesModelsTests.swift
+++ b/Tests/apfelTests/ResponsesModelsTests.swift
@@ -180,6 +180,81 @@ func runResponsesModelsTests() {
         try assertEqual(ResponsesRequestValidator.validate(r), .missingSchema)
     }
 
+    test("decodes input_image part and flags hasNonTextPart") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[
+            {"type":"input_image","image_url":"data:image/png;base64,AA=="},
+            {"type":"input_text","text":"describe"}]}]}
+        """)
+        guard case .items(let items)? = r.input else { throw TestFailure("expected .items") }
+        try assertTrue(items[0].hasNonTextPart)
+        try assertEqual(items[0].textContent, "describe")
+    }
+
+    test("pure input_text parts do not flag hasNonTextPart") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[{"type":"input_text","text":"hi"}]}]}
+        """)
+        guard case .items(let items)? = r.input else { throw TestFailure("expected .items") }
+        try assertFalse(items[0].hasNonTextPart)
+    }
+
+    test("scalar content (not string, not array) throws a decode error") {
+        do {
+            _ = try decodeResponses("""
+            {"model":"apple-foundationmodel","input":[{"role":"user","content":37}]}
+            """)
+            throw TestFailure("expected decode error for scalar content")
+        } catch is DecodingError {
+            // expected
+        }
+    }
+
+    // ========================================================================
+    // MARK: - Validator: content quality (#409)
+    // ========================================================================
+
+    test("validator: empty string content in last user item is a 400") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[{"role":"user","content":""}]}
+        """)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .emptyLastUserContent)
+        try assertEqual(f?.httpStatusCode, 400)
+    }
+
+    test("validator: text part without text in last user item is a 400") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[{"type":"input_text"}]}]}
+        """)
+        try assertEqual(ResponsesRequestValidator.validate(r), .emptyLastUserContent)
+    }
+
+    test("validator: image part is rejected as a 400") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[
+            {"type":"input_image","image_url":"data:image/png;base64,AA=="},
+            {"type":"input_text","text":"describe"}]}]}
+        """)
+        let f = ResponsesRequestValidator.validate(r)
+        try assertEqual(f, .imageContent)
+        try assertEqual(f?.httpStatusCode, 400)
+        try assertTrue(f?.message.contains("Image content") == true)
+    }
+
+    test("validator: image-only part is also rejected") {
+        let r = try decodeResponses("""
+        {"model":"apple-foundationmodel","input":[
+          {"role":"user","content":[
+            {"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}
+        """)
+        try assertEqual(ResponsesRequestValidator.validate(r), .imageContent)
+    }
+
     test("validator: out-of-range sampling params are 400s") {
         for json in [
             #"{"model":"apple-foundationmodel","input":"x","temperature":3}"#,

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -293,3 +293,51 @@ def test_responses_error_object_has_null_param_and_code():
     err = r.json()["error"]
     assert "param" in err and err["param"] is None
     assert "code" in err and err["code"] is None
+
+
+# ============================================================================
+# #409 - Responses content validation: empty/scalar/image -> 400, not 500
+# ============================================================================
+
+
+def test_responses_empty_content_is_400():
+    """Empty string content must be a 400, not a downstream 500."""
+    r = _responses({"model": MODEL, "input": [{"role": "user", "content": ""}]})
+    assert r.status_code == 400, (r.status_code, r.text)
+    err = _assert_openai_error(r, expected_type="invalid_request_error")
+    assert "non-empty" in err["message"].lower() or "content" in err["message"].lower()
+
+
+def test_responses_scalar_content_is_400():
+    """A non-string, non-array content (e.g. integer) must be a 400."""
+    r = _responses({"model": MODEL, "input": [{"role": "user", "content": 37}]})
+    assert r.status_code == 400, (r.status_code, r.text)
+
+
+def test_responses_text_part_without_text_is_400():
+    """A text part with no text field must be a 400, not a downstream 500."""
+    r = _responses({"model": MODEL, "input": [
+        {"role": "user", "content": [{"type": "input_text"}]}
+    ]})
+    assert r.status_code == 400, (r.status_code, r.text)
+    _assert_openai_error(r, expected_type="invalid_request_error")
+
+
+def test_responses_image_part_is_400():
+    """An input_image part must be rejected, not silently dropped."""
+    r = _responses({"model": MODEL, "input": [
+        {"role": "user", "content": [
+            {"type": "input_image", "image_url": "data:image/png;base64,AA=="},
+            {"type": "input_text", "text": "Say OK"},
+        ]}
+    ]})
+    assert r.status_code == 400, (r.status_code, r.text)
+    err = _assert_openai_error(r, expected_type="invalid_request_error")
+    assert "image" in err["message"].lower()
+
+
+def test_responses_and_chat_agree_on_malformed_content():
+    """Both endpoints return 400 for empty string content - not 500."""
+    chat_r = _post({"model": MODEL, "messages": [{"role": "user", "content": ""}]})
+    resp_r = _responses({"model": MODEL, "input": [{"role": "user", "content": ""}]})
+    assert chat_r.status_code == resp_r.status_code == 400


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #409.

## Root cause

`ResponsesInputItem.init(from:)` used `try?` for both content-decoding paths (string and array-of-parts). When `content` was a scalar like `37`, both branches silently failed and `textContent` became `nil`, which the mapper turned into an empty string that the model rejected as a 500 "Last message has no text content". When `content` contained an `input_image` part, the part's `text` was `nil` so `compactMap(\.text)` skipped it - silently dropping the image and answering as though it had been read.

The `ResponsesRequestValidator` checked item roles and input shape but never whether the final user item's flattened text was actually usable, and had no image-content check - unlike `ChatRequestValidator`, which has both (#233).

## The fix

Three changes in `Sources/Core/ResponsesModels.swift`:

1. **Changed `try?` to `try`** on the second content-decode branch in `ResponsesInputItem.init(from:)`. A `content` value that is neither a string nor an array of parts now throws a `DecodingError`, which the handler already turns into a 400. The first branch keeps `try?` for the intended string-to-array fallthrough.

2. **Added `hasNonTextPart` tracking** to `ResponsesInputItem`. When decoding parts, any part whose `type` is not `input_text` or `output_text` sets this flag.

3. **Added two new validator failures** to `ResponsesRequestValidator`: `.imageContent` (400, rejects requests containing non-text parts before they silently vanish) and `.emptyLastUserContent` (400, catches empty/nil text in the last user item before it becomes a downstream 500). Both mirror the checks `ChatRequestValidator` already has.

## Test coverage

- Added 3 decoding tests in `ResponsesModelsTests.swift`: `hasNonTextPart` flag positive, negative, and scalar-content decode error.
- Added 4 validator tests in `ResponsesModelsTests.swift`: empty string content, text-part-without-text, image+text rejection, image-only rejection.
- Added 5 integration tests in `server_validation_test.py`: `test_responses_empty_content_is_400`, `test_responses_scalar_content_is_400`, `test_responses_text_part_without_text_is_400`, `test_responses_image_part_is_400`, `test_responses_and_chat_agree_on_malformed_content`.
- Existing tests for valid string/parts input, mapper, and all 501 paths are unchanged.

## What I verified (static only)

- Read the full `ResponsesModels.swift`, `ChatRequestValidator.swift`, `Handlers.swift`, `ResponsesHandlers.swift`, and both test files.
- Confirmed the `try?` to `try` change only affects the content-decode path, not the top-level `input` decode (which already uses `try` on the array branch).
- Confirmed `decodeIfPresent` returns `nil` for absent keys and null values, so the `else` branch still fires correctly for items without a `content` key.
- Confirmed the image check runs before the empty-content check, matching `ChatRequestValidator`'s ordering.
- Swift 6 concurrency: no data races introduced - `hasNonTextPart` is a `let` on a `Sendable` struct.
- Diff limited to `Sources/Core/ResponsesModels.swift`, `Tests/apfelTests/ResponsesModelsTests.swift`, `Tests/integration/server_validation_test.py`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial (the repo owner) with a clear root-cause analysis and no embedded code to copy.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01XosNE6Kr7Kf58uop62fSYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XosNE6Kr7Kf58uop62fSYV)_