### PR TITLE
fix(mcp): move blocking stdio I/O off cooperative pool (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AnyMCPConnection.callTool` no longer blocks the cooperative thread pool during stdio I/O (#431). `Task.detached` only drops context inheritance, not the executor; the blocking `poll`/`read` in `sendAndReceive` now runs on a real GCD thread via `DispatchQueue.global(qos: .userInitiated)`.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -14,9 +14,10 @@ private let mcpShutdownGraceSeconds: TimeInterval = 2.0
 /// A connection to a single MCP server process (stdio transport).
 ///
 /// Thread safety (justifying `@unchecked Sendable`): in `--serve` mode,
-/// `AnyMCPConnection.callTool` runs this connection's blocking stdio I/O via
-/// `Task.detached`, so concurrent requests reach one instance from multiple
-/// threads. All mutable state is confined behind locks: `nextId` is guarded by
+/// `AnyMCPConnection.callTool` runs this connection's blocking stdio I/O on
+/// a GCD thread via `DispatchQueue.global()` (#431), so concurrent requests
+/// reach one instance from multiple threads. All mutable state is confined
+/// behind locks: `nextId` is guarded by
 /// `lock` (`allocId()`), and every wire exchange - the full send+receive pair
 /// in `sendAndReceive` and standalone notification writes via `sendLocked` -
 /// is serialized by `ioLock`, so two concurrent tool calls can neither
@@ -384,8 +385,20 @@ enum AnyMCPConnection: Sendable {
     func callTool(name: String, arguments: String) async throws -> MCPProtocol.ToolCallResult {
         switch self {
         case .local(let c):
-            // Run blocking stdio I/O off the cooperative thread pool
-            return try await Task.detached { try c.callTool(name: name, arguments: arguments) }.value
+            // Run blocking stdio I/O on a real GCD thread (#431).
+            // Task.detached only drops context inheritance (priority,
+            // task-locals, cancellation) - it does NOT leave the cooperative
+            // pool, so the synchronous poll/read in sendAndReceive would
+            // park a cooperative worker for the entire exchange.
+            return try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        continuation.resume(returning: try c.callTool(name: name, arguments: arguments))
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
         case .remote(let c):
             return try await c.callTool(name: name, arguments: arguments)
         }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -506,6 +506,55 @@ func runMCPClientTests() {
         try assertEqual("\(err)", "Tool 'x' arguments are not valid JSON")
     }
 
+    // MARK: - GCD dispatch for blocking stdio I/O (#431)
+    // Task.detached does not leave the cooperative pool; blocking I/O must
+    // run on a real GCD thread so it does not stall unrelated async work.
+
+    testAsync("GCD dispatch propagates tool call results (#431)") {
+        let result: String = try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: "tool-result-42")
+            }
+        }
+        try assertEqual(result, "tool-result-42")
+    }
+
+    testAsync("GCD dispatch propagates errors from blocking work (#431)") {
+        do {
+            let _: String = try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(throwing: MCPError.timedOut("tool 'slow' timed out after 5s"))
+                }
+            }
+            throw TestFailure("expected error to propagate")
+        } catch let e as MCPError {
+            guard case .timedOut(let msg) = e else {
+                throw TestFailure("expected MCPError.timedOut, got \(e)")
+            }
+            try assertTrue(msg.contains("timed out"))
+        }
+    }
+
+    testAsync("concurrent async work is not blocked by GCD dispatch (#431)") {
+        let blockingWork = Task {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    Thread.sleep(forTimeInterval: 0.3)
+                    continuation.resume()
+                }
+            }
+        }
+
+        let start = Date()
+        let heartbeat = await Task { "alive" }.value
+        let elapsed = Date().timeIntervalSince(start)
+
+        try assertEqual(heartbeat, "alive")
+        try assertTrue(elapsed < 0.15, "cooperative task delayed \(elapsed)s by GCD-dispatched work")
+
+        try await blockingWork.value
+    }
+
     test("Tool call detection works on object-argument format from #144 report") {
         // The #144 reporter showed the model producing arguments as a JSON object
         // (not an escaped string). Detection must handle both forms.


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #431.

## Root cause

`AnyMCPConnection.callTool` wrapped the blocking stdio I/O in `Task.detached`, with a comment saying it runs "off the cooperative thread pool". But `Task.detached` does not change the executor - it only drops context inheritance (priority, task-locals, cancellation). The synchronous `sendAndReceive` call, which holds `ioLock` and blocks in POSIX `poll`/`read` via `BufferedLineReader.readLine`, was parking a cooperative worker thread for the entire MCP exchange. With the cooperative pool constrained (one thread per core), this stalls unrelated `async` work - including other HTTP requests in `--serve` mode.

## The fix

Replaced `Task.detached { ... }.value` with `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .userInitiated).async` so the blocking call runs on a real GCD thread, not a cooperative worker. `MCPConnection` is already serialised internally by `ioLock`, so moving the call site to a Dispatch queue does not change its concurrency contract. Also updated the `@unchecked Sendable` justification comment on `MCPConnection` that referenced `Task.detached`.

## Test coverage

- Added three `testAsync` tests to `Tests/apfelTests/MCPClientTests.swift`:
  - `GCD dispatch propagates tool call results (#431)` - verifies the continuation pattern correctly returns results.
  - `GCD dispatch propagates errors from blocking work (#431)` - verifies `MCPError.timedOut` propagates through the GCD path.
  - `concurrent async work is not blocked by GCD dispatch (#431)` - verifies a cooperative task completes on schedule while a 300ms blocking operation runs on GCD.
- Existing MCP protocol tests cover the happy path for tool call formatting and parsing.

## What I verified (static only)

- Read `MCPClient.swift` end-to-end: `MCPConnection`, `RemoteMCPConnection`, `AnyMCPConnection`, `MCPManager`.
- Read `BufferedLineReader.swift` to confirm the blocking `poll`/`read` path.
- Confirmed `MCPConnection.ioLock` serialisation is unchanged - the GCD dispatch does not alter the internal concurrency contract.
- Confirmed the `.remote` path is unaffected (already uses `async`/`await` with `URLSession`).
- Swift 6 concurrency: no data races introduced. `MCPConnection` is already `@unchecked Sendable` with lock-based safety; the `DispatchQueue.global().async` closure captures `c` (the `MCPConnection` instance, which is `Sendable`) and `continuation` (also `Sendable`).
- Diff limited to `Sources/MCPClient.swift`, `Tests/apfelTests/MCPClientTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- CHANGELOG `[Unreleased]` entry added per changelog-gate policy (#369).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or the Swift compiler. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- Full reproduction with `SWIFT_MAX_CONCURRENCY=1` and a slow MCP fixture (requires a running apfel binary).
- The `shutdown()` and `shutdownAndWait()` methods also call blocking `MCPConnection.shutdown()` on the cooperative pool. These are one-shot lifecycle events (not the hot path), so they are left as-is. A follow-up could apply the same GCD pattern there if desired.

## Anything that seemed suspicious

Nothing - straightforward concurrency bug with a well-documented fix pattern.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgNgtzsfh88ydbm4DgDnfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgNgtzsfh88ydbm4DgDnfQ)_