### PR TITLE
fix(tests): remove wrong model marker from #213 permit-leak tests (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The three #213 permit-leak regression tests (`test_stream_permit_release.py`) are no longer marked `@pytest.mark.model` (#434). Every request in the suite fails validation at 400 before a `LanguageModelSession` is constructed, so the marker was wrong - these are model-free tests that belong in the per-PR CI gate.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Tests/integration/test_marker_discipline.py
+++ b/Tests/integration/test_marker_discipline.py
@@ -19,7 +19,6 @@ MODEL_SUITES = [
     "mcp_remote_test.py",
     "openapi_conformance_test.py",
     "performance_test.py",
-    "test_stream_permit_release.py",
     "test_context_strict.py",
     "test_tdd_red.py",
 ]

--- a/Tests/integration/test_stream_permit_release.py
+++ b/Tests/integration/test_stream_permit_release.py
@@ -17,11 +17,10 @@ Run: python3 -m pytest Tests/integration/test_stream_permit_release.py -v
 import httpx
 import pytest
 
-# Whole-suite marker: these tests drive real on-device generation (or, for
-# the permit/benchmark suites, need Apple Intelligence up); GitHub CI cannot
-# run them (CLAUDE.md "What GitHub CI CANNOT run"). Keeps -m "not model" a
-# complete, correct model-free selector for the fast preflight phase (#374).
-pytestmark = pytest.mark.model
+# NOT marked `model`: every request here fails validation and returns 400
+# before a LanguageModelSession is built, so these run on GitHub runners
+# without Apple Intelligence.  They guard the #213 permit leak - exactly
+# the kind of regression the per-PR gate should catch.
 
 
 BASE_URL = "http://localhost:11434"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #434.

## Summary

The three regression tests in `test_stream_permit_release.py` that guard the #213 concurrency-permit leak carry `pytestmark = pytest.mark.model`, but none of them touch the model. Every request fails `ChatRequestValidator` at 400 before a `LanguageModelSession` is constructed. The module-level marker excludes them from `-m \"not model\"`, and the file is not listed in the CI workflow's model-free HTTP server job either, so these tests have never run on GitHub CI.

This PR removes the marker and updates `test_marker_discipline.py` to match. CHANGELOG entry added.

## Root cause

The marker was copy-pasted from the template used for suites that drive real generation. The file's own docstring (line 11: \"Model-free: every request here fails with 400 before touching the model\") contradicts the marker on line 24, but no one noticed because the marker-discipline test in `test_marker_discipline.py` was written to assert the (wrong) status quo.

## The fix

- Removed `pytestmark = pytest.mark.model` from `test_stream_permit_release.py`, replaced with a comment explaining why it is NOT marked.
- Removed `\"test_stream_permit_release.py\"` from `MODEL_SUITES` in `test_marker_discipline.py`.
- Added `[Unreleased]` CHANGELOG entry.

## What Franz still needs to do

This PR does **not** touch `.github/workflows/ci.yml` (auto-drafted PRs must not modify workflow files). Before or at merge, Franz should:

1. Add `Tests/integration/test_stream_permit_release.py \\` to the model-free HTTP server job in `.github/workflows/ci.yml` (after line 117, alongside the existing three suites).
2. Update the comment on line 113 from \"these three suites\" to \"these four suites\".
3. Update the model-free test counts in `CLAUDE.md` (182 -> 185, 1221 -> 1224, 295 -> 292) and add `test_stream_permit_release.py` (3) to the descriptive list on line 370.

## Test coverage

- No new tests needed - this is about running the three that already exist.
- `test_marker_discipline.py::test_model_suites_carry_module_pytestmark` will pass once `test_stream_permit_release.py` is removed from `MODEL_SUITES` (and would fail without this change).
- The three permit-leak tests themselves (`test_validation_failing_streaming_requests_release_permits`, `test_json_schema_failing_streaming_requests_release_permits`, `test_server_still_answers_after_early_failing_streams`) continue to work - they only need the server running, not Apple Intelligence.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` locally to confirm all 477 integration tests still pass with 0 skipped

## What I verified (static only)

- Read and confirmed all three tests in `test_stream_permit_release.py` send payloads that fail validation before model invocation.
- Confirmed no other suite in `MODEL_SUITES` is wholly mismarked (agent checked all 7 remaining files).
- Diff limited to `test_stream_permit_release.py`, `test_marker_discipline.py`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced (Python test files only).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the marker removal causes unexpected side effects in the test runner, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward marker misclassification. The issue was filed by the project owner (`Arthur-Ficial`). The suggested fix in the issue body matches the independent analysis.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready. The CI workflow change (`ci.yml`) and CLAUDE.md count updates are listed above for you to land alongside this.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EtQ2Yz7LjGkjgwEzGQWhm"}
</invoke>

---
_Generated by [Claude Code](https://claude.ai/code/session_019EtQ2Yz7LjGkjgwEzGQWhm)_