### PR TITLE
fix(benchmark): make measure() rethrow so failing operations crash the benchmark (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Benchmark cases no longer swallow errors with `try?` inside `measure()` closures (#436). A throwing timed operation now fails the benchmark instead of being recorded as a fast, validated sample. `measure()` accepts a throwing closure and rethrows, so errors propagate to the caller.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Benchmark.swift
+++ b/Sources/Benchmark.swift
@@ -85,7 +85,7 @@ private func benchmarkReport() async throws -> BenchmarkReport {
     let streamDebugCapture = await benchmarkStreamDebugCaptureDisabled()
     let contextManager = try await benchmarkContextManager(options: options)
     let requestPipeline = try await benchmarkRequestPipeline(options: options)
-    let requestDecode = await benchmarkRequestDecode()
+    let requestDecode = try await benchmarkRequestDecode()
     let toolDetection = await benchmarkToolDetection()
     let responseEncode = await benchmarkResponseEncode()
 
@@ -239,8 +239,8 @@ private func benchmarkContextManager(options: SessionOptions) async throws -> Be
     let messages = benchmarkMessages()
 
     let iterations = 12
-    let timing = await measure(iterations: iterations) {
-        _ = try? await ContextManager.makeSession(
+    let timing = try await measure(iterations: iterations) {
+        _ = try await ContextManager.makeSession(
             messages: messages,
             tools: tools,
             options: options,
@@ -342,8 +342,8 @@ private func benchmarkRequestPipeline(options: SessionOptions) async throws -> B
     let validation = try await benchmarkRequestPipelineResult(request: request, options: options)
 
     let iterations = 40
-    let timing = await measure(iterations: iterations) {
-        _ = try? await benchmarkRequestPipelineResult(request: request, options: options)
+    let timing = try await measure(iterations: iterations) {
+        _ = try await benchmarkRequestPipelineResult(request: request, options: options)
     }
 
     return BenchmarkCaseResult(
@@ -357,11 +357,11 @@ private func benchmarkRequestPipeline(options: SessionOptions) async throws -> B
     )
 }
 
-private func benchmarkRequestDecode() async -> BenchmarkCaseResult {
+private func benchmarkRequestDecode() async throws -> BenchmarkCaseResult {
     let requestJSON = makeRequestJSON()
     let iterations = 500
-    let timing = await measure(iterations: iterations) {
-        _ = try? JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
+    let timing = try await measure(iterations: iterations) {
+        _ = try JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
     }
 
     return BenchmarkCaseResult(
@@ -433,18 +433,18 @@ private func benchmarkResponseEncode() async -> BenchmarkCaseResult {
 private func measure(
     iterations: Int,
     warmup: Int = 2,
-    operation: @escaping () async -> Void
-) async -> BenchmarkTiming {
+    operation: () async throws -> Void
+) async rethrows -> BenchmarkTiming {
     guard iterations > 0 else { return BenchmarkTiming(avgMilliseconds: 0) }
 
     for _ in 0..<warmup {
-        await operation()
+        try await operation()
     }
 
     var totalNanoseconds: UInt64 = 0
     for _ in 0..<iterations {
         let start = DispatchTime.now().uptimeNanoseconds
-        await operation()
+        try await operation()
         totalNanoseconds += DispatchTime.now().uptimeNanoseconds - start
     }
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #436.

## Root cause

`measure(iterations:operation:)` accepted a non-throwing closure (`() async -> Void`), which forced every call site to discard errors at the boundary with `try?`. Three benchmark cases - `benchmarkContextManager`, `benchmarkRequestPipeline`, and `benchmarkRequestDecode` - silently swallowed errors from their timed operations. A throwing operation was timed as an immediate return and reported with `validated: true`, making a regression look like a speed improvement.

## The fix

Changed `measure()` to accept `() async throws -> Void` with `rethrows`, so errors propagate through to the caller. Removed `try?` from all three call sites, replacing with `try`/`try await`. Updated `benchmarkRequestDecode` from `async` to `async throws` (and its call site in `benchmarkReport()`) since it now calls a rethrowing `measure`. Non-throwing call sites (the other 8 benchmark cases) are unaffected thanks to `rethrows` - they continue to use plain `await` with no `try` needed.

The `validated` field on `benchmarkContextManager` and `benchmarkRequestDecode` remains `true` because reaching the return statement now means all iterations completed without throwing - if any iteration fails, `measure` rethrows and the benchmark case never produces a result. For `benchmarkRequestPipeline`, the separate `validation` call is retained for its output-property checks (`finalPrompt`, `promptTokens`, `responseBytes`); the timed invocations now also propagate failures, so validation and timing are consistent.

## Test coverage

No new unit tests added. The `measure` function and `BenchmarkCaseResult` are both `private` within the `apfel` executable target, which depends on FoundationModels. The test runner (`apfel-tests`) depends only on `ApfelCore` and `ApfelCLI` and cannot access these symbols. Adding a direct test would require either moving `measure` to `ApfelCore` (scope creep for this fix) or restructuring the target dependencies.

The existing integration test `Tests/integration/performance_test.py` exercises the full `--benchmark` path and verifies all cases produce results. The fix ensures that if any timed operation starts throwing, the benchmark fails loudly rather than reporting misleading numbers.

## What I verified (static only)

- All three `try?` usages inside `measure` closures are replaced with `try`.
- `measure()` signature changed from `@escaping () async -> Void` / `async` to `() async throws -> Void` / `async rethrows`.
- `benchmarkRequestDecode` promoted to `async throws`; its call site in `benchmarkReport()` updated to `try await`.
- No other call sites affected (8 non-throwing benchmark cases still compile without `try` thanks to `rethrows`).
- Swift 6 concurrency: no data races introduced. The closure parameter is non-escaping (removed `@escaping`), which is correct since it is only called within the function body.
- Diff limited to `Sources/Benchmark.swift` and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- `[Unreleased]` CHANGELOG entry added per changelog-gate policy (#369).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. Specifically: the removal of `@escaping` from the async closure parameter and the `rethrows` on the function need a Swift 6.3 compile to confirm. If the compiler requires `@escaping` for async closures in this context, the fallback is `@Sendable () async throws -> Void` with `throws` instead of `rethrows` (matching the `withRetry` pattern in `Sources/Core/Retry.swift`), which would require adding `try` to all 17 `measure` call sites.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial (owner).

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1Pewu18BUbKbPUjsEJt4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd1Pewu18BUbKbPUjsEJt4)_