### PR TITLE
fix(session): throw on MCP re-prompt cap exhaustion instead of silent success (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Exhausting the MCP re-prompt cap (3 rounds) with a pending tool call now throws `ApfelError.toolExecution` instead of silently returning a stripped fragment as `finish_reason: stop`. CLI gets a non-zero exit; server gets an error body (#435).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Session.swift
+++ b/Sources/Session.swift
@@ -428,10 +428,9 @@ func executeMCPToolCallsForCLI(
         ).content
     }
 
-    // Cap exhausted but the model is still emitting a tool call: strip the raw
-    // JSON so it never reaches the user as text.
     if ToolCallHandler.detectToolCall(in: finalContent) != nil {
-        finalContent = stripToolCallJSON(from: finalContent)
+        throw ApfelError.toolExecution(
+            "model kept requesting tool calls after \(maxReprompts) re-prompt rounds; no final answer was produced")
     }
 
     return (content: finalContent, toolLog: aggregatedLog)
@@ -525,10 +524,9 @@ func executeMCPToolCallsForServer(
         currentExecuted = next
     }
 
-    // Cap exhausted but the model is still emitting a tool call: strip the raw
-    // JSON so it never reaches the client as content with finish_reason stop.
     if ToolCallHandler.detectToolCall(in: finalContent) != nil {
-        finalContent = stripToolCallJSON(from: finalContent)
+        throw ApfelError.toolExecution(
+            "model kept requesting tool calls after \(maxReprompts) re-prompt rounds; no final answer was produced")
     }
 
     return (content: finalContent, toolLog: aggregatedLog)

--- a/Tests/apfelTests/ToolCallHandlerTests.swift
+++ b/Tests/apfelTests/ToolCallHandlerTests.swift
@@ -492,4 +492,30 @@ func runToolCallHandlerTests() {
         let result = ProcessPromptResult(content: "", toolLog: [])
         try assertTrue(result.content.isEmpty)
     }
+
+    // MARK: - Re-prompt cap exhaustion (#435)
+
+    test("toolExecution error for re-prompt cap exhaustion maps to HTTP 500 and non-zero exit") {
+        let err = ApfelError.toolExecution(
+            "model kept requesting tool calls after 3 re-prompt rounds; no final answer was produced")
+        try assertEqual(err.httpStatusCode, 500)
+        try assertEqual(err.openAIType, "server_error")
+        try assertEqual(err.cliLabel, "[tool error]")
+        try assertTrue(!err.isRetryable)
+        try assertTrue(err.openAIMessage.contains("re-prompt rounds"))
+    }
+
+    test("stripToolCallJSON still strips when tool-call JSON is present") {
+        let text = "Here is some text {\"tool_calls\": [{\"id\": \"call_1\", \"type\": \"function\", \"function\": {\"name\": \"add\", \"arguments\": \"{}\"}}]}"
+        let stripped = ToolCallHandler.stripToolCallJSON(from: text)
+        try assertTrue(!stripped.contains("tool_calls"), "tool-call JSON must be stripped")
+        try assertTrue(stripped.contains("Here is some text"), "surrounding text must be preserved")
+    }
+
+    test("detectToolCall finds pending call in cap-exhaustion scenario") {
+        let modelOutput = "{\"tool_calls\": [{\"id\": \"call_99\", \"type\": \"function\", \"function\": {\"name\": \"multiply\", \"arguments\": \"{\\\"a\\\": 6, \\\"b\\\": 7}\"}}]}"
+        let detected = ToolCallHandler.detectToolCall(in: modelOutput)
+        try assertNotNil(detected, "must detect the pending tool call")
+        try assertEqual(detected!.first!.name, "multiply")
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #435.

## Summary

When the MCP re-prompt loop hits its 3-round cap and the model is still requesting tool calls, apfel strips the pending tool-call JSON and returns whatever text is left as a successful answer (`finish_reason: stop`). Callers get no indication that tool work was abandoned. This violates the project's fail-loud principle.

The fix throws `ApfelError.toolExecution` instead of returning the stripped fragment. The existing error infrastructure handles the rest: CLI gets a non-zero exit with `[tool error]`, the server returns an HTTP 500 with an `error` body instead of `finish_reason: stop`.

## Root cause

Both `executeMCPToolCallsForCLI` (Session.swift:433) and `executeMCPToolCallsForServer` (Session.swift:530) detect that the model is still emitting tool calls after the cap, strip the JSON, and then return normally. `processPrompt` assigns `.stop` to any non-nil result from these functions, so the caller sees a successful completion with empty or fragmentary content.

## The fix

Replace the strip-and-return with a throw at both call sites. The error message names the cap so the caller can act on it. Raw tool-call JSON still never reaches the user because the throw preempts the return entirely.

## Test coverage

- Added 3 unit tests in `Tests/apfelTests/ToolCallHandlerTests.swift` under the `Re-prompt cap exhaustion (#435)` mark:
  - `toolExecution error for re-prompt cap exhaustion maps to HTTP 500 and non-zero exit` - validates the error case surfaces correctly on all paths (httpStatusCode, openAIType, cliLabel, isRetryable)
  - `stripToolCallJSON still strips when tool-call JSON is present` - confirms the existing strip function still works (regression guard)
  - `detectToolCall finds pending call in cap-exhaustion scenario` - confirms detection still fires for the guard condition

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `make test` (full suite including integration tests with Apple Intelligence)

## What I verified (static only)

- Both throw sites use the existing `ApfelError.toolExecution` case - no new enum case added, patch-level change.
- `ApfelError.toolExecution` already maps to HTTP 500, `server_error`, CLI exit code 1, `[tool error]` label, and is not retryable. All confirmed by existing tests.
- `processPrompt` wraps `executeMCPToolCallsForCLI` in a `try` so the throw propagates to the CLI error handler.
- `Handlers.swift` wraps `executeMCPToolCallsForServer` in a `try` so the throw propagates to the HTTP error handler.
- Loops that finish inside the cap are unchanged - the throw only fires when `detectToolCall` finds a pending call after the while loop exits.
- Diff limited to `Sources/Session.swift`, `Tests/apfelTests/ToolCallHandlerTests.swift`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced (throw is a synchronous control-flow change).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.
- The acceptance criterion "the cap and the terminal behaviour are defined in exactly one place" is partially addressed (both sites now throw identically) but not fully (the `maxReprompts = 3` constant is still duplicated as a local `let` in each function). Deduplicating the loop into a shared function is a larger refactor that could be a follow-up.

## Anything that seemed suspicious

Nothing - straightforward bug from the project owner with accurate line references.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01KxYF7cj789Q3CZzqHAaVXC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxYF7cj789Q3CZzqHAaVXC)_