### PR TITLE
fix(mcp): dispatch blocking stdio I/O to DispatchQueue.global (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Blocking MCP stdio I/O no longer parks a cooperative-pool thread (#431). `AnyMCPConnection.callTool` dispatches the blocking `sendAndReceive` call to `DispatchQueue.global()` instead of `Task.detached`, which does not leave the cooperative executor.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/MCPClient.swift
+++ b/Sources/MCPClient.swift
@@ -14,8 +14,8 @@ private let mcpShutdownGraceSeconds: TimeInterval = 2.0
 /// A connection to a single MCP server process (stdio transport).
 ///
 /// Thread safety (justifying `@unchecked Sendable`): in `--serve` mode,
-/// `AnyMCPConnection.callTool` runs this connection's blocking stdio I/O via
-/// `Task.detached`, so concurrent requests reach one instance from multiple
+/// `AnyMCPConnection.callTool` dispatches this connection's blocking stdio
+/// I/O to `DispatchQueue.global()`, so concurrent requests reach one instance from multiple
 /// threads. All mutable state is confined behind locks: `nextId` is guarded by
 /// `lock` (`allocId()`), and every wire exchange - the full send+receive pair
 /// in `sendAndReceive` and standalone notification writes via `sendLocked` -
@@ -384,8 +384,15 @@ enum AnyMCPConnection: Sendable {
     func callTool(name: String, arguments: String) async throws -> MCPProtocol.ToolCallResult {
         switch self {
         case .local(let c):
-            // Run blocking stdio I/O off the cooperative thread pool
-            return try await Task.detached { try c.callTool(name: name, arguments: arguments) }.value
+            return try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        continuation.resume(returning: try c.callTool(name: name, arguments: arguments))
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
         case .remote(let c):
             return try await c.callTool(name: name, arguments: arguments)
         }

--- a/Tests/apfelTests/MCPClientTests.swift
+++ b/Tests/apfelTests/MCPClientTests.swift
@@ -517,4 +517,33 @@ func runMCPClientTests() {
         try assertEqual(calls!.first?.id, "call_001")
         try assertTrue(calls!.first!.argumentsString.contains("CLAUDE.md"), "arguments must contain the file path")
     }
+
+    // MARK: - Cooperative-pool starvation fix (#431)
+    // Task.detached does not leave the cooperative pool; blocking stdio I/O
+    // must be dispatched to DispatchQueue.global() instead.
+
+    testAsync("DispatchQueue.global continuation propagates tool results (#431)") {
+        let result: String = try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: "20501")
+            }
+        }
+        try assertEqual(result, "20501")
+    }
+
+    testAsync("DispatchQueue.global continuation propagates errors (#431)") {
+        do {
+            let _: String = try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(throwing: MCPError.timedOut("tool 'slow' timed out after 5s"))
+                }
+            }
+            throw TestFailure("expected MCPError.timedOut to propagate through continuation")
+        } catch let e as MCPError {
+            guard case .timedOut(let msg) = e else {
+                throw TestFailure("expected .timedOut, got \(e)")
+            }
+            try assertTrue(msg.contains("slow"), "message must preserve tool name: \(msg)")
+        }
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #431.

## Summary

`AnyMCPConnection.callTool` used `Task.detached` to run blocking MCP stdio I/O, but `Task.detached` does not leave the cooperative thread pool - it only changes context inheritance (priority, task-locals, cancellation). The blocking `sendAndReceive` call (which holds `ioLock` and blocks in `poll`/`read` via `BufferedLineReader`) was parking a cooperative worker for the entire exchange, starving unrelated `async` work - including other HTTP requests in `--serve` mode.

Replaced with `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .userInitiated)` so the blocking I/O runs on a real GCD thread. `MCPConnection` is already serialised internally by `ioLock`, so moving the call to a Dispatch queue does not change its concurrency contract.

## Root cause

`Task.detached` creates an unstructured task that still runs on Swift's cooperative executor. The comment at `MCPClient.swift:387` said "Run blocking stdio I/O off the cooperative thread pool", but `Task.detached` never provided that guarantee. Every in-flight stdio tool call was occupying one of the cooperative pool's threads (one per core) for up to `--mcp-timeout` seconds.

## The fix

- `AnyMCPConnection.callTool` (`.local` case): `Task.detached { ... }.value` replaced with `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .userInitiated).async`
- `MCPConnection` class doc updated to reflect `DispatchQueue.global()` instead of `Task.detached`
- `CHANGELOG.md` `[Unreleased]` entry added

## Test coverage

- Added `MCPClientTests.swift`: "DispatchQueue.global continuation propagates tool results (#431)" - verifies the dispatch-to-continuation bridge returns results correctly.
- Added `MCPClientTests.swift`: "DispatchQueue.global continuation propagates errors (#431)" - verifies errors propagate through the continuation without being swallowed.
- Existing tests cover the happy path for protocol formatting, parsing, and tool-call detection.

## What I verified (static only)

- Diff is limited to `Sources/MCPClient.swift`, `Tests/apfelTests/MCPClientTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced. `MCPConnection` is already `@unchecked Sendable` with all mutable state behind `NSLock`/`ioLock`; the fix moves the call site, not the synchronisation.
- `withCheckedThrowingContinuation` has runtime assertions that the continuation is resumed exactly once - safer than the unsafe variant.
- Cancellation behaviour is unchanged: `Task.detached` did not propagate parent cancellation to the blocking call, and `DispatchQueue.global()` does not either.
- The `shutdown()` and `shutdownAndWait()` methods on `AnyMCPConnection` also call blocking code synchronously, but those run on the deregister/exit path (not the per-request hot path). Left for a follow-up if needed.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- Behavioural verification (heartbeat-under-load timing test) requires constraining the cooperative pool (`LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`) which only works on macOS with a running binary.

## Anything that seemed suspicious

Nothing - straightforward concurrency bug. The issue body included a proposed fix that used the same pattern; I wrote my own version independently after verifying the root cause.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ2y52zw14upZZTP8aYRcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZ2y52zw14upZZTP8aYRcA)_