### PR TITLE
fix(session): throw on MCP reprompt cap exhaustion (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Exhausting the MCP re-prompt cap (3 rounds) with a tool call still pending now throws `ApfelError.toolExecution` instead of silently returning a stripped fragment as `finish_reason: stop`. CLI gets a non-zero exit; the server returns an error body. The cap is defined once (`ToolCallHandler.mcpRepromptCap`) and shared by both paths (#435).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/ToolCallHandler.swift
+++ b/Sources/Core/ToolCallHandler.swift
@@ -51,6 +51,22 @@ public struct ParsedToolCall: Sendable {
 
 public enum ToolCallHandler {
 
+    // MARK: - MCP Re-prompt Cap
+
+    /// Maximum number of follow-up re-prompts when the model keeps emitting
+    /// tool calls. Both CLI and HTTP paths use this single constant.
+    public static let mcpRepromptCap = 3
+
+    /// After the MCP tool loop exits, verify the model is not still requesting
+    /// a tool call. If it is, the cap was exhausted with work still pending -
+    /// returning a stripped fragment as `finish_reason: stop` would be dishonest,
+    /// so this throws `.toolExecution` instead (#435).
+    public static func ensureToolLoopCompleted(in content: String) throws {
+        guard detectToolCall(in: content) != nil else { return }
+        throw ApfelError.toolExecution(
+            "MCP tool loop hit its \(mcpRepromptCap)-round cap with a tool call still pending; no final answer was produced")
+    }
+
     // MARK: - System Prompt Building
 
     /// Build output format instructions only (no tool schemas).

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -412,11 +412,9 @@ func executeMCPToolCallsForCLI(
     // returned it verbatim that JSON would leak to the user as raw text. Run a
     // bounded re-detection loop: execute any further tool calls and re-prompt
     // again, with a hard cap so a model that keeps emitting tool_calls cannot
-    // spin forever. On cap exhaustion we strip the trailing tool-call JSON so no
-    // raw protocol text leaks.
-    let maxReprompts = 3
+    // spin forever.
     var reprompts = 0
-    while reprompts < maxReprompts,
+    while reprompts < ToolCallHandler.mcpRepromptCap,
           let followUp = try await detectAndExecuteMCPTools(in: finalContent, mcpManager: mcpManager) {
         reprompts += 1
         aggregatedLog.append(contentsOf: followUp.toolLog)
@@ -428,11 +426,9 @@ func executeMCPToolCallsForCLI(
         ).content
     }
 
-    // Cap exhausted but the model is still emitting a tool call: strip the raw
-    // JSON so it never reaches the user as text.
-    if ToolCallHandler.detectToolCall(in: finalContent) != nil {
-        finalContent = stripToolCallJSON(from: finalContent)
-    }
+    // Cap exhausted but the model is still emitting a tool call: fail loudly
+    // instead of stripping the JSON and returning a fragment as success (#435).
+    try ToolCallHandler.ensureToolLoopCompleted(in: finalContent)
 
     return (content: finalContent, toolLog: aggregatedLog)
 }
@@ -492,8 +488,7 @@ func executeMCPToolCallsForServer(
     var finalContent = ""
 
     // Mirror the CLI path's bounded loop: initial re-prompt plus up to
-    // maxReprompts further rounds when the model keeps emitting tool calls.
-    let maxReprompts = 3
+    // mcpRepromptCap further rounds when the model keeps emitting tool calls.
     var reprompts = 0
     while true {
         let truncated = await truncatedServerToolResults(
@@ -515,7 +510,7 @@ func executeMCPToolCallsForServer(
         // The re-prompt answer may itself request another tool call. Execute and
         // re-prompt again with a hard cap so a model that keeps emitting
         // tool_calls cannot spin forever.
-        guard reprompts < maxReprompts,
+        guard reprompts < ToolCallHandler.mcpRepromptCap,
               let next = try await detectAndExecuteMCPTools(in: finalContent, mcpManager: mcpManager) else {
             break
         }
@@ -525,11 +520,9 @@ func executeMCPToolCallsForServer(
         currentExecuted = next
     }
 
-    // Cap exhausted but the model is still emitting a tool call: strip the raw
-    // JSON so it never reaches the client as content with finish_reason stop.
-    if ToolCallHandler.detectToolCall(in: finalContent) != nil {
-        finalContent = stripToolCallJSON(from: finalContent)
-    }
+    // Cap exhausted but the model is still emitting a tool call: fail loudly
+    // instead of stripping the JSON and returning a fragment as success (#435).
+    try ToolCallHandler.ensureToolLoopCompleted(in: finalContent)
 
     return (content: finalContent, toolLog: aggregatedLog)
 }

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -475,6 +475,48 @@ func runToolCallHandlerTests() {
         try assertEqual(a, b)
     }
 
+    // MARK: - mcpRepromptCap (#435)
+
+    test("mcpRepromptCap is defined once and equals 3") {
+        try assertEqual(ToolCallHandler.mcpRepromptCap, 3)
+    }
+
+    // MARK: - ensureToolLoopCompleted (#435)
+
+    test("ensureToolLoopCompleted passes when content has no tool call") {
+        try ToolCallHandler.ensureToolLoopCompleted(in: "The answer is 42.")
+    }
+
+    test("ensureToolLoopCompleted passes for empty content") {
+        try ToolCallHandler.ensureToolLoopCompleted(in: "")
+    }
+
+    test("ensureToolLoopCompleted throws toolExecution when a tool call is pending") {
+        let pending = #"Here is what I found. {"tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "add", "arguments": "{\"a\":1,\"b\":2}"}}]}"#
+        var thrown = false
+        do {
+            try ToolCallHandler.ensureToolLoopCompleted(in: pending)
+        } catch let e as ApfelError {
+            if case .toolExecution(let msg) = e {
+                thrown = true
+                try assertTrue(msg.contains("cap"), "message should mention the cap")
+                try assertTrue(msg.contains("pending"), "message should mention pending")
+            }
+        }
+        try assertTrue(thrown, "should have thrown ApfelError.toolExecution")
+    }
+
+    test("ensureToolLoopCompleted throws for unparseable tool-call JSON too") {
+        let broken = #"Sure! {"tool_calls": [{"id": "x", "function": {"name": "add", "arguments": {"a": "1"#
+        var thrown = false
+        do {
+            try ToolCallHandler.ensureToolLoopCompleted(in: broken)
+        } catch let e as ApfelError {
+            if case .toolExecution = e { thrown = true }
+        }
+        try assertTrue(thrown, "should throw for unparseable tool-call JSON")
+    }
+
     // MARK: - ProcessPromptResult
 
     test("ProcessPromptResult with empty toolLog") {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #435.

## Summary

When the MCP re-prompt loop hits its 3-round cap and the model is still requesting tool calls, both CLI and HTTP paths were stripping the raw tool-call JSON and returning the (possibly empty) remainder as a normal completion with `finish_reason: stop`. This silently swallowed the fact that the tool loop gave up, violating the fail-loud principle.

Now both paths call `ToolCallHandler.ensureToolLoopCompleted(in:)`, which throws `ApfelError.toolExecution` when a tool call is still pending. The CLI maps this to a non-zero exit; the server maps it to an HTTP 500 error body with `openAIType: "server_error"`. The cap constant is defined once as `ToolCallHandler.mcpRepromptCap` (= 3), shared by both paths.

## Root cause

Both `executeMCPToolCallsForCLI` and `executeMCPToolCallsForServer` in `Sources/Session.swift` ran a bounded re-detection loop capped at 3 rounds. When the cap was exhausted with a pending tool call, they stripped the tool-call JSON via `stripToolCallJSON(from:)` and returned the fragment as a successful result. The CLI then assigned `.stop`; the server treated it as normal content. Callers had no way to know the tool loop gave up.

## The fix

- Added `ToolCallHandler.mcpRepromptCap` (= 3) as a single shared constant in ApfelCore, replacing the two independent `let maxReprompts = 3` locals.
- Added `ToolCallHandler.ensureToolLoopCompleted(in:)` which throws `ApfelError.toolExecution` if `detectToolCall` finds a pending call in the content.
- Both loops now call the shared method instead of strip-and-return.
- The existing `ApfelError.toolExecution` case already maps to non-zero CLI exit (via `ApfelExitCodes`), HTTP 500, and `openAIType: "server_error"` - no new enum case needed.

## Test coverage

- Added `ToolCallHandlerTests`: `mcpRepromptCap is defined once and equals 3` - locks the constant.
- Added `ToolCallHandlerTests`: `ensureToolLoopCompleted passes when content has no tool call` - normal path.
- Added `ToolCallHandlerTests`: `ensureToolLoopCompleted passes for empty content` - edge case.
- Added `ToolCallHandlerTests`: `ensureToolLoopCompleted throws toolExecution when a tool call is pending` - the bug path.
- Added `ToolCallHandlerTests`: `ensureToolLoopCompleted throws for unparseable tool-call JSON too` - salvage path.
- Existing `stripToolCallJSON` tests still cover the stripping logic (used elsewhere).

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Both CLI and HTTP loops now reference `ToolCallHandler.mcpRepromptCap` instead of independent locals.
- Both terminal checks call `ensureToolLoopCompleted` which throws instead of stripping and returning.
- Swift 6 concurrency: no data races introduced (the new method is a pure static function on a non-isolated enum).
- Diff limited to `Sources/Core/ToolCallHandler.swift`, `Sources/Session.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug filed by the repo owner with accurate code references.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y42kv1Xj1AMyKtAdPoafLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y42kv1Xj1AMyKtAdPoafLC)_