### PR TITLE
fix(benchmark): make measure() rethrow so throwing ops fail the benchmark (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Benchmark cases no longer swallow errors via `try?` inside `measure()` closures (#436). A throwing timed operation now fails the benchmark instead of reporting a fast, validated sample. `measure()` accepts a throwing closure and rethrows; `validated` is derived from the timed invocations rather than hardcoded or computed from a separate call.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Benchmark.swift
+++ b/Sources/Benchmark.swift
@@ -85,7 +85,7 @@ private func benchmarkReport() async throws -> BenchmarkReport {
     let streamDebugCapture = await benchmarkStreamDebugCaptureDisabled()
     let contextManager = try await benchmarkContextManager(options: options)
     let requestPipeline = try await benchmarkRequestPipeline(options: options)
-    let requestDecode = await benchmarkRequestDecode()
+    let requestDecode = try await benchmarkRequestDecode()
     let toolDetection = await benchmarkToolDetection()
     let responseEncode = await benchmarkResponseEncode()
 
@@ -239,14 +239,16 @@ private func benchmarkContextManager(options: SessionOptions) async throws -> Be
     let messages = benchmarkMessages()
 
     let iterations = 12
-    let timing = await measure(iterations: iterations) {
-        _ = try? await ContextManager.makeSession(
+    var lastPrompt = ""
+    let timing = try await measure(iterations: iterations) {
+        let (_, prompt, _) = try await ContextManager.makeSession(
             messages: messages,
             tools: tools,
             options: options,
             jsonMode: true,
             toolChoice: .auto
         )
+        lastPrompt = prompt
     }
 
     return BenchmarkCaseResult(
@@ -255,7 +257,7 @@ private func benchmarkContextManager(options: SessionOptions) async throws -> Be
         baseline_avg_ms: nil,
         current_avg_ms: timing.avgMilliseconds,
         speedup_ratio: nil,
-        validated: true,
+        validated: !lastPrompt.isEmpty,
         notes: "End-to-end session assembly with tools, JSON mode, and transcript trimming."
     )
 }
@@ -339,11 +341,11 @@ private func benchmarkStreamDebugCaptureDisabled() async -> BenchmarkCaseResult 
 private func benchmarkRequestPipeline(options: SessionOptions) async throws -> BenchmarkCaseResult {
     let requestJSON = makeRequestJSON()
     let request = try JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
-    let validation = try await benchmarkRequestPipelineResult(request: request, options: options)
 
     let iterations = 40
-    let timing = await measure(iterations: iterations) {
-        _ = try? await benchmarkRequestPipelineResult(request: request, options: options)
+    var lastResult: (finalPrompt: String, promptTokens: Int, responseBytes: Int) = ("", 0, 0)
+    let timing = try await measure(iterations: iterations) {
+        lastResult = try await benchmarkRequestPipelineResult(request: request, options: options)
     }
 
     return BenchmarkCaseResult(
@@ -352,16 +354,17 @@ private func benchmarkRequestPipeline(options: SessionOptions) async throws -> B
         baseline_avg_ms: nil,
         current_avg_ms: timing.avgMilliseconds,
         speedup_ratio: nil,
-        validated: !validation.finalPrompt.isEmpty && validation.promptTokens > 0 && validation.responseBytes > 0,
+        validated: !lastResult.finalPrompt.isEmpty && lastResult.promptTokens > 0 && lastResult.responseBytes > 0,
         notes: "Decode + context build + token counting + response encode, excluding model inference."
     )
 }
 
-private func benchmarkRequestDecode() async -> BenchmarkCaseResult {
+private func benchmarkRequestDecode() async throws -> BenchmarkCaseResult {
     let requestJSON = makeRequestJSON()
     let iterations = 500
-    let timing = await measure(iterations: iterations) {
-        _ = try? JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
+    var lastDecoded: ChatCompletionRequest?
+    let timing = try await measure(iterations: iterations) {
+        lastDecoded = try JSONDecoder().decode(ChatCompletionRequest.self, from: requestJSON)
     }
 
     return BenchmarkCaseResult(
@@ -370,7 +373,7 @@ private func benchmarkRequestDecode() async -> BenchmarkCaseResult {
         baseline_avg_ms: nil,
         current_avg_ms: timing.avgMilliseconds,
         speedup_ratio: nil,
-        validated: true,
+        validated: lastDecoded != nil && !(lastDecoded!.messages.isEmpty),
         notes: "OpenAI-compatible request decoding throughput."
     )
 }
@@ -433,18 +436,18 @@ private func benchmarkResponseEncode() async -> BenchmarkCaseResult {
 private func measure(
     iterations: Int,
     warmup: Int = 2,
-    operation: @escaping () async -> Void
-) async -> BenchmarkTiming {
+    operation: @escaping () async throws -> Void
+) async rethrows -> BenchmarkTiming {
     guard iterations > 0 else { return BenchmarkTiming(avgMilliseconds: 0) }
 
     for _ in 0..<warmup {
-        await operation()
+        try await operation()
     }
 
     var totalNanoseconds: UInt64 = 0
     for _ in 0..<iterations {
         let start = DispatchTime.now().uptimeNanoseconds
-        await operation()
+        try await operation()
         totalNanoseconds += DispatchTime.now().uptimeNanoseconds - start
     }
 

--- a/Tests/apfelTests/BenchmarkTests.swift
+++ b/Tests/apfelTests/BenchmarkTests.swift
@@ -1,0 +1,113 @@
+// ============================================================================
+// BenchmarkTests.swift - Benchmark timing helper rethrow + validated semantics
+// Part of apfel test suite
+//
+// The actual measure() function is private in the main target (which depends
+// on FoundationModels). These tests verify the behavioral contract: a
+// rethrowing timing helper propagates errors from its body, and a benchmark
+// case that throws must not report validated: true.
+// ============================================================================
+
+import Foundation
+
+private struct BenchmarkTestError: Error {}
+
+func runBenchmarkTests() {
+
+    // -- measure rethrow contract --
+
+    testAsync("rethrowing measure propagates error from body on first iteration") {
+        var iterationsRun = 0
+        do {
+            _ = try await measureRethrowing(iterations: 5) {
+                iterationsRun += 1
+                throw BenchmarkTestError()
+            }
+            throw TestFailure("expected BenchmarkTestError, but measure completed normally")
+        } catch is BenchmarkTestError {
+            try assertEqual(iterationsRun, 1,
+                "measure should stop on the first throwing iteration")
+        }
+    }
+
+    testAsync("rethrowing measure completes all iterations when body does not throw") {
+        var iterationsRun = 0
+        let result = try await measureRethrowing(iterations: 5) {
+            iterationsRun += 1
+        }
+        try assertEqual(iterationsRun, 5)
+        try assertTrue(result > 0, "timing must be positive")
+    }
+
+    testAsync("rethrowing measure propagates error mid-sequence") {
+        var iterationsRun = 0
+        do {
+            _ = try await measureRethrowing(iterations: 10) {
+                iterationsRun += 1
+                if iterationsRun == 3 { throw BenchmarkTestError() }
+            }
+            throw TestFailure("expected BenchmarkTestError on iteration 3")
+        } catch is BenchmarkTestError {
+            try assertEqual(iterationsRun, 3)
+        }
+    }
+
+    // -- validated flag semantics --
+
+    testAsync("a throwing body prevents reaching the validated assignment") {
+        var reachedValidated = false
+        do {
+            _ = try await measureRethrowing(iterations: 1) {
+                throw BenchmarkTestError()
+            }
+            reachedValidated = true
+        } catch {
+            // expected
+        }
+        try assertTrue(!reachedValidated,
+            "a throwing timed operation must prevent the validated: true assignment")
+    }
+
+    // -- try? silently swallows errors (the bug this fix addresses) --
+
+    testAsync("non-throwing measure with try? body silently completes -- the bug pattern") {
+        var iterationsRun = 0
+        let result = await measureNonThrowing(iterations: 5) {
+            iterationsRun += 1
+            _ = try? { () -> Int in throw BenchmarkTestError() }()
+        }
+        try assertEqual(iterationsRun, 5,
+            "non-throwing measure runs all iterations even when every one fails via try?")
+        try assertTrue(result > 0,
+            "the bug: measure reports a timing for iterations that did no real work")
+    }
+}
+
+// Local reimplementations matching the old and new measure() signatures.
+// These mirror the actual function in Sources/Benchmark.swift.
+
+private func measureRethrowing(
+    iterations: Int,
+    _ body: () async throws -> Void
+) async rethrows -> Double {
+    var totalNanoseconds: UInt64 = 0
+    for _ in 0..<iterations {
+        let start = DispatchTime.now().uptimeNanoseconds
+        try await body()
+        totalNanoseconds += DispatchTime.now().uptimeNanoseconds - start
+    }
+    return Double(totalNanoseconds) / Double(iterations) / 1_000_000
+}
+
+private func measureNonThrowing(
+    iterations: Int,
+    _ body: () async -> Void
+) async -> Double {
+    var totalNanoseconds: UInt64 = 0
+    for _ in 0..<iterations {
+        let start = DispatchTime.now().uptimeNanoseconds
+        await body()
+        totalNanoseconds += DispatchTime.now().uptimeNanoseconds - start
+    }
+    return Double(totalNanoseconds) / Double(iterations) / 1_000_000
+}

--- a/Tests/apfelTests/main.swift
+++ b/Tests/apfelTests/main.swift
@@ -129,6 +129,7 @@ suite("MessagesFlagTests") { runMessagesFlagTests() }
 suite("CodeFlagTests") { runCodeFlagTests() }
 suite("PrewarmDecisionTests") { runPrewarmDecisionTests() }
 suite("ResponsesModelsTests") { runResponsesModelsTests() }
+suite("BenchmarkTests") { runBenchmarkTests() }
 
 // MARK: - Summary
 


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #436.

## Summary

Three benchmark cases (`benchmarkContextManager`, `benchmarkRequestPipeline`, `benchmarkRequestDecode`) wrapped their timed operation in `try?`, so an operation that throws on every iteration was silently timed and reported as a fast, validated sample. The root cause is that `measure(iterations:)` accepted a non-throwing closure (`() async -> Void`), which forced every call site to discard errors at the boundary.

This makes `measure()` accept a throwing closure and `rethrow`. All three call sites now use `try` instead of `try?`. The `validated` flag is derived from the timed invocations (captured results from within the measure loop) rather than hardcoded to `true` or computed from a separate invocation.

## Root cause

`measure()` at `Sources/Benchmark.swift:433` took `() async -> Void`, so call sites had to silence throws with `try?`. Two cases (`benchmarkContextManager`, `benchmarkRequestDecode`) then set `validated: true` unconditionally, and the pipeline case (`benchmarkRequestPipeline`) validated a separate invocation rather than the one it timed. A benchmark measuring nothing looked like one that got faster.

## The fix

- `measure()` now takes `() async throws -> Void` and is marked `rethrows` - a throwing body propagates to the caller instead of being silently discarded.
- All three `try?` usages inside `measure` closures are replaced with `try`.
- `benchmarkContextManager`: captures the prompt from the last timed iteration for validation instead of hardcoding `validated: true`.
- `benchmarkRequestPipeline`: captures the result from the last timed iteration for validation instead of using a separate pre-loop invocation.
- `benchmarkRequestDecode`: captures the decoded request from the last timed iteration for validation instead of hardcoding `validated: true`. Function signature updated from `async` to `async throws`.

## Test coverage

- Added `Tests/apfelTests/BenchmarkTests.swift` with 5 tests covering the rethrow and validated-flag semantics:
  - `rethrowing measure propagates error from body on first iteration`
  - `rethrowing measure completes all iterations when body does not throw`
  - `rethrowing measure propagates error mid-sequence`
  - `a throwing body prevents reaching the validated assignment`
  - `non-throwing measure with try? body silently completes -- the bug pattern`
- Tests use local reimplementations of the old and new `measure()` signatures since the actual function is private in the FoundationModels-dependent target.

## What I verified (static only)

- All three `try?` usages inside `measure` closures removed - confirmed via grep.
- `measure()` signature changed to `rethrows` with throwing closure.
- `benchmarkRequestDecode` call site updated from `await` to `try await`.
- `validated` derived from timed invocations in all three cases.
- CHANGELOG.md `[Unreleased]` entry added.
- Diff limited to `Sources/Benchmark.swift`, `Tests/apfelTests/BenchmarkTests.swift`, `Tests/apfelTests/main.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: mutable captures in `measure` closures are safe - `operation` is not `@Sendable` and runs sequentially. No data races introduced.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the mutable variable captures in the `measure` closures cause Swift 6 strict concurrency diagnostics, the fix is to annotate them `nonisolated(unsafe)` (the accesses are sequential, no race).

## Anything that seemed suspicious

Nothing - straightforward bug with a clear code-level fix. The issue body contained a suggested diff that matches the direction of this fix, but the implementation was written independently from reading the source.

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `apfel --benchmark` produces correct output when nothing throws

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5JVawtpoR2ZMofDzoh7So

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5JVawtpoR2ZMofDzoh7So)_