### PR TITLE
fix(server): unify duplicate chatFailure/responsesFailure into shared openAIFailure (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Unified the duplicate `chatFailure`/`responsesFailure` HTTP error builders into a single `openAIFailure` function shared by both the chat completions and responses endpoints, eliminating a drift risk (#437). No change to error payloads, status codes, or debug capture.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -48,7 +48,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         body = try await request.body.collect(upTo: BodyLimits.maxRequestBodyBytes)
     } catch {
         let mib = BodyLimits.maxRequestBodyBytes / (1024 * 1024)
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: 413),
             message: "Request body exceeds the \(mib) MiB limit.",
             type: "invalid_request_error",
@@ -66,7 +66,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         chatRequest = try JSONDecoder().decode(ChatCompletionRequest.self, from: body)
     } catch {
         let msg = "Invalid JSON: \(error.localizedDescription)"
-        return chatFailure(
+        return openAIFailure(
             status: .badRequest,
             message: msg,
             type: "invalid_request_error",
@@ -82,7 +82,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     let wantsJSONSchema = chatRequest.response_format?.type == "json_schema"
 
     if let failure = ChatRequestValidator.validate(chatRequest) {
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: failure.httpStatusCode),
             message: failure.message,
             type: "invalid_request_error",
@@ -104,7 +104,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     if wantsJSONSchema {
         guard let spec = chatRequest.response_format?.json_schema,
               let schemaJSON = spec.schema?.value else {
-            return chatFailure(
+            return openAIFailure(
                 status: .badRequest,
                 message: "response_format.json_schema requires a 'schema' object",
                 type: "invalid_request_error",
@@ -117,7 +117,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         do {
             structuredSchema = try SchemaConverter.generationSchema(fromJSON: schemaJSON, name: spec.name)
         } catch {
-            return chatFailure(
+            return openAIFailure(
                 status: .badRequest,
                 message: "Invalid response_format.json_schema: \(error)",
                 type: "invalid_request_error",
@@ -169,7 +169,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     } catch {
         let classified = ApfelError.classify(error)
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -288,7 +288,7 @@ private func mcpAutoExecuteResponse(
             )
         }
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -321,7 +321,7 @@ private func mcpAutoExecuteResponse(
     } catch {
         let classified = ApfelError.classify(error)
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -425,7 +425,7 @@ private func nonStreamingResponse(
             )
         }
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -826,7 +826,7 @@ private func structuredNonStreamingResponse(
             )
         }
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -1035,7 +1035,7 @@ private func structuredStreamingResponse(
     )
 }
 
-private func chatFailure(
+func openAIFailure(
     status: HTTPResponse.Status,
     message: String,
     type: String,

--- a/Sources/ResponsesHandlers.swift
+++ b/Sources/ResponsesHandlers.swift
@@ -63,31 +63,7 @@ struct ResponsesEcho {
     }
 }
 
-// MARK: - Failure helper (same shape as the chat handler's chatFailure)
-
-private func responsesFailure(
-    status: HTTPResponse.Status,
-    message: String,
-    type: String,
-    stream: Bool,
-    requestBody: String?,
-    events: [String],
-    event: String,
-    code: String? = nil,
-    param: String? = nil
-) -> (response: Response, trace: ChatRequestTrace) {
-    (
-        openAIError(status: status, message: message, type: type, code: code, param: param),
-        ChatRequestTrace(
-            stream: stream,
-            estimatedTokens: nil,
-            error: message,
-            requestBody: requestBody,
-            responseBody: captureTruncatedLogBody(message, enabled: serverState.config.debug),
-            events: events + [event]
-        )
-    )
-}
+// Failure construction shared with the chat handler - see openAIFailure() in Handlers.swift.
 
 // MARK: - Handler
 
@@ -100,7 +76,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
         body = try await request.body.collect(upTo: BodyLimits.maxRequestBodyBytes)
     } catch {
         let mib = BodyLimits.maxRequestBodyBytes / (1024 * 1024)
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: 413),
             message: "Request body exceeds the \(mib) MiB limit.",
             type: "invalid_request_error",
@@ -115,7 +91,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
         responsesRequest = try JSONDecoder().decode(ResponsesRequest.self, from: body)
     } catch {
         let msg = "Invalid JSON: \(error.localizedDescription)"
-        return responsesFailure(
+        return openAIFailure(
             status: .badRequest, message: msg, type: "invalid_request_error",
             stream: false, requestBody: requestBodyString, events: events,
             event: "decode failed: \(msg)")
@@ -123,7 +99,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
     let isStreaming = responsesRequest.stream == true
 
     if let failure = ResponsesRequestValidator.validate(responsesRequest) {
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: failure.httpStatusCode),
             message: failure.message,
             type: "invalid_request_error",
@@ -144,7 +120,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
             structuredSchema = try SchemaConverter.generationSchema(
                 fromJSON: schemaJSON, name: format.name ?? "schema")
         } catch {
-            return responsesFailure(
+            return openAIFailure(
                 status: .badRequest,
                 message: "Invalid text.format json_schema: \(error)",
                 type: "invalid_request_error",
@@ -179,7 +155,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
             jsonMode: jsonMode, toolChoice: responsesRequest.tool_choice)
     } catch {
         let classified = ApfelError.classify(error)
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: classified.openAIMessage,
             type: classified.openAIType,
@@ -276,7 +252,7 @@ private func responsesNonStreamingResponse(
                                   events: events + ["refusal delivered"],
                                   estimatedTokens: promptTokens + completionTokens)
         }
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: classified.openAIMessage,
             type: classified.openAIType,

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -293,3 +293,39 @@ def test_responses_error_object_has_null_param_and_code():
     err = r.json()["error"]
     assert "param" in err and err["param"] is None
     assert "code" in err and err["code"] is None
+
+
+# ============================================================================
+# #437 - chat and responses error bodies must have the same shape
+# ============================================================================
+
+
+def test_chat_and_responses_error_bodies_have_the_same_shape():
+    """Both endpoints use the same openAIFailure builder, so equivalent bad
+    requests must produce error bodies with identical key sets and types (#437)."""
+    chat_r = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        content="{not json",
+        headers={"Content-Type": "application/json"},
+        timeout=15,
+    )
+    resp_r = httpx.post(
+        f"{BASE_URL}/v1/responses",
+        content="{not json",
+        headers={"Content-Type": "application/json"},
+        timeout=15,
+    )
+    assert chat_r.status_code == resp_r.status_code == 400
+
+    chat_err = chat_r.json()["error"]
+    resp_err = resp_r.json()["error"]
+
+    assert set(chat_err.keys()) == set(resp_err.keys()), (
+        f"key mismatch: chat={sorted(chat_err.keys())} responses={sorted(resp_err.keys())}"
+    )
+    for key in chat_err:
+        assert type(chat_err[key]) is type(resp_err[key]), (
+            f"type mismatch on '{key}': chat={type(chat_err[key]).__name__} "
+            f"responses={type(resp_err[key]).__name__}"
+        )
+    assert chat_err["type"] == resp_err["type"] == "invalid_request_error"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #437.

## Root cause

`chatFailure` in `Handlers.swift` and `responsesFailure` in `ResponsesHandlers.swift` were character-identical private functions that build OpenAI-shaped HTTP error responses (status, error body, debug capture, trace, event append). The `responsesFailure` copy even documented itself as a copy with a comment: "same shape as the chat handler's chatFailure". This meant any future change to how error responses are built - adding a `request_id`, changing the debug-capture policy, adding a header - had to be applied to both copies independently, and a missed update would cause the endpoints to silently disagree.

## The fix

Renamed `chatFailure` to `openAIFailure`, changed its visibility from `private` to module-internal (`func` without access modifier), and removed the duplicate `responsesFailure` entirely. All 10 call sites in `Handlers.swift` and 6 call sites in `ResponsesHandlers.swift` now call the single `openAIFailure`. The function body is unchanged - no behavioral difference in status codes, error payloads, headers, or debug capture.

## Test coverage

- Added `Tests/integration/server_validation_test.py:test_chat_and_responses_error_bodies_have_the_same_shape` to lock down that both endpoints produce error bodies with identical key sets and value types for equivalent bad requests.
- Existing `test_oversized_body_returns_413_with_error_object`, `test_error_object_always_has_null_param_and_code_when_absent`, `test_responses_invalid_json_returns_400`, and `test_responses_error_object_has_null_param_and_code` continue to cover the individual error paths.

## What I verified (static only)

- Both function bodies were character-identical (diffing after name normalization produces no delta).
- All call sites in both files updated - grep confirms zero remaining references to `chatFailure` or `responsesFailure`.
- `openAIFailure` placed alongside `openAIError` in `Handlers.swift` (both are shared HTTP error helpers used by both handler files).
- `ChatRequestTrace` is already defined in `Handlers.swift` and used by `ResponsesHandlers.swift` - no new cross-file dependency introduced.
- `serverState.config.debug` accessed via the module-level global, same as both originals.
- Swift 6 concurrency: no data races introduced (function is pure aside from the `serverState` read, same as both originals).
- Diff limited to `Sources/Handlers.swift`, `Sources/ResponsesHandlers.swift`, `Tests/integration/server_validation_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward DRY refactoring filed by the repo owner.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NPqBMrtyd3Fw65chceAWa

---
_Generated by [Claude Code](https://claude.ai/code/session_012NPqBMrtyd3Fw65chceAWa)_