### PR TITLE
fix(mcp): propagate remote notifications/initialized failure (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Remote MCP handshake no longer swallows a failed `notifications/initialized` response (#432). The `try?` that silently discarded a non-2xx reply is now `try`, matching the stdio transport. A server that rejects the notification is no longer attached with tools the model would fail to call.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -279,7 +279,7 @@ actor RemoteMCPConnection: Sendable {
         do {
             let initResp = try await post(MCPProtocol.initializeRequest(id: allocId()))
             _ = try MCPProtocol.parseInitializeResponse(initResp)
-            _ = try? await post(MCPProtocol.initializedNotification())
+            _ = try await post(MCPProtocol.initializedNotification())
             let toolsResp = try await post(MCPProtocol.toolsListRequest(id: allocId()))
             self.tools = try MCPProtocol.parseToolsListResponse(toolsResp)
         } catch let error as MCPError {

--- a/Tests/integration/mcp_remote_test.py
+++ b/Tests/integration/mcp_remote_test.py
@@ -16,6 +16,7 @@ import socket
 import subprocess
 import sys
 import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import httpx
 import pytest
@@ -518,3 +519,116 @@ def test_mixed_mcp_tool_executes(apfel_mixed_mcp_url):
     assert data["choices"][0]["finish_reason"] == "stop"
     content = data["choices"][0]["message"]["content"]
     assert "144" in content, f"Expected '144' (12*12) in: {content}"
+
+
+# ============================================================================
+# Tests: notifications/initialized handshake consistency (#432)
+#
+# The remote transport must propagate a failed notifications/initialized the
+# same way the stdio transport does. A server that rejects the notification
+# has not finished initialising; apfel must not attach it.
+# ============================================================================
+
+
+class _RejectInitializedHandler(BaseHTTPRequestHandler):
+    """Stub MCP server: 200 for initialize, 503 for notifications/initialized,
+    200 for tools/list. Exercises the exact failure path from #432."""
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+        method = body.get("method", "")
+        req_id = body.get("id")
+
+        if method == "initialize":
+            resp = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "reject-stub", "version": "0.1"},
+                },
+            }
+            self._json_response(200, resp)
+        elif method in ("notifications/initialized", "initialized"):
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"initialized rejected"}')
+        elif method == "tools/list":
+            resp = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"tools": [{"name": "noop", "description": "no-op",
+                                       "inputSchema": {"type": "object", "properties": {}}}]},
+            }
+            self._json_response(200, resp)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _json_response(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+
+@pytest.fixture(scope="module")
+def reject_initialized_port():
+    """Start a stub MCP server that returns 503 for notifications/initialized."""
+    import threading
+
+    port = find_free_port()
+    server = HTTPServer(("127.0.0.1", port), _RejectInitializedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    if not _wait_for_port(port):
+        pytest.fail("reject-initialized stub server did not start in time")
+    yield port
+    server.shutdown()
+
+
+def test_remote_rejecting_initialized_notification_fails_to_attach(reject_initialized_port):
+    """A remote server that returns non-2xx to notifications/initialized must
+    cause a startup failure, not be silently attached (#432)."""
+    mcp_url = f"http://127.0.0.1:{reject_initialized_port}"
+    result = subprocess.run(
+        [
+            str(BINARY),
+            "--serve",
+            "--port",
+            str(find_free_port()),
+            "--mcp",
+            mcp_url,
+        ],
+        capture_output=True,
+        timeout=15,
+    )
+    assert result.returncode != 0, (
+        f"Expected non-zero exit when notifications/initialized is rejected\n"
+        f"stderr: {result.stderr.decode('utf-8', errors='replace')[:500]}"
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert any(x in stderr for x in ["503", "failed", "handshake", "MCP", "error"]), (
+        f"Expected error indicator in stderr: {stderr[:500]}"
+    )
+
+
+def test_remote_202_on_notification_still_attaches(apfel_remote_mcp_url):
+    """A 202 response to notifications/initialized is the normal success path
+    and must not regress when #432 tightens the error handling."""
+    base = apfel_remote_mcp_url.rsplit("/v1", 1)[0]
+    resp = httpx.get(f"{base}/health", timeout=10)
+    assert resp.status_code == 200
+    assert resp.json()["model_available"] is True


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #432.

## Summary

The remote (Streamable HTTP) MCP handshake used `try?` on the `notifications/initialized` post (`Sources/MCPClient.swift:282`), silently discarding any error. The stdio transport at line 89 uses `try`, propagating the failure. This meant a remote server that rejected the notification was still attached with tools the model would then fail to call - a silent fallback the project's principles rule out.

Changed `try?` to `try`. The surrounding `catch` block already maps thrown errors to `MCPError.processError("Remote MCP handshake failed for ...")`, so the diagnostic path exists and works. A 202 response (the normal success path) is already normalised to `"{}"` by `post()`, so servers that accept the notification with 202 keep working.

One-character source fix, two integration tests, one CHANGELOG entry.

## Root cause

`Sources/MCPClient.swift:282` - `_ = try? await post(MCPProtocol.initializedNotification())` swallowed the error from `post()`, which throws `MCPError.serverError` on non-2xx HTTP status codes. The stdio transport at line 89 uses `try sendLocked(MCPProtocol.initializedNotification())`, so the two transports disagreed on whether this step had to succeed.

## The fix

Changed `try?` to `try` on line 282 of `Sources/MCPClient.swift`. The error now propagates to the existing `catch` block at lines 285-289, which wraps it in `MCPError.processError` with the server URL - giving the user a clear diagnostic.

## Test coverage

- Added `Tests/integration/mcp_remote_test.py:test_remote_rejecting_initialized_notification_fails_to_attach` - starts a stub HTTP MCP server that returns 503 for `notifications/initialized`, verifies apfel exits non-zero with an error message.
- Added `Tests/integration/mcp_remote_test.py:test_remote_202_on_notification_still_attaches` - explicit regression guard that the normal 202 acceptance path still works after tightening the error handling.
- Existing `test_remote_mcp_apfel_healthy` still covers the happy path (the HTTP test server returns 202 for the notification).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/mcp_remote_test.py -v -k "rejecting_initialized or 202_on_notification"` (new tests)
- [ ] `python3 -m pytest Tests/integration/mcp_remote_test.py -v` (full remote MCP suite)

## What I verified (static only)

- The `post()` method already throws `MCPError.serverError` on non-2xx status codes (line 338-341).
- The `catch` block at lines 285-289 correctly re-throws `MCPError` and wraps other errors with the URL.
- 202 is handled at line 337 (`return "{}"`), before the non-2xx guard, so 202 keeps working.
- Swift 6 concurrency: no data races introduced (single-char change within an actor).
- Diff limited to `Sources/MCPClient.swift`, `CHANGELOG.md`, and `Tests/integration/mcp_remote_test.py` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the project's own automated review tooling from the `Arthur-Ficial` account.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZsDz8KqPYwmCAMfW4Yi9h

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZsDz8KqPYwmCAMfW4Yi9h)_