### PR TITLE
fix(cli): read pipe before waitUntilExit and return nil on failure (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `shellOutput` now reads the child's stdout before `waitUntilExit()`, preventing a deadlock when output exceeds the OS pipe buffer. Launch failures and non-zero exit codes return `nil` instead of an empty string so callers can distinguish failure from empty output (#433).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -715,8 +715,8 @@ func performUpdate() {
     }
 
     // Check for updates via brew
-    let outdatedJSON = shellOutput(brewExec, args: ["info", "--json=v2", "apfel"])
-    guard let data = outdatedJSON.data(using: .utf8),
+    guard let outdatedJSON = shellOutput(brewExec, args: ["info", "--json=v2", "apfel"]),
+          let data = outdatedJSON.data(using: .utf8),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
           let formulae = json["formulae"] as? [[String: Any]],
           let formula = formulae.first,
@@ -751,8 +751,11 @@ func performUpdate() {
     print(styled("Running: brew upgrade apfel", .dim))
     let result = shellPassthrough(brewExec, args: ["upgrade", "apfel"])
     if result == 0 {
-        let newVersion = shellOutput(apfelExec, args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
-        print(styled("Updated to \(newVersion)", .green))
+        if let newVersion = shellOutput(apfelExec, args: ["--version"])?.trimmingCharacters(in: .whitespacesAndNewlines) {
+            print(styled("Updated to \(newVersion)", .green))
+        } else {
+            print(styled("Upgrade succeeded.", .green))
+        }
     } else {
         printError("brew upgrade failed (exit \(result)). Try manually: brew upgrade apfel")
     }
@@ -769,23 +772,6 @@ private func findExecutableInPath(_ name: String) -> String? {
         if fm.isExecutableFile(atPath: candidate) { return candidate }
     }
     return nil
-}
-
-/// Run a command and capture stdout.
-private func shellOutput(_ executable: String, args: [String]) -> String {
-    let proc = Process()
-    let pipe = Pipe()
-    proc.executableURL = URL(fileURLWithPath: executable)
-    proc.arguments = args
-    proc.standardOutput = pipe
-    proc.standardError = FileHandle.nullDevice
-    do {
-        try proc.run()
-        proc.waitUntilExit()
-    } catch {
-        return ""
-    }
-    return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
 }
 
 /// Run a command with stdout/stderr passed through to the terminal.

--- a/Sources/CLI/ShellOutput.swift
+++ b/Sources/CLI/ShellOutput.swift
@@ -1,0 +1,28 @@
+// ============================================================================
+// ShellOutput.swift - Run a subprocess and capture its stdout.
+//
+// Reads the pipe before waitUntilExit() to avoid deadlocking when the child
+// writes more than the OS pipe buffer (typically 64 KiB). Returns nil when
+// the command cannot be launched or exits non-zero so callers can distinguish
+// failure from empty output (#433).
+// ============================================================================
+
+import Foundation
+
+public func shellOutput(_ executable: String, args: [String]) -> String? {
+    let proc = Process()
+    let pipe = Pipe()
+    proc.executableURL = URL(fileURLWithPath: executable)
+    proc.arguments = args
+    proc.standardOutput = pipe
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+    } catch {
+        return nil
+    }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+    guard proc.terminationStatus == 0 else { return nil }
+    return String(data: data, encoding: .utf8)
+}

--- a/Tests/apfelTests/ShellOutputTests.swift
+++ b/Tests/apfelTests/ShellOutputTests.swift
@@ -1,0 +1,46 @@
+// ============================================================================
+// ShellOutputTests.swift - Unit tests for shellOutput() (#433)
+//
+// Verifies the pipe-before-wait ordering, non-zero exit handling, and
+// missing-executable handling that the old private helper got wrong.
+// ============================================================================
+
+import Foundation
+import ApfelCLI
+
+func runShellOutputTests() {
+
+    test("shellOutput returns stdout of a successful command") {
+        let result = shellOutput("/bin/echo", args: ["hello"])
+        try assertEqual(result, "hello\n")
+    }
+
+    test("shellOutput returns nil for a missing executable") {
+        let result = shellOutput("/nonexistent/path/to/binary", args: [])
+        try assertNil(result, "missing executable should return nil, not empty string")
+    }
+
+    test("shellOutput returns nil for a non-zero exit status") {
+        let result = shellOutput("/usr/bin/false", args: [])
+        try assertNil(result, "non-zero exit should return nil, not empty string")
+    }
+
+    test("shellOutput returns empty string for a command that produces no output") {
+        let result = shellOutput("/usr/bin/true", args: [])
+        try assertEqual(result, "", "successful empty output should be empty string, not nil")
+    }
+
+    test("shellOutput handles large output without deadlocking") {
+        // Write 256 KiB via dd - well above the typical 64 KiB pipe buffer.
+        // The old implementation would deadlock here because it called
+        // waitUntilExit() before reading the pipe.
+        let result = shellOutput("/bin/dd", args: ["if=/dev/zero", "bs=1024", "count=256", "status=none"])
+        try assertNotNil(result, "large output must not deadlock")
+        try assertEqual(result!.utf8.count, 256 * 1024, "expected 256 KiB of output")
+    }
+
+    test("shellOutput returns nil when executable exists but is not executable") {
+        let result = shellOutput("/dev/null", args: [])
+        try assertNil(result, "non-executable path should return nil")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -129,6 +129,7 @@ suite("MessagesFlagTests") { runMessagesFlagTests() }
 suite("CodeFlagTests") { runCodeFlagTests() }
 suite("PrewarmDecisionTests") { runPrewarmDecisionTests() }
 suite("ResponsesModelsTests") { runResponsesModelsTests() }
+suite("ShellOutputTests") { runShellOutputTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #433.

## Summary

`shellOutput` read the child's stdout **after** `waitUntilExit()`. When a child writes more than the OS pipe buffer (typically 64 KiB), the child blocks in `write(2)` waiting for the parent to read, and the parent blocks in `waitUntilExit()` waiting for the child to exit - a classic deadlock. The same helper swallowed launch errors and non-zero exit codes as empty strings, making every failure indistinguishable from successful empty output.

## Root cause

The ordering in `shellOutput` was: `run()` -> `waitUntilExit()` -> `readDataToEndOfFile()`. The pipe must be drained before waiting. Additionally, `catch { return "" }` and no `terminationStatus` check collapsed three distinct outcomes (launch failure, non-zero exit, successful empty output) into one.

## The fix

- Extracted `shellOutput` from a private function in `Sources/CLI.swift` to a public function in `Sources/CLI/ShellOutput.swift` (the `ApfelCLI` module) so it is unit-testable.
- Changed return type from `String` to `String?` - `nil` means the command could not be launched or exited non-zero.
- Reads `pipe.fileHandleForReading.readDataToEndOfFile()` **before** `proc.waitUntilExit()`.
- Checks `proc.terminationStatus == 0` before returning the output.
- Updated both call sites in `Sources/CLI.swift`:
  - Line 718 (`brew info`): `guard let` naturally falls through to the "Could not check for updates" branch.
  - Line 754 (`apfel --version`): handles `nil` with a generic "Upgrade succeeded." message instead of displaying an empty version.

## Test coverage

- Added `Tests/apfelTests/ShellOutputTests.swift` with 6 tests:
  - `testShellOutputReturnsStdoutOfSuccessfulCommand`
  - `testShellOutputReturnsNilForMissingExecutable`
  - `testShellOutputReturnsNilForNonZeroExitStatus`
  - `testShellOutputReturnsEmptyStringForNoOutput` (distinguishes from nil)
  - `testShellOutputHandlesLargeOutputWithoutDeadlocking` (256 KiB via dd)
  - `testShellOutputReturnsNilWhenExecutableIsNotExecutable`
- Registered the suite in `Tests/apfelTests/main.swift`.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Pipe-before-wait ordering is correct in the new implementation.
- Both call sites handle the `String?` return cleanly.
- No new dependencies, no changes to `Package.swift`.
- No touches to `.version`, `BuildInfo.swift`, CI workflows, or release scripts.
- Swift 6 concurrency: no data races introduced - `shellOutput` is a synchronous free function with no shared mutable state.
- CHANGELOG `[Unreleased]` entry added.
- Diff limited to `Sources/CLI/ShellOutput.swift`, `Sources/CLI.swift`, `Tests/apfelTests/ShellOutputTests.swift`, `Tests/apfelTests/main.swift`, `CHANGELOG.md`.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or the Swift compiler on this Linux runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a well-documented root cause. The issue was filed by the repo owner.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01VV9DLXkPMDZndZFbfxLTgC

---
_Generated by [Claude Code](https://claude.ai/code/session_01VV9DLXkPMDZndZFbfxLTgC)_