### PR TITLE
fix(tests): remove incorrect model marker from permit-leak suite (#434)

### DIFF
--- a/Tests/integration/test_marker_discipline.py
+++ b/Tests/integration/test_marker_discipline.py
@@ -19,7 +19,6 @@ MODEL_SUITES = [
     "mcp_remote_test.py",
     "openapi_conformance_test.py",
     "performance_test.py",
-    "test_stream_permit_release.py",
     "test_context_strict.py",
     "test_tdd_red.py",
 ]

--- a/Tests/integration/test_stream_permit_release.py
+++ b/Tests/integration/test_stream_permit_release.py
@@ -17,12 +17,6 @@ Run: python3 -m pytest Tests/integration/test_stream_permit_release.py -v
 import httpx
 import pytest
 
-# Whole-suite marker: these tests drive real on-device generation (or, for
-# the permit/benchmark suites, need Apple Intelligence up); GitHub CI cannot
-# run them (CLAUDE.md "What GitHub CI CANNOT run"). Keeps -m "not model" a
-# complete, correct model-free selector for the fast preflight phase (#374).
-pytestmark = pytest.mark.model
-
 
 BASE_URL = "http://localhost:11434"
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #434.

## Root cause

`Tests/integration/test_stream_permit_release.py` carries a whole-suite `pytestmark = pytest.mark.model`, but none of its three tests touch the model. Every request sends deliberately invalid payloads (`messages: []`, missing `json_schema.schema`) that fail `ChatRequestValidator` and return 400 before a `LanguageModelSession` is ever constructed. The file's own docstring already says "Model-free: every request here fails with 400 before touching the model." The marker contradicts this, and CI's `-m "not model"` filter silently excludes all three tests. The file is also absent from the CI workflow's model-free HTTP server step file list. Together, the #213 DoS permit-leak regression guard has never run on the per-PR gate.

## The fix

Removes the `pytestmark = pytest.mark.model` line (and its now-inaccurate comment) from `test_stream_permit_release.py`, and removes the file from `MODEL_SUITES` in `test_marker_discipline.py` so the discipline test stays green.

**Important: this PR is half of the full fix.** The CI workflow (`.github/workflows/ci.yml`) also needs `test_stream_permit_release.py` added to the model-free HTTP server suites step (lines 114-118), alongside the existing three files. That change is release infrastructure and outside the scope of what the bug-solver routine is allowed to touch - Franz, please add it when landing this. The diff would be:

```yaml
          APFEL_MODELFREE_ONLY=1 python3 -m pytest \
            Tests/integration/security_test.py \
            Tests/integration/openapi_spec_test.py \
            Tests/integration/server_validation_test.py \
            Tests/integration/test_stream_permit_release.py \
            -m "not model" -n auto --dist loadfile -v --tb=short || STATUS=$?
```

The comment above that block ("these three suites") would also need updating to "these four suites", and CLAUDE.md's model-free test count would go from 182 to 185 (and total CI from 1221 to 1224).

## Test coverage

- No new tests needed - the three existing tests in `test_stream_permit_release.py` are the regression guard. The fix is about making them run where they should.
- `test_marker_discipline.py::test_model_suites_carry_module_pytestmark` updated to no longer expect `test_stream_permit_release.py` in the model-suite list.

## What I verified (static only)

- Read every line of `test_stream_permit_release.py` - confirmed all three tests send validation-failing payloads and assert on status codes and `/health` counters, with no model dependency.
- Read `test_marker_discipline.py` - confirmed removing the file from `MODEL_SUITES` is the only change needed for the discipline tests to stay green.
- Checked the other MODEL_SUITES files for similar misclassification. Found `test_tdd_red.py` has the same problem (6 of 12 tests are model-free, including some that explicitly document "MODEL-FREE" in their docstrings). Filed as a follow-up note below rather than widening this PR.
- Diff is limited to two test files. No touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: not applicable (Python test files only).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. The marker removal should be transparent to the local test suite (tests still run, just in the model-free phase of `make preflight` instead of the model phase).

## Follow-up finding

`test_tdd_red.py` has the same class of problem: 6 of its 12 tests are model-free (source-level guards reading `.swift` files, a `/health` check, a schema validation 400, and a literal `pass` body), but the whole-suite `pytestmark = pytest.mark.model` excludes all of them from CI. That file needs per-test `@pytest.mark.model` on the 6 tests that actually need the model, rather than a whole-suite marker. Recommend a separate issue/PR for that.

## Anything that seemed suspicious

Nothing - straightforward test classification bug. The issue body is well-structured and matches what I found in the code.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready. The CI workflow change (adding the file to the model-free HTTP server step) needs to land alongside or after this.

_Generated by the apfel bug-solver routine._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6pDuQJDWjcU3KWDm7UyZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6pDuQJDWjcU3KWDm7UyZr)_