### PR TITLE
fix(cli): drain pipe before waitUntilExit in shellOutput (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `shellOutput` now drains stdout before waiting for the child process to exit, preventing a pipe-buffer deadlock when output exceeds 64 KiB (#433). The function also returns `String?` so callers can distinguish a failed or non-zero-exit command from successful empty output.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -715,8 +715,8 @@ func performUpdate() {
     }
 
     // Check for updates via brew
-    let outdatedJSON = shellOutput(brewExec, args: ["info", "--json=v2", "apfel"])
-    guard let data = outdatedJSON.data(using: .utf8),
+    guard let outdatedJSON = shellOutput(brewExec, args: ["info", "--json=v2", "apfel"]),
+          let data = outdatedJSON.data(using: .utf8),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
           let formulae = json["formulae"] as? [[String: Any]],
           let formula = formulae.first,
@@ -751,8 +751,8 @@ func performUpdate() {
     print(styled("Running: brew upgrade apfel", .dim))
     let result = shellPassthrough(brewExec, args: ["upgrade", "apfel"])
     if result == 0 {
-        let newVersion = shellOutput(apfelExec, args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
-        print(styled("Updated to \(newVersion)", .green))
+        let newVersion = shellOutput(apfelExec, args: ["--version"])?.trimmingCharacters(in: .whitespacesAndNewlines)
+        print(styled("Updated to \(newVersion ?? "unknown")", .green))
     } else {
         printError("brew upgrade failed (exit \(result)). Try manually: brew upgrade apfel")
     }
@@ -769,23 +769,6 @@ private func findExecutableInPath(_ name: String) -> String? {
         if fm.isExecutableFile(atPath: candidate) { return candidate }
     }
     return nil
-}
-
-/// Run a command and capture stdout.
-private func shellOutput(_ executable: String, args: [String]) -> String {
-    let proc = Process()
-    let pipe = Pipe()
-    proc.executableURL = URL(fileURLWithPath: executable)
-    proc.arguments = args
-    proc.standardOutput = pipe
-    proc.standardError = FileHandle.nullDevice
-    do {
-        try proc.run()
-        proc.waitUntilExit()
-    } catch {
-        return ""
-    }
-    return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
 }
 
 /// Run a command with stdout/stderr passed through to the terminal.

--- a/Sources/CLI/ShellRunner.swift
+++ b/Sources/CLI/ShellRunner.swift
@@ -1,0 +1,27 @@
+// ============================================================================
+// ShellRunner.swift - Run a subprocess and capture its stdout.
+// ============================================================================
+
+import Foundation
+
+/// Run `executable` with `args` and return its stdout, or nil when the
+/// command could not be launched or exited non-zero.
+public func shellOutput(_ executable: String, args: [String]) -> String? {
+    let proc = Process()
+    let pipe = Pipe()
+    proc.executableURL = URL(fileURLWithPath: executable)
+    proc.arguments = args
+    proc.standardOutput = pipe
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+    } catch {
+        return nil
+    }
+    // Drain before waiting: the child blocks in write(2) once the pipe
+    // buffer fills, so waitUntilExit() would never return.
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+    guard proc.terminationStatus == 0 else { return nil }
+    return String(data: data, encoding: .utf8)
+}

--- a/Tests/apfelTests/ShellRunnerTests.swift
+++ b/Tests/apfelTests/ShellRunnerTests.swift
@@ -1,0 +1,38 @@
+// ============================================================================
+// ShellRunnerTests.swift - Unit tests for shellOutput (pipe deadlock fix, #433)
+// ============================================================================
+
+import Foundation
+import ApfelCLI
+
+func runShellRunnerTests() {
+
+    test("successful command returns stdout") {
+        let result = shellOutput("/bin/echo", args: ["hello"])
+        try assertEqual(result, "hello\n")
+    }
+
+    test("successful command with no output returns empty string") {
+        let result = shellOutput("/usr/bin/true", args: [])
+        try assertNotNil(result)
+        try assertEqual(result!, "")
+    }
+
+    test("non-zero exit returns nil") {
+        let result = shellOutput("/usr/bin/false", args: [])
+        try assertNil(result)
+    }
+
+    test("missing executable returns nil") {
+        let result = shellOutput("/nonexistent/binary/path", args: [])
+        try assertNil(result)
+    }
+
+    test("output beyond pipe buffer does not deadlock") {
+        // 128 KiB exceeds the typical 64 KiB pipe buffer. With the old
+        // wait-before-read ordering this would hang forever.
+        let result = shellOutput("/bin/dd", args: ["if=/dev/zero", "bs=131072", "count=1"])
+        try assertNotNil(result)
+        try assertEqual(result!.utf8.count, 131072)
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -129,6 +129,7 @@ suite("MessagesFlagTests") { runMessagesFlagTests() }
 suite("CodeFlagTests") { runCodeFlagTests() }
 suite("PrewarmDecisionTests") { runPrewarmDecisionTests() }
 suite("ResponsesModelsTests") { runResponsesModelsTests() }
+suite("ShellRunnerTests") { runShellRunnerTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #433.

## Summary

`shellOutput` read stdout **after** `waitUntilExit()`, creating a classic pipe-buffer deadlock when child output exceeds 64 KiB. The same function swallowed launch errors (`catch { return "" }`) and ignored non-zero exit status, making all failure modes indistinguishable from successful empty output.

The fix:
- **Drain before wait.** `readDataToEndOfFile()` now runs before `waitUntilExit()`, so the pipe buffer empties while the child writes.
- **Return `String?` instead of `String`.** `nil` means the command could not be launched or exited non-zero. Callers can now distinguish "no output" from "command failed".
- **Check `terminationStatus`.** A non-zero exit returns `nil` instead of being silently treated as success.
- **Extracted to `ApfelCLI`** (`Sources/CLI/ShellRunner.swift`) so the function is unit-testable. The main target already imports `ApfelCLI`.

Both call sites updated:
- Line 718 (`brew info`): folds `shellOutput` into the existing `guard let` chain - a failed brew command falls through to the existing "Could not check for updates" message.
- Line 754 (`apfel --version`): uses optional chaining with `?? "unknown"` so a failed version check still reports the upgrade succeeded.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests` (5 new tests in `ShellRunnerTests`)
- [ ] `make install` and manual smoke test (`apfel --update`)

## Test coverage

- Added `Tests/apfelTests/ShellRunnerTests.swift` with 5 tests:
  - `testSuccessfulCommandReturnsStdout` - `/bin/echo hello` returns `"hello\n"`
  - `testSuccessfulCommandWithNoOutputReturnsEmptyString` - `/usr/bin/true` returns `""`
  - `testNonZeroExitReturnsNil` - `/usr/bin/false` returns `nil`
  - `testMissingExecutableReturnsNil` - nonexistent path returns `nil`
  - `testOutputBeyondPipeBufferDoesNotDeadlock` - 128 KiB via `/bin/dd` returns without hanging
- Existing `--update` integration tests still cover the happy path.

## What I verified (static only)

- Read ordering is correct: drain, then wait, then check status.
- Both call sites handle `nil` naturally through existing fallback branches.
- No Swift 6 concurrency issues: `shellOutput` is a synchronous free function with no shared state.
- Diff limited to `Sources/CLI.swift`, `Sources/CLI/ShellRunner.swift`, `Tests/apfelTests/ShellRunnerTests.swift`, `Tests/apfelTests/main.swift`, and `CHANGELOG.md`.
- No touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a clean fix. The issue was filed by the repo owner account.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5TYs61ZwXNdFwiWy86GUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5TYs61ZwXNdFwiWy86GUr)_