### PR TITLE
fix(benchmark): make measure rethrow so failing operations fail the benchmark (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Benchmark timing helper `measure` now rethrows: a timed operation that throws fails the benchmark instead of being silently discarded and reported as a fast, validated sample. Removed `try?` from `benchmarkContextManager`, `benchmarkRequestPipeline`, and `benchmarkRequestDecode` closures (#436).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Benchmark.swift
+++ b/Sources/Benchmark.swift
@@ -85,7 +85,7 @@ private func benchmarkReport() async throws -> BenchmarkReport {
     let streamDebugCapture = await benchmarkStreamDebugCaptureDisabled()
     let contextManager = try await benchmarkContextManager(options: options)
     let requestPipeline = try await benchmarkRequestPipeline(options: options)
-    let requestDecode = await benchmarkRequestDecode()
+    let requestDecode = try await benchmarkRequestDecode()
     let toolDetection = await benchmarkToolDetection()
     let responseEncode = await benchmarkResponseEncode()
 
@@ -239,8 +239,8 @@ private func benchmarkContextManager(options: SessionOptions) async throws -> Be
     let messages = benchmarkMessages()
 
     let iterations = 12
-    let timing = await measure(iterations: iterations) {
-        _ = try? await ContextManager.makeSession(
+    let timing = try await measure(iterations: iterations) {
+        _ = try await ContextManager.makeSession(
             messages: messages,
             tools: tools,
             options: options,
@@ -342,8 +342,8 @@ private func benchmarkRequestPipeline(options: SessionOptions) async throws -> B
     let validation = try await benchmarkRequestPipelineResult(request: request, options: options)
 
     let iterations = 40
-    let timing = await measure(iterations: iterations) {
-        _ = try? await benchmarkRequestPipelineResult(request: request, options: options)
+    let timing = try await measure(iterations: iterations) {
+        _ = try await benchmarkRequestPipelineResult(request: request, options: options)
     }
 
     return BenchmarkCaseResult(
@@ -357,11 +357,11 @@ private func benchmarkRequestPipeline(options: SessionOptions) async throws -> B
     )
 }
 
-private func benchmarkRequestDecode() async -> BenchmarkCaseResult {
+private func benchmarkRequestDecode() async throws -> BenchmarkCaseResult {
     let requestJSON = makeRequestJSON()
     let iterations = 500
-    let timing = await measure(iterations: iterations) {
-        _ = try? JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
+    let timing = try await measure(iterations: iterations) {
+        _ = try JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
     }
 
     return BenchmarkCaseResult(
@@ -433,18 +433,18 @@ private func benchmarkResponseEncode() async -> BenchmarkCaseResult {
 private func measure(
     iterations: Int,
     warmup: Int = 2,
-    operation: @escaping () async -> Void
-) async -> BenchmarkTiming {
+    operation: @escaping () async throws -> Void
+) async rethrows -> BenchmarkTiming {
     guard iterations > 0 else { return BenchmarkTiming(avgMilliseconds: 0) }
 
     for _ in 0..<warmup {
-        await operation()
+        try await operation()
     }
 
     var totalNanoseconds: UInt64 = 0
     for _ in 0..<iterations {
         let start = DispatchTime.now().uptimeNanoseconds
-        await operation()
+        try await operation()
         totalNanoseconds += DispatchTime.now().uptimeNanoseconds - start
     }
 

--- a/Tests/apfelTests/BenchmarkTests.swift
+++ b/Tests/apfelTests/BenchmarkTests.swift
@@ -1,0 +1,113 @@
+// ============================================================================
+// BenchmarkTests.swift - Benchmark timing helper contract tests
+// Part of apfel test suite
+//
+// The production `measure` function lives in the FoundationModels-coupled
+// executable target and cannot be imported here. These tests lock the
+// rethrowing contract using a local replica with the identical signature,
+// ensuring the pattern stays correct if the production code is refactored.
+// ============================================================================
+
+import Foundation
+
+private struct BenchmarkTiming {
+    let avgMilliseconds: Double
+}
+
+private func measure(
+    iterations: Int,
+    warmup: Int = 2,
+    operation: @escaping () async throws -> Void
+) async rethrows -> BenchmarkTiming {
+    guard iterations > 0 else { return BenchmarkTiming(avgMilliseconds: 0) }
+
+    for _ in 0..<warmup {
+        try await operation()
+    }
+
+    var totalNanoseconds: UInt64 = 0
+    for _ in 0..<iterations {
+        let start = DispatchTime.now().uptimeNanoseconds
+        try await operation()
+        totalNanoseconds += DispatchTime.now().uptimeNanoseconds - start
+    }
+
+    return BenchmarkTiming(
+        avgMilliseconds: Double(totalNanoseconds) / Double(iterations) / 1_000_000
+    )
+}
+
+private struct BenchmarkCaseResult {
+    let name: String
+    let validated: Bool
+    let avgMs: Double
+}
+
+private struct ForcedBenchmarkError: Error {}
+
+func runBenchmarkTests() {
+
+    testAsync("measure rethrows when body throws") {
+        var threw = false
+        do {
+            _ = try await measure(iterations: 3, warmup: 0) {
+                throw ForcedBenchmarkError()
+            }
+        } catch is ForcedBenchmarkError {
+            threw = true
+        }
+        try assertTrue(threw, "measure must propagate the body's error, not swallow it")
+    }
+
+    testAsync("measure returns timing when body succeeds") {
+        var count = 0
+        let timing = try await measure(iterations: 5, warmup: 0) {
+            count += 1
+        }
+        try assertEqual(count, 5, "body should run exactly iterations times")
+        try assertTrue(timing.avgMilliseconds >= 0, "timing must be non-negative")
+    }
+
+    testAsync("measure with zero iterations returns zero") {
+        let timing = try await measure(iterations: 0, warmup: 0) {
+            throw ForcedBenchmarkError()
+        }
+        try assertTrue(timing.avgMilliseconds == 0, "zero iterations must return 0 ms")
+    }
+
+    testAsync("failing case must not be reported as validated") {
+        var validated = true
+        do {
+            _ = try await measure(iterations: 1, warmup: 0) {
+                throw ForcedBenchmarkError()
+            }
+        } catch {
+            validated = false
+        }
+        try assertTrue(!validated,
+            "a benchmark case whose timed operation throws must not reach validated: true")
+    }
+
+    testAsync("measure runs warmup before timed iterations") {
+        var callCount = 0
+        _ = try await measure(iterations: 3, warmup: 2) {
+            callCount += 1
+        }
+        try assertEqual(callCount, 5, "warmup (2) + iterations (3) = 5 total calls")
+    }
+
+    testAsync("measure rethrows during warmup") {
+        var threw = false
+        var callCount = 0
+        do {
+            _ = try await measure(iterations: 10, warmup: 1) {
+                callCount += 1
+                throw ForcedBenchmarkError()
+            }
+        } catch is ForcedBenchmarkError {
+            threw = true
+        }
+        try assertTrue(threw, "measure must rethrow errors from warmup phase")
+        try assertEqual(callCount, 1, "should fail on first warmup call")
+    }
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -129,6 +129,7 @@ suite("MessagesFlagTests") { runMessagesFlagTests() }
 suite("CodeFlagTests") { runCodeFlagTests() }
 suite("PrewarmDecisionTests") { runPrewarmDecisionTests() }
 suite("ResponsesModelsTests") { runResponsesModelsTests() }
+suite("BenchmarkTests") { runBenchmarkTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #436.

## Summary

The benchmark timing helper `measure` accepted a non-throwing closure (`() async -> Void`), which forced three call sites - `benchmarkContextManager`, `benchmarkRequestPipeline`, and `benchmarkRequestDecode` - to discard errors with `try?`. A timed operation that threw on every iteration was still timed (measuring an immediate throw) and reported with `validated: true`, making a regression look like a performance improvement.

The fix makes `measure` accept a throwing closure and `rethrows`, then replaces all three `try?` sites with `try` so errors propagate. `benchmarkRequestDecode` gains `throws` on its own signature, with the call site in `benchmarkReport()` updated to `try await`.

## Root cause

`measure`'s closure parameter was `() async -> Void` (non-throwing). Every call site that wrapped a throwing operation had to use `try?` at the boundary, silently discarding errors. The result: a failing benchmark case produced a near-zero timing and `validated: true` instead of failing the suite.

## The fix

- Changed `measure` signature from `() async -> Void` to `() async throws -> Void` with `rethrows`
- Warmup and timing loops now use `try await operation()` instead of `await operation()`
- Removed `try?` from `benchmarkContextManager` (line 243), `benchmarkRequestPipeline` (line 346), and `benchmarkRequestDecode` (line 364)
- `benchmarkRequestDecode` signature changed from `async -> BenchmarkCaseResult` to `async throws -> BenchmarkCaseResult`
- Call site in `benchmarkReport()` updated to `try await benchmarkRequestDecode()`

## Test coverage

- Added `Tests/apfelTests/BenchmarkTests.swift` with 6 tests:
  - `measure rethrows when body throws` - verifies error propagation
  - `measure returns timing when body succeeds` - verifies normal operation
  - `measure with zero iterations returns zero` - edge case
  - `failing case must not be reported as validated` - verifies the core bug: a throwing body cannot reach `validated: true`
  - `measure runs warmup before timed iterations` - verifies warmup + iteration count
  - `measure rethrows during warmup` - verifies errors during warmup phase also propagate
- Registered suite in `Tests/apfelTests/main.swift`

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `apfel --benchmark` produces unchanged output when nothing throws

## What I verified (static only)

- No `try?` remains inside any `measure` closure
- `measure` signature uses `rethrows` (not `throws`) so non-throwing call sites are unaffected
- All existing non-throwing `measure` call sites (textContent, trimNewest, trimOldest, toolSchemaConvert, requestBodyCapture, streamDebugCapture, toolDetection, responseEncode) continue to compile without `try` since `rethrows` is inferred as non-throwing when the closure doesn't throw
- Swift 6 concurrency: no data races introduced
- Diff limited to `Sources/Benchmark.swift`, `Tests/apfelTests/BenchmarkTests.swift`, `Tests/apfelTests/main.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by `Arthur-Ficial` and the code paths match exactly.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_019eJnzFwntyRfDbZSznLV9W

---
_Generated by [Claude Code](https://claude.ai/code/session_019eJnzFwntyRfDbZSznLV9W)_