### PR TITLE
fix(models): reject unrepresentable JSON numbers instead of silently rewriting to null (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AnyCodable` no longer silently rewrites unrepresentable JSON numbers (e.g. `1e999`) to `null`. These values now produce a `DecodingError`, surfaced as HTTP 400 `invalid_request_error` on the server (#455).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -428,7 +428,9 @@ struct AnyCodable: Codable, Sendable {
             value = array
             return
         }
-        value = nil
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "Value is not representable as JSON (numbers must fit in a Double)")
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -124,6 +124,31 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?[1] as? String, "two")
         try assertEqual(parsed?[2] as? Bool, false)
     }
+
+    test("RawJSON rejects unrepresentable number (#455)") {
+        do {
+            _ = try decode(RawJSON.self, from: "1e999")
+            try assertTrue(false, "should have thrown for unrepresentable number")
+        } catch is DecodingError {
+            // expected
+        }
+    }
+
+    test("RawJSON preserves explicit null (#455)") {
+        let raw = try decode(RawJSON.self, from: "null")
+        try assertEqual(raw.value, "null")
+    }
+
+    test("RawJSON round-trips nested schema unchanged (#455)") {
+        let input = #"{"type":"object","properties":{"x":{"type":"number","maximum":100}}}"#
+        let raw = try decode(RawJSON.self, from: input)
+        let reparsed = try JSONSerialization.jsonObject(with: Data(raw.value.utf8)) as? [String: Any]
+        let props = reparsed?["properties"] as? [String: Any]
+        let x = props?["x"] as? [String: Any]
+        try assertEqual(x?["maximum"] as? Int, 100)
+        try assertEqual(x?["type"] as? String, "number")
+        try assertEqual(reparsed?["type"] as? String, "object")
+    }
 }
 
 func runChatRequestValidatorTests() {

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -152,6 +152,31 @@ def test_undecodable_tool_choice_object_returns_400():
 
 
 # ============================================================================
+# #455 - unrepresentable JSON numbers must be rejected, not silently rewritten
+# ============================================================================
+
+def test_tool_parameters_with_unrepresentable_number_is_400():
+    """Tool parameters containing a number outside Double range (1e999) must
+    return 400 invalid_request_error, not silently rewrite it to null (#455)."""
+    raw_body = (
+        '{"model":"' + MODEL + '","max_tokens":20,'
+        '"messages":[{"role":"user","content":"Say OK"}],'
+        '"tools":[{"type":"function","function":{"name":"f","description":"d",'
+        '"parameters":{"type":"object","properties":{"x":{"type":"number","maximum":1e999}}}}}]}'
+    )
+    resp = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        content=raw_body,
+        headers={"Content-Type": "application/json"},
+        timeout=15,
+    )
+    assert resp.status_code == 400, (
+        f"unrepresentable number in tool parameters must 400, got {resp.status_code}: {resp.text}"
+    )
+    _assert_openai_error(resp, expected_type="invalid_request_error")
+
+
+# ============================================================================
 # #238a - stream_options.include_usage emits usage:null on non-final chunks
 # (model-dependent: needs Apple Intelligence, run by the controller)
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #455.

## Summary

`AnyCodable.init(from:)` had an unconditional `value = nil` fallback at the end of its decode chain. Any JSON value that failed every decode attempt (in practice, a number outside `Double`'s range like `1e999`) was silently stored as `nil`, and `RawJSON` then re-encoded it as the JSON literal `null`. This meant schema constraints like `{"maximum": 1e999}` silently disappeared - the server accepted the request with HTTP 200 and applied a schema the caller never wrote.

The fix replaces the `value = nil` fallback with a `throw DecodingError.dataCorruptedError`, which the existing error handlers surface as HTTP 400 `invalid_request_error`. The explicit `container.decodeNil()` branch at the top of `init(from:)` already handles genuine JSON `null` values, so legitimate nulls are unaffected.

## Root cause

`Sources/Core/OpenAIModels.swift:431` - the terminal `value = nil` in `AnyCodable.init(from:)`. When `JSONDecoder` encounters a number outside `Double`'s representable range (e.g. `1e999`), the `try? container.decode(Double.self)` returns `nil`, and every other type attempt also fails, so the fallback fires and the value becomes `null`. `RawJSON.init(from:)` then re-encodes it, and the caller's schema constraint vanishes without any indication.

## The fix

One line changed in `Sources/Core/OpenAIModels.swift`: the `value = nil` fallback becomes a `throw DecodingError.dataCorruptedError(in:debugDescription:)`. Since `RawJSON.init(from:)` is already `throws`, and the HTTP handlers turn decode failures into 400 `invalid_request_error`, this is the minimal change needed.

## Test coverage

- Added `Tests/apfelTests/OpenAIModelsTests.swift`: `RawJSON rejects unrepresentable number (#455)` - asserts decoding `1e999` throws `DecodingError`
- Added `Tests/apfelTests/OpenAIModelsTests.swift`: `RawJSON preserves explicit null (#455)` - asserts a genuine JSON `null` still decodes correctly
- Added `Tests/apfelTests/OpenAIModelsTests.swift`: `RawJSON round-trips nested schema unchanged (#455)` - asserts a normal schema with numeric constraints round-trips intact
- Added `Tests/integration/server_validation_test.py`: `test_tool_parameters_with_unrepresentable_number_is_400` - asserts the server returns 400 for tool parameters containing `1e999`

## Test plan
- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## What I verified (static only)

- Read and understood the `AnyCodable` decode/encode pair and the `RawJSON` re-encoding path
- Confirmed the existing `decodeNil()` branch handles genuine `null` before the fallback
- Confirmed `RawJSON.init(from:)` is `throws`, so the `DecodingError` propagates naturally
- Confirmed the HTTP handlers already turn `DecodingError` into 400 `invalid_request_error`
- Swift 6 concurrency: no data races introduced (no shared mutable state touched)
- Diff limited to `Sources/Core/OpenAIModels.swift`, `Tests/apfelTests/OpenAIModelsTests.swift`, `Tests/integration/server_validation_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code on this cloud runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by the repo owner and the reproduction is clean.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9wP7TW7G1AaHX21PCmUya

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9wP7TW7G1AaHX21PCmUya)_