### PR TITLE
fix(mcp): bound send() with write timeout and cap oversized ping ids (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP `send()` now respects `--mcp-timeout`: writes use non-blocking I/O with `poll(2)` and a shared deadline, preventing a peer that stops reading stdin from hanging apfel indefinitely (#418).
+- Ping requests with oversized string ids (> 4096 bytes) are silently ignored instead of echoed, removing the write-amplification vector that made the hang trivially triggerable (#418).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/MCPProtocol.swift
+++ b/Sources/Core/MCPProtocol.swift
@@ -217,6 +217,9 @@ public enum MCPProtocol {
         // notifications do not. Answer pings; skip everything else.
         if let method = obj["method"] as? String {
             if method == "ping", let pingId = obj["id"] {
+                if let s = pingId as? String, s.utf8.count > 4096 {
+                    return .unrelated
+                }
                 let reply: [String: Any] = ["jsonrpc": "2.0", "id": pingId, "result": [:] as [String: Any]]
                 if JSONSerialization.isValidJSONObject(reply),
                    let replyData = try? JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys]),

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -74,6 +74,11 @@ final class MCPConnection: @unchecked Sendable {
         self.lineReader = BufferedLineReader(fileDescriptor: stdoutP.fileHandleForReading.fileDescriptor)
         self.tools = [] // placeholder, filled below
 
+        // Non-blocking so send() can poll+write with a deadline (#418).
+        let stdinWriteFd = stdinP.fileHandleForWriting.fileDescriptor
+        let stdinFlags = fcntl(stdinWriteFd, F_GETFL)
+        if stdinFlags >= 0 { _ = fcntl(stdinWriteFd, F_SETFL, stdinFlags | O_NONBLOCK) }
+
         try proc.run()
 
         do {
@@ -159,21 +164,52 @@ final class MCPConnection: @unchecked Sendable {
         return id
     }
 
-    private func send(_ message: String) throws {
+    private func send(_ message: String, deadlineTimestamp: Double) throws {
         guard let data = (message + "\n").data(using: .utf8) else { return }
-        // Guard against writing to a crashed MCP server. Without this a closed
-        // read end raises SIGPIPE (fatal by default) or, with the legacy
-        // non-throwing FileHandle.write(_:), an uncatchable ObjC exception on
-        // EPIPE. The isRunning check catches the common case fast; the throwing
-        // write(contentsOf:) inside do/catch catches the crash-mid-write race
-        // and maps it to a recoverable MCPError (#215).
         guard process.isRunning else {
             throw MCPError.processError("MCP server process is not running (\(path))")
         }
-        do {
-            try stdinPipe.fileHandleForWriting.write(contentsOf: data)
-        } catch {
-            throw MCPError.processError("failed to write to MCP server stdin (\(path)): \(error.localizedDescription)")
+        let fd = stdinPipe.fileHandleForWriting.fileDescriptor
+        let bytes = [UInt8](data)
+        var offset = 0
+        while offset < bytes.count {
+            let remaining = Int((deadlineTimestamp - Date().timeIntervalSinceReferenceDate) * 1000.0)
+            if remaining <= 0 {
+                throw MCPError.timedOut("Write to MCP server timed out (\(path))")
+            }
+            var pfd = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+            let ready = poll(&pfd, 1, Int32(min(remaining, Int(Int32.max))))
+            if ready == 0 {
+                throw MCPError.timedOut("Write to MCP server timed out (\(path))")
+            }
+            if ready < 0 {
+                if errno == EINTR { continue }
+                throw MCPError.processError(
+                    "Failed waiting to write to MCP server (\(path)): \(String(cString: strerror(errno)))")
+            }
+            if (pfd.revents & Int16(POLLNVAL)) != 0 {
+                throw MCPError.processError("MCP server stdin became invalid (\(path))")
+            }
+            if (pfd.revents & Int16(POLLERR)) != 0 {
+                throw MCPError.processError("MCP server stdin reported an I/O error (\(path))")
+            }
+            if (pfd.revents & Int16(POLLHUP)) != 0 && (pfd.revents & Int16(POLLOUT)) == 0 {
+                throw MCPError.processError("MCP server stdin pipe closed (\(path))")
+            }
+            if (pfd.revents & Int16(POLLOUT)) == 0 {
+                continue
+            }
+            let toWrite = bytes.count - offset
+            let written = bytes.withUnsafeBufferPointer { buf in
+                Darwin.write(fd, buf.baseAddress! + offset, toWrite)
+            }
+            if written < 0 {
+                if errno == EINTR { continue }
+                if errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                throw MCPError.processError(
+                    "Failed to write to MCP server stdin (\(path)): \(String(cString: strerror(errno)))")
+            }
+            offset += written
         }
     }
 
@@ -183,7 +219,8 @@ final class MCPConnection: @unchecked Sendable {
     private func sendLocked(_ message: String) throws {
         ioLock.lock()
         defer { ioLock.unlock() }
-        try send(message)
+        let deadline = Date().timeIntervalSinceReferenceDate + Double(timeoutMilliseconds) / 1000.0
+        try send(message, deadlineTimestamp: deadline)
     }
 
     /// Sends `message` and reads until the response whose JSON-RPC `"id"`
@@ -205,8 +242,8 @@ final class MCPConnection: @unchecked Sendable {
     ) throws -> String {
         ioLock.lock()
         defer { ioLock.unlock() }
-        try send(message)
         let deadline = Date().timeIntervalSinceReferenceDate + Double(timeoutMilliseconds) / 1000.0
+        try send(message, deadlineTimestamp: deadline)
         while true {
             let remainingMilliseconds = Int((deadline - Date().timeIntervalSinceReferenceDate) * 1000.0)
             guard remainingMilliseconds > 0 else {
@@ -220,7 +257,7 @@ final class MCPConnection: @unchecked Sendable {
             case .matchingResponse:
                 return line
             case .pingRequest(let reply):
-                try send(reply)
+                try send(reply, deadlineTimestamp: deadline)
             case .unrelated:
                 continue
             }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -517,4 +517,41 @@ func runMCPClientTests() {
         try assertEqual(calls!.first?.id, "call_001")
         try assertTrue(calls!.first!.argumentsString.contains("CLAUDE.md"), "arguments must contain the file path")
     }
+
+    // MARK: - Oversized ping id rejection (#418)
+
+    test("classifyIncoming ignores a ping with an oversized string id (#418)") {
+        let bigId = String(repeating: "x", count: 262_144)
+        let json: [String: Any] = ["jsonrpc": "2.0", "id": bigId, "method": "ping"]
+        let data = try JSONSerialization.data(withJSONObject: json, options: [])
+        let line = String(data: data, encoding: .utf8)!
+        try assertEqual(MCPProtocol.classifyIncoming(line, awaitingId: 7), .unrelated)
+    }
+
+    test("classifyIncoming still echoes a ping with a 4096-byte string id (#418)") {
+        let okId = String(repeating: "a", count: 4096)
+        let json: [String: Any] = ["jsonrpc": "2.0", "id": okId, "method": "ping"]
+        let data = try JSONSerialization.data(withJSONObject: json, options: [])
+        let line = String(data: data, encoding: .utf8)!
+        guard case .pingRequest = MCPProtocol.classifyIncoming(line, awaitingId: 7) else {
+            throw TestFailure("expected .pingRequest for a 4096-byte id")
+        }
+    }
+
+    test("classifyIncoming ignores a ping with a 4097-byte string id (#418)") {
+        let bigId = String(repeating: "b", count: 4097)
+        let json: [String: Any] = ["jsonrpc": "2.0", "id": bigId, "method": "ping"]
+        let data = try JSONSerialization.data(withJSONObject: json, options: [])
+        let line = String(data: data, encoding: .utf8)!
+        try assertEqual(MCPProtocol.classifyIncoming(line, awaitingId: 7), .unrelated)
+    }
+
+    test("classifyIncoming still echoes a ping with a numeric id (#418)") {
+        let line = #"{"jsonrpc":"2.0","id":99999,"method":"ping"}"#
+        guard case .pingRequest(let reply) = MCPProtocol.classifyIncoming(line, awaitingId: 7) else {
+            throw TestFailure("expected .pingRequest for a numeric id")
+        }
+        let obj = try JSONSerialization.jsonObject(with: Data(reply.utf8)) as! [String: Any]
+        try assertEqual(obj["id"] as! Int, 99999)
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #418.

## Root cause

`MCPConnection.send()` performed a blocking `write(2)` with no deadline at all. The `--mcp-timeout` flag only bounded the read side (via `BufferedLineReader.readLine`'s `poll(POLLIN)` + deadline loop). A peer that stopped draining its stdin - whether malicious or merely buggy - could block apfel in `write(2)` indefinitely. The amplification vector was the ping path: `classifyIncoming` echoed the server's `id` back verbatim, so a 256 KiB `id` forced a ~256 KiB reply into a pipe whose capacity is ~64 KiB, guaranteeing the write would block once the peer stopped reading.

## The fix

Two independent changes:

1. **Write timeout** (`Sources/MCPClient.swift`): The stdin pipe's write-end fd is now set to `O_NONBLOCK` in `init`. `send()` accepts a `deadlineTimestamp` and uses the same `poll(POLLOUT)` + partial `write(2)` + deadline discipline that `BufferedLineReader.readLine` already uses for reads. `sendAndReceive` computes its deadline before the initial send (not after) and passes it to all `send` calls (including ping replies), so one exchange shares one deadline. `sendLocked` computes its own deadline from `timeoutMilliseconds`. On timeout, `send` throws `MCPError.timedOut`, which triggers the existing deregister-and-reap path in `MCPManager.execute`.

2. **Ping id cap** (`Sources/Core/MCPProtocol.swift`): `classifyIncoming` now returns `.unrelated` for a ping whose string `id` exceeds 4096 bytes. Numeric ids are unaffected (they cannot be oversized). This removes the trivial amplification vector while the write timeout removes the general-case hang.

## Test coverage

- Added `MCPClientTests.swift`: `classifyIncoming ignores a ping with an oversized string id (#418)` - 256 KiB id returns `.unrelated`.
- Added `MCPClientTests.swift`: `classifyIncoming still echoes a ping with a 4096-byte string id (#418)` - boundary: exactly 4096 bytes is still echoed.
- Added `MCPClientTests.swift`: `classifyIncoming ignores a ping with a 4097-byte string id (#418)` - one byte over the cap is ignored.
- Added `MCPClientTests.swift`: `classifyIncoming still echoes a ping with a numeric id (#418)` - numeric ids are never capped.
- Existing `classifyIncoming` tests cover the happy-path ping echo with normal ids.

## What I verified (static only)

- The new `send()` poll+write loop mirrors the existing `BufferedLineReader.readLine` pattern (same `poll` flag checks: POLLNVAL, POLLERR, POLLHUP, EINTR handling, deadline calculation).
- `sendAndReceive` deadline is computed before the first `send` call, so the write is included in the timeout budget.
- Ping reply inside `sendAndReceive` shares the same deadline.
- `sendLocked` (notification path) gets its own deadline from `timeoutMilliseconds`.
- `O_NONBLOCK` on the write-end fd does not affect the child process's stdin read-end.
- SIGPIPE is already ignored process-wide (`Sources/main.swift:57`), so `write(2)` returning EPIPE on a closed pipe is handled by the error path, not a signal.
- No new dependencies, no forbidden files touched.
- Swift 6 concurrency: no data races introduced. The new code runs under the existing `ioLock` serialization.
- Diff limited to `Sources/MCPClient.swift`, `Sources/Core/MCPProtocol.swift`, `Tests/apfelTests/MCPClientTests.swift`, `CHANGELOG.md`.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or build the project on this Linux cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- Integration tests from the issue's acceptance criteria (the reproduction peer, calculator happy path) need to be run locally and potentially added.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the repo owner's automated review tooling.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_018Lwubw3Y1SuvGct3fJYXLG

---
_Generated by [Claude Code](https://claude.ai/code/session_018Lwubw3Y1SuvGct3fJYXLG)_