### PR TITLE
fix(server): deduplicate chatFailure/responsesFailure into openAIFailure (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Deduplicated `chatFailure`/`responsesFailure` into a single `openAIFailure()` builder shared by both `/v1/chat/completions` and `/v1/responses` (#437). Internal-only, no change to wire behaviour.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -48,7 +48,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         body = try await request.body.collect(upTo: BodyLimits.maxRequestBodyBytes)
     } catch {
         let mib = BodyLimits.maxRequestBodyBytes / (1024 * 1024)
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: 413),
             message: "Request body exceeds the \(mib) MiB limit.",
             type: "invalid_request_error",
@@ -66,7 +66,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         chatRequest = try JSONDecoder().decode(ChatCompletionRequest.self, from: body)
     } catch {
         let msg = "Invalid JSON: \(error.localizedDescription)"
-        return chatFailure(
+        return openAIFailure(
             status: .badRequest,
             message: msg,
             type: "invalid_request_error",
@@ -82,7 +82,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     let wantsJSONSchema = chatRequest.response_format?.type == "json_schema"
 
     if let failure = ChatRequestValidator.validate(chatRequest) {
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: failure.httpStatusCode),
             message: failure.message,
             type: "invalid_request_error",
@@ -104,7 +104,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     if wantsJSONSchema {
         guard let spec = chatRequest.response_format?.json_schema,
               let schemaJSON = spec.schema?.value else {
-            return chatFailure(
+            return openAIFailure(
                 status: .badRequest,
                 message: "response_format.json_schema requires a 'schema' object",
                 type: "invalid_request_error",
@@ -117,7 +117,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
         do {
             structuredSchema = try SchemaConverter.generationSchema(fromJSON: schemaJSON, name: spec.name)
         } catch {
-            return chatFailure(
+            return openAIFailure(
                 status: .badRequest,
                 message: "Invalid response_format.json_schema: \(error)",
                 type: "invalid_request_error",
@@ -169,7 +169,7 @@ func handleChatCompletion(_ request: Request, context: some RequestContext) asyn
     } catch {
         let classified = ApfelError.classify(error)
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -288,7 +288,7 @@ private func mcpAutoExecuteResponse(
             )
         }
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -321,7 +321,7 @@ private func mcpAutoExecuteResponse(
     } catch {
         let classified = ApfelError.classify(error)
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -425,7 +425,7 @@ private func nonStreamingResponse(
             )
         }
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -826,7 +826,7 @@ private func structuredNonStreamingResponse(
             )
         }
         let msg = classified.openAIMessage
-        return chatFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: msg,
             type: classified.openAIType,
@@ -1035,7 +1035,7 @@ private func structuredStreamingResponse(
     )
 }
 
-private func chatFailure(
+func openAIFailure(
     status: HTTPResponse.Status,
     message: String,
     type: String,

--- a/Sources/ResponsesHandlers.swift
+++ b/Sources/ResponsesHandlers.swift
@@ -63,31 +63,7 @@ struct ResponsesEcho {
     }
 }
 
-// MARK: - Failure helper (same shape as the chat handler's chatFailure)
-
-private func responsesFailure(
-    status: HTTPResponse.Status,
-    message: String,
-    type: String,
-    stream: Bool,
-    requestBody: String?,
-    events: [String],
-    event: String,
-    code: String? = nil,
-    param: String? = nil
-) -> (response: Response, trace: ChatRequestTrace) {
-    (
-        openAIError(status: status, message: message, type: type, code: code, param: param),
-        ChatRequestTrace(
-            stream: stream,
-            estimatedTokens: nil,
-            error: message,
-            requestBody: requestBody,
-            responseBody: captureTruncatedLogBody(message, enabled: serverState.config.debug),
-            events: events + [event]
-        )
-    )
-}
+// Failure construction shared with the chat handler - see openAIFailure() in Handlers.swift.
 
 // MARK: - Handler
 
@@ -100,7 +76,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
         body = try await request.body.collect(upTo: BodyLimits.maxRequestBodyBytes)
     } catch {
         let mib = BodyLimits.maxRequestBodyBytes / (1024 * 1024)
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: 413),
             message: "Request body exceeds the \(mib) MiB limit.",
             type: "invalid_request_error",
@@ -115,7 +91,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
         responsesRequest = try JSONDecoder().decode(ResponsesRequest.self, from: body)
     } catch {
         let msg = "Invalid JSON: \(error.localizedDescription)"
-        return responsesFailure(
+        return openAIFailure(
             status: .badRequest, message: msg, type: "invalid_request_error",
             stream: false, requestBody: requestBodyString, events: events,
             event: "decode failed: \(msg)")
@@ -123,7 +99,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
     let isStreaming = responsesRequest.stream == true
 
     if let failure = ResponsesRequestValidator.validate(responsesRequest) {
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: failure.httpStatusCode),
             message: failure.message,
             type: "invalid_request_error",
@@ -144,7 +120,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
             structuredSchema = try SchemaConverter.generationSchema(
                 fromJSON: schemaJSON, name: format.name ?? "schema")
         } catch {
-            return responsesFailure(
+            return openAIFailure(
                 status: .badRequest,
                 message: "Invalid text.format json_schema: \(error)",
                 type: "invalid_request_error",
@@ -179,7 +155,7 @@ func handleResponses(_ request: Request, context: some RequestContext) async thr
             jsonMode: jsonMode, toolChoice: responsesRequest.tool_choice)
     } catch {
         let classified = ApfelError.classify(error)
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: classified.openAIMessage,
             type: classified.openAIType,
@@ -276,7 +252,7 @@ private func responsesNonStreamingResponse(
                                   events: events + ["refusal delivered"],
                                   estimatedTokens: promptTokens + completionTokens)
         }
-        return responsesFailure(
+        return openAIFailure(
             status: .init(code: classified.httpStatusCode),
             message: classified.openAIMessage,
             type: classified.openAIType,

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -293,3 +293,29 @@ def test_responses_error_object_has_null_param_and_code():
     err = r.json()["error"]
     assert "param" in err and err["param"] is None
     assert "code" in err and err["code"] is None
+
+
+# ============================================================================
+# #437 - chat and responses error bodies must have the same shape
+# ============================================================================
+
+
+def test_chat_and_responses_error_bodies_have_the_same_shape():
+    """Both endpoints must produce identical JSON error structure for an
+    equivalent bad request. Guards against the two failure paths drifting
+    apart now that they share a single builder (#437)."""
+    chat_r = _post({"model": "nonexistent-model",
+                     "messages": [{"role": "user", "content": "hi"}]})
+    resp_r = _responses({"model": "nonexistent-model", "input": "hi"})
+
+    assert chat_r.status_code == resp_r.status_code == 404
+
+    chat_err = chat_r.json()["error"]
+    resp_err = resp_r.json()["error"]
+
+    assert set(chat_err.keys()) == set(resp_err.keys()), (
+        f"key mismatch: chat={sorted(chat_err.keys())} "
+        f"responses={sorted(resp_err.keys())}")
+    assert chat_err["type"] == resp_err["type"]
+    assert chat_err["code"] == resp_err["code"]
+    assert chat_err["param"] == resp_err["param"]


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #437.

## Summary

`chatFailure` (Handlers.swift:1038) and `responsesFailure` (ResponsesHandlers.swift:68) were character-identical private functions building the same OpenAI-shaped error tuple. Promoted `chatFailure` to internal scope as `openAIFailure()`, removed the duplicate from ResponsesHandlers.swift, and repointed all 16 call sites.

## Root cause

When the `/v1/responses` endpoint was added (#365), the failure helper was copied verbatim from the chat handler rather than extracted into a shared function. The comment on the copy even acknowledged it: "same shape as the chat handler's chatFailure". Two private copies of the same rule for how HTTP errors are built creates a silent drift risk - any future fix applied to one (request_id, debug-capture policy, header changes) would miss the other.

## The fix

- `chatFailure` in `Handlers.swift` renamed to `openAIFailure` and visibility changed from `private` to `internal` (module-scoped, not public).
- The identical `responsesFailure` removed from `ResponsesHandlers.swift`, replaced by a one-line breadcrumb comment.
- All 10 call sites in `Handlers.swift` and 6 in `ResponsesHandlers.swift` updated to call `openAIFailure`.
- Net effect: -18 lines of duplicated code, zero change to wire behaviour.

## Test coverage

- Added `server_validation_test.py::test_chat_and_responses_error_bodies_have_the_same_shape` to lock down that both endpoints produce identical JSON error structure (same keys, same type, same code, same param) for equivalent bad requests. Model-free, runs in CI.
- Existing `security_test.py`, `server_validation_test.py`, and `openapi_spec_test.py` suites are the regression gate for all error responses.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Diff limited to `Handlers.swift`, `ResponsesHandlers.swift`, `server_validation_test.py`, and `CHANGELOG.md`.
- No touches to release infrastructure, guardrails, CI, or dependencies.
- All 16 call sites updated; zero stale references to `chatFailure` or `responsesFailure` remain.
- `openAIError`, `captureTruncatedLogBody`, `ChatRequestTrace`, and `serverState` are all already internal-scoped - no visibility changes needed beyond the function itself.
- Swift 6 concurrency: no data races introduced (the function is a pure value constructor, same as before).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward DRY extraction from the project owner's own issue.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01QZ56bznKmaCj48EAkN9714

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZ56bznKmaCj48EAkN9714)_