### PR TITLE
fix(core): reject unrepresentable JSON numbers instead of storing null (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AnyCodable` no longer silently rewrites unrepresentable JSON numbers (e.g. `1e999`) to `null`. Tool parameter schemas and `response_format.json_schema.schema` containing such values now fail decoding and return HTTP 400 `invalid_request_error` instead of silently dropping constraints (#455).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -428,7 +428,10 @@ struct AnyCodable: Codable, Sendable {
             value = array
             return
         }
-        value = nil
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "Value is not representable as JSON (numbers must fit in a Double)"
+        )
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -124,6 +124,30 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?[1] as? String, "two")
         try assertEqual(parsed?[2] as? Bool, false)
     }
+
+    test("AnyCodable rejects unrepresentable number instead of storing null (#455)") {
+        do {
+            _ = try decode(RawJSON.self, from: "1e999")
+            throw TestFailure("expected DecodingError for 1e999 but decode succeeded")
+        } catch is DecodingError {
+            // expected
+        }
+    }
+
+    test("AnyCodable preserves explicit JSON null (#455)") {
+        let raw = try decode(RawJSON.self, from: "null")
+        try assertEqual(raw.value, "null")
+    }
+
+    test("RawJSON round-trips nested tool parameter schema unchanged (#455)") {
+        let json = #"{"type":"object","properties":{"x":{"type":"number","maximum":100}}}"#
+        let raw = try decode(RawJSON.self, from: json)
+        let decoded = try JSONSerialization.jsonObject(with: Data(raw.value.utf8)) as? [String: Any]
+        let props = decoded?["properties"] as? [String: Any]
+        let x = props?["x"] as? [String: Any]
+        try assertEqual(x?["maximum"] as? Int, 100)
+        try assertEqual(x?["type"] as? String, "number")
+    }
 }
 
 func runChatRequestValidatorTests() {

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -152,6 +152,28 @@ def test_undecodable_tool_choice_object_returns_400():
 
 
 # ============================================================================
+# #455 - unrepresentable number in tool parameters returns 400
+# ============================================================================
+
+def test_tool_parameters_with_unrepresentable_number_returns_400():
+    """A tool parameter schema containing a number outside Double range (1e999)
+    must be rejected with 400, not silently rewritten to null (#455)."""
+    raw = (
+        '{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],'
+        '"tools":[{"type":"function","function":{"name":"f","description":"d",'
+        '"parameters":{"type":"object","properties":{"x":{"type":"number","maximum":1e999}}}}}]}'
+    )
+    resp = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        content=raw,
+        headers={"Content-Type": "application/json"},
+        timeout=15,
+    )
+    assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text}"
+    _assert_openai_error(resp, expected_type="invalid_request_error")
+
+
+# ============================================================================
 # #238a - stream_options.include_usage emits usage:null on non-final chunks
 # (model-dependent: needs Apple Intelligence, run by the controller)
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #455.

## Summary

`AnyCodable.init(from:)` had an unconditional `value = nil` fallback at the end of its decode chain. Any JSON value that failed every decode attempt (in practice, a number outside `Double`'s range like `1e999`) was silently stored as `nil`, which `RawJSON` then re-encoded as the JSON literal `null`. This meant tool parameter schemas and `response_format.json_schema.schema` could have constraints silently dropped - a `{"maximum": 1e999}` became `{"maximum": null}` with no error to the caller.

The fix replaces the silent `value = nil` fallback with a `DecodingError.dataCorruptedError` throw. The existing handler decode path at `Handlers.swift:65-78` already catches `DecodingError` and returns HTTP 400 `invalid_request_error`, so no handler changes are needed. The explicit `container.decodeNil()` branch at the top of the decode chain already handles genuine JSON `null` values, so those are unaffected.

## Root cause

Line 431 of `Sources/Core/OpenAIModels.swift`: `value = nil` as the terminal fallback in `AnyCodable.init(from:)`. When `JSONDecoder` cannot decode a number into `Double` (overflow), all `try?` branches fail silently, and the value is stored as `nil` rather than rejected.

## The fix

One-line change: replace `value = nil` with a `DecodingError.dataCorruptedError` throw. The error propagates through `RawJSON.init(from:)` up to the request decoder, where the existing catch block returns a 400.

## Test coverage

- Added `OpenAIModelsTests.swift`: `AnyCodable rejects unrepresentable number instead of storing null (#455)` - asserts decoding `1e999` throws `DecodingError`
- Added `OpenAIModelsTests.swift`: `AnyCodable preserves explicit JSON null (#455)` - asserts a real `null` still decodes correctly
- Added `OpenAIModelsTests.swift`: `RawJSON round-trips nested tool parameter schema unchanged (#455)` - asserts a normal schema with `{"maximum": 100}` is preserved
- Added `server_validation_test.py`: `test_tool_parameters_with_unrepresentable_number_returns_400` - sends raw JSON with `1e999` in tool parameters, asserts HTTP 400

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Read `Sources/Core/OpenAIModels.swift` and confirmed the bug at line 431
- Read `Sources/Handlers.swift:65-78` and confirmed `DecodingError` is caught and mapped to 400 `invalid_request_error`
- Confirmed `container.decodeNil()` at line 418 handles genuine JSON `null` before the new throw path
- Confirmed `encode(to:)` default arm at line 454-455 is unreachable once decoding rejects unsupported types (harmless to leave)
- Swift 6 concurrency: no data races introduced (change is in a synchronous `init(from:)`)
- Diff limited to `Sources/Core/OpenAIModels.swift`, `Tests/apfelTests/OpenAIModelsTests.swift`, `Tests/integration/server_validation_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a clear root cause and minimal fix.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01VxNifS2pSXikKuQMxMDXKt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxNifS2pSXikKuQMxMDXKt)_