### PR TITLE
fix(mcp): propagate remote initialized-notification errors (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Remote MCP handshake now propagates errors from `notifications/initialized` instead of silently swallowing them via `try?` (#432). A remote server that rejects the notification correctly fails to attach, matching the stdio transport's behavior.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -279,7 +279,7 @@ actor RemoteMCPConnection: Sendable {
         do {
             let initResp = try await post(MCPProtocol.initializeRequest(id: allocId()))
             _ = try MCPProtocol.parseInitializeResponse(initResp)
-            _ = try? await post(MCPProtocol.initializedNotification())
+            _ = try await post(MCPProtocol.initializedNotification())
             let toolsResp = try await post(MCPProtocol.toolsListRequest(id: allocId()))
             self.tools = try MCPProtocol.parseToolsListResponse(toolsResp)
         } catch let error as MCPError {

--- a/Tests/integration/mcp_remote_test.py
+++ b/Tests/integration/mcp_remote_test.py
@@ -15,7 +15,9 @@ import pathlib
 import socket
 import subprocess
 import sys
+import threading
 import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import httpx
 import pytest
@@ -518,3 +520,134 @@ def test_mixed_mcp_tool_executes(apfel_mixed_mcp_url):
     assert data["choices"][0]["finish_reason"] == "stop"
     content = data["choices"][0]["message"]["content"]
     assert "144" in content, f"Expected '144' (12*12) in: {content}"
+
+
+# ============================================================================
+# Tests: notifications/initialized rejection (#432)
+#
+# A remote server that returns non-2xx to notifications/initialized has not
+# completed the MCP handshake. apfel must fail to attach, matching the stdio
+# transport's behavior (which propagates via `try`).
+# ============================================================================
+
+
+class _RejectInitializedHandler(BaseHTTPRequestHandler):
+    """Minimal MCP server that accepts initialize but rejects notifications/initialized."""
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+        method = body.get("method", "")
+        req_id = body.get("id")
+        if method == "initialize":
+            resp = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "reject-test", "version": "1.0"},
+                },
+            }
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(resp).encode())
+        elif method in ("notifications/initialized", "initialized"):
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"service unavailable"}')
+        elif method == "tools/list":
+            resp = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"tools": [{"name": "noop", "description": "no-op", "inputSchema": {"type": "object", "properties": {}}}]},
+            }
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(resp).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_DELETE(self):
+        self.send_response(200)
+        self.end_headers()
+
+
+@pytest.fixture(scope="module")
+def reject_initialized_port():
+    """Start a mock MCP server that rejects notifications/initialized with 503."""
+    if not BINARY.exists():
+        pytest.skip(f"apfel binary not found at {BINARY}")
+    port = find_free_port()
+    server = HTTPServer(("127.0.0.1", port), _RejectInitializedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    if not _wait_for_port(port, timeout=5):
+        pytest.fail("Reject-initialized mock server did not start")
+    yield port
+    server.shutdown()
+
+
+def test_remote_rejecting_initialized_notification_fails_to_attach(reject_initialized_port):
+    """A remote server returning 503 to notifications/initialized must cause a non-zero exit (#432)."""
+    mcp_url = f"http://127.0.0.1:{reject_initialized_port}/mcp"
+    result = subprocess.run(
+        [
+            str(BINARY),
+            "--serve",
+            "--port",
+            str(find_free_port()),
+            "--mcp",
+            mcp_url,
+        ],
+        capture_output=True,
+        timeout=15,
+    )
+    assert result.returncode != 0, (
+        f"Expected non-zero exit when notifications/initialized is rejected\nstderr: {result.stderr}"
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert any(x in stderr for x in ["503", "handshake", "failed", "HTTP", "MCP"]), (
+        f"Expected handshake error in stderr: {stderr[:500]}"
+    )
+
+
+def test_remote_and_stdio_agree_on_handshake_failure(reject_initialized_port):
+    """Both transports must fail when the handshake is incomplete (#432).
+
+    The remote transport is tested via the reject-initialized fixture above.
+    The stdio transport fails on any sendLocked error (already covered by
+    existing tests via broken-pipe and unreachable scenarios). This test
+    verifies the remote path exits with a diagnostic naming the URL.
+    """
+    mcp_url = f"http://127.0.0.1:{reject_initialized_port}/mcp"
+    result = subprocess.run(
+        [
+            str(BINARY),
+            "test prompt",
+            "--mcp",
+            mcp_url,
+        ],
+        capture_output=True,
+        timeout=15,
+    )
+    assert result.returncode != 0, (
+        f"Expected non-zero exit for rejected initialized notification\nstderr: {result.stderr}"
+    )
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert "127.0.0.1" in stderr, (
+        f"Error message must name the URL: {stderr[:500]}"
+    )


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #432.

## Summary

The remote (Streamable HTTP) MCP transport silently swallowed errors from posting `notifications/initialized` via `try?` (`Sources/MCPClient.swift:282`), while the stdio transport propagated them via `try` (`Sources/MCPClient.swift:89`). A remote server that rejected the notification was still attached with tools the model would then fail to call - the exact kind of silent fallback the project's principles rule out.

**Root cause:** a single `try?` on line 282 that should have been `try`. The surrounding `catch` block at lines 285-289 already maps thrown errors to `MCPError.processError("Remote MCP handshake failed for \(urlString): \(error)")`, so the diagnostic path exists - it was just unreachable for this specific failure.

**The fix:** change `try?` to `try` (one character). The `post()` method already normalizes HTTP 202 responses to `"{}"` (line 337), so servers that accept the notification with 202 keep working. Only non-2xx responses now correctly propagate as errors.

## Test coverage

- Added `Tests/integration/mcp_remote_test.py:test_remote_rejecting_initialized_notification_fails_to_attach` - a mock MCP server returns 503 to `notifications/initialized`; verifies apfel exits non-zero with a diagnostic message.
- Added `Tests/integration/mcp_remote_test.py:test_remote_and_stdio_agree_on_handshake_failure` - verifies the remote transport fails with a diagnostic naming the URL when the notification is rejected (single-query mode).
- Added `_RejectInitializedHandler` inline mock server and `reject_initialized_port` fixture, following the existing conftest/fixture pattern.
- Existing `test_remote_mcp_apfel_healthy` and all other remote MCP tests cover the happy path (202 response to notification).

## What I verified (static only)

- The `try?` to `try` change is the only production code modification.
- `post()` returns `"{}"` for HTTP 202 (line 337), so the 202 acceptance path is unaffected.
- The `catch let error as MCPError` / `catch` blocks (lines 285-289) already produce the right diagnostic message.
- Swift 6 concurrency: no data races introduced (no new mutable state, no new `@unchecked Sendable`).
- Diff limited to `Sources/MCPClient.swift`, `Tests/integration/mcp_remote_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue body's suggested fix matches what I independently determined as the correct change.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full integration suite on a Mac with Apple Intelligence)

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTtPWDRMArfnkGFRbR1yoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTtPWDRMArfnkGFRbR1yoD)_