### PR TITLE
fix(mcp): propagate remote initialized-notification failure (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Remote MCP handshake no longer silently swallows a failed `notifications/initialized` response (#432). The `try?` that discarded non-2xx status from the notification post is now `try`, matching the stdio transport. A remote server that rejects the notification correctly fails to attach instead of presenting broken tools to the model.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -279,7 +279,7 @@ actor RemoteMCPConnection: Sendable {
         do {
             let initResp = try await post(MCPProtocol.initializeRequest(id: allocId()))
             _ = try MCPProtocol.parseInitializeResponse(initResp)
-            _ = try? await post(MCPProtocol.initializedNotification())
+            _ = try await post(MCPProtocol.initializedNotification())
             let toolsResp = try await post(MCPProtocol.toolsListRequest(id: allocId()))
             self.tools = try MCPProtocol.parseToolsListResponse(toolsResp)
         } catch let error as MCPError {

--- a/Tests/integration/mcp_remote_test.py
+++ b/Tests/integration/mcp_remote_test.py
@@ -492,6 +492,119 @@ def test_unreachable_mcp_url_fails_gracefully():
 
 
 # ============================================================================
+# Fixtures: MCP server that rejects notifications/initialized (#432)
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def rejecting_initialized_mcp_port():
+    """HTTP MCP server that returns 503 for notifications/initialized."""
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class RejectInitializedHandler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass
+
+        def do_POST(self):
+            if self.path != "/mcp":
+                self.send_response(404)
+                self.end_headers()
+                return
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length)
+            try:
+                body = json.loads(raw)
+            except json.JSONDecodeError:
+                self.send_response(400)
+                self.end_headers()
+                return
+            method = body.get("method", "")
+            req_id = body.get("id")
+            if method == "initialize":
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "reject-test", "version": "1.0"},
+                    },
+                }
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(resp).encode())
+            elif method in ("notifications/initialized", "initialized"):
+                self.send_response(503)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error":"service unavailable"}')
+            elif method == "tools/list":
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "tools": [{
+                            "name": "dummy",
+                            "description": "dummy tool",
+                            "inputSchema": {"type": "object", "properties": {}},
+                        }],
+                    },
+                }
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(resp).encode())
+            else:
+                self.send_response(202)
+                self.end_headers()
+
+    port = find_free_port()
+    server = HTTPServer(("127.0.0.1", port), RejectInitializedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    if not _wait_for_port(port):
+        pytest.fail("Rejecting-initialized MCP server did not start in time")
+    yield port
+    server.shutdown()
+
+
+# ============================================================================
+# Tests: notifications/initialized rejection (#432)
+# ============================================================================
+
+
+def test_remote_rejecting_initialized_notification_fails(rejecting_initialized_mcp_port):
+    """A remote server returning 503 to notifications/initialized must not attach (#432).
+
+    Before the fix the try? on the notification post silently discarded
+    the error and apfel continued to tool discovery, attaching a server
+    whose handshake never completed."""
+    mcp_url = f"http://127.0.0.1:{rejecting_initialized_mcp_port}/mcp"
+    result = subprocess.run(
+        [
+            str(BINARY),
+            "--serve",
+            "--port",
+            str(find_free_port()),
+            "--mcp",
+            mcp_url,
+        ],
+        capture_output=True,
+        timeout=15,
+    )
+    assert result.returncode != 0, (
+        f"Expected non-zero exit when notifications/initialized is rejected\n"
+        f"stderr: {result.stderr.decode('utf-8', errors='replace')[:500]}"
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert any(x in stderr.lower() for x in ["503", "handshake", "failed", "mcp"]), (
+        f"Expected handshake failure indicator in stderr: {stderr[:500]}"
+    )
+
+
+# ============================================================================
 # Tests: mixed local stdio + remote HTTP MCP
 # ============================================================================
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #432.

## Root cause

The remote (Streamable HTTP) MCP handshake in `RemoteMCPConnection.init` used `try?` on the `post(MCPProtocol.initializedNotification())` call (line 282), silently discarding any error from the server. The stdio transport in `MCPConnection.init` used `try sendLocked(...)` on the same step (line 89), correctly propagating the failure. A remote server that rejected the notification with a non-2xx status was still attached and its tools presented to the model as ready, leading to tool-call failures that looked like model errors rather than a broken handshake.

## The fix

Changed `try?` to `try` on the single line in `RemoteMCPConnection.init`. The surrounding `do/catch` block already maps thrown errors to `MCPError.processError("Remote MCP handshake failed for \(urlString): \(error)")`, so the diagnostic path exists and the error message names the URL. A 202 response to the notification continues to work because `post` already normalises 202 to `"{}"` before returning.

## Test coverage

- Added `Tests/integration/mcp_remote_test.py:test_remote_rejecting_initialized_notification_fails` with an inline HTTP server fixture that returns 200 for `initialize`, 503 for `notifications/initialized`, and 200 for `tools/list`. Asserts apfel exits non-zero with a handshake-failure message in stderr.
- Existing `test_remote_mcp_apfel_healthy` and `test_remote_mcp_multiply_correct_result` confirm that a normal 202 notification response still works.

## What I verified (static only)

- The `try?` to `try` change is the only source modification.
- The surrounding `catch` block (lines 285-289) already converts thrown errors to `MCPError`, so no new error-handling code is needed.
- `post` returns `"{}"` for 202 responses and throws `MCPError.serverError` for non-2xx, so the only behavioral change is that non-2xx now propagates.
- Swift 6 concurrency: no data races introduced (actor isolation unchanged).
- Diff limited to `Sources/MCPClient.swift`, `Tests/integration/mcp_remote_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or the integration test suite. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the owner account and the reporter's analysis matched the code exactly.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCoPnNTBMnUMLeAncPFz4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCoPnNTBMnUMLeAncPFz4o)_