### PR TITLE
fix(openai): reject unrepresentable JSON numbers instead of coercing to null (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AnyCodable` no longer silently coerces unrepresentable JSON numbers (e.g. `1e999`) to `null`. Tool parameter schemas and `response_format.json_schema.schema` payloads containing such values now return HTTP 400 `invalid_request_error` instead of silently rewriting the caller's JSON (#455).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -428,7 +428,9 @@ struct AnyCodable: Codable, Sendable {
             value = array
             return
         }
-        value = nil
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "Value is not representable as JSON (numbers must fit in a 64-bit float)")
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -124,6 +124,57 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?[1] as? String, "two")
         try assertEqual(parsed?[2] as? Bool, false)
     }
+
+    // MARK: - #455 AnyCodable rejects unrepresentable values
+
+    test("AnyCodable rejects unrepresentable number (1e999) instead of coercing to null (#455)") {
+        do {
+            _ = try decode(RawJSON.self, from: "1e999")
+            throw TestFailure("expected DecodingError for 1e999, none thrown")
+        } catch is TestFailure {
+            throw TestFailure("expected DecodingError for 1e999, none thrown")
+        } catch {
+            try assertTrue(error is DecodingError, "expected DecodingError, got \(type(of: error))")
+        }
+    }
+
+    test("AnyCodable rejects negative overflow number (-1e999) (#455)") {
+        do {
+            _ = try decode(RawJSON.self, from: "-1e999")
+            throw TestFailure("expected DecodingError for -1e999, none thrown")
+        } catch is TestFailure {
+            throw TestFailure("expected DecodingError for -1e999, none thrown")
+        } catch {
+            try assertTrue(error is DecodingError, "expected DecodingError, got \(type(of: error))")
+        }
+    }
+
+    test("AnyCodable preserves explicit JSON null (#455)") {
+        let raw = try decode(RawJSON.self, from: "null")
+        try assertEqual(raw.value, "null")
+    }
+
+    test("AnyCodable round-trips nested schema unchanged (#455)") {
+        let input = #"{"type":"object","properties":{"x":{"type":"number","maximum":100}}}"#
+        let raw = try decode(RawJSON.self, from: input)
+        let reparsed = try JSONSerialization.jsonObject(with: Data(raw.value.utf8)) as? [String: Any]
+        let props = reparsed?["properties"] as? [String: Any]
+        let x = props?["x"] as? [String: Any]
+        try assertEqual(x?["maximum"] as? Int, 100)
+        try assertEqual(x?["type"] as? String, "number")
+    }
+
+    test("Tool parameters with nested unrepresentable number reject at decode (#455)") {
+        let json = #"{"type":"function","function":{"name":"f","description":"d","parameters":{"type":"object","properties":{"x":{"type":"number","maximum":1e999}}}}}"#
+        do {
+            _ = try decode(OpenAITool.self, from: json)
+            throw TestFailure("expected DecodingError for nested 1e999, none thrown")
+        } catch is TestFailure {
+            throw TestFailure("expected DecodingError for nested 1e999, none thrown")
+        } catch {
+            try assertTrue(error is DecodingError, "expected DecodingError, got \(type(of: error))")
+        }
+    }
 }
 
 func runChatRequestValidatorTests() {

--- a/Tests/integration/server_validation_test.py
+++ b/Tests/integration/server_validation_test.py
@@ -152,6 +152,36 @@ def test_undecodable_tool_choice_object_returns_400():
 
 
 # ============================================================================
+# #455 - unrepresentable JSON numbers in tool parameters must be 400
+# ============================================================================
+
+def test_tool_parameters_with_unrepresentable_number_is_400():
+    """A number outside Double range (1e999) in tool parameters must be rejected, not silently nulled."""
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "x": {"type": "number", "maximum": float("inf")},
+                        },
+                    },
+                },
+            }
+        ],
+    }
+    resp = _post(payload)
+    assert resp.status_code == 400, f"expected 400 for unrepresentable number, got {resp.status_code}: {resp.text}"
+    _assert_openai_error(resp, expected_type="invalid_request_error")
+
+
+# ============================================================================
 # #238a - stream_options.include_usage emits usage:null on non-final chunks
 # (model-dependent: needs Apple Intelligence, run by the controller)
 # ============================================================================


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #455.

## Root cause

`AnyCodable.init(from:)` has an unconditional `value = nil` fallback at its terminal branch. Any JSON value that fails every decode attempt (in practice, a number outside `Double`'s representable range like `1e999`) is silently stored as `nil`. When `RawJSON.init(from:)` re-encodes it, `nil` becomes the JSON literal `null`. The caller's schema constraint simply disappears - a `{"maximum": 1e999}` becomes `{"maximum": null}` - and the server returns HTTP 200 with a schema that no longer matches what was sent.

The explicit `container.decodeNil()` branch at line 418 already handles genuine JSON `null` values, so the terminal fallback only fires for truly unrepresentable values.

## The fix

Replace the `value = nil` fallback with a `throw DecodingError.dataCorruptedError(in:debugDescription:)`. The existing handler in `Handlers.swift` already catches `DecodingError` from `JSONDecoder().decode(ChatCompletionRequest.self, from: body)` and maps it to HTTP 400 `invalid_request_error`, so no plumbing changes are needed. The error message reads: "Value is not representable as JSON (numbers must fit in a 64-bit float)".

One-line change in production code. The `default: try container.encodeNil()` arm in `encode(to:)` becomes unreachable but is harmless to leave.

## Test coverage

- Added `OpenAIModelsTests.swift`: `AnyCodable rejects unrepresentable number (1e999) instead of coercing to null` - asserts decoding `1e999` via `RawJSON` throws `DecodingError`.
- Added `OpenAIModelsTests.swift`: `AnyCodable rejects negative overflow number (-1e999)` - same for negative overflow.
- Added `OpenAIModelsTests.swift`: `AnyCodable preserves explicit JSON null` - asserts a genuine `null` still decodes as `"null"`.
- Added `OpenAIModelsTests.swift`: `AnyCodable round-trips nested schema unchanged` - asserts a normal schema with `{"maximum": 100}` survives decode/re-encode.
- Added `OpenAIModelsTests.swift`: `Tool parameters with nested unrepresentable number reject at decode` - asserts a full `OpenAITool` with nested `1e999` in parameters throws.
- Added `server_validation_test.py`: `test_tool_parameters_with_unrepresentable_number_is_400` - integration test confirming the HTTP surface returns 400 for `float("inf")` in tool parameters.
- Existing `RawJSON preserves nested tool parameter schemas as valid JSON` still covers the happy path.

## What I verified (static only)

- Read `AnyCodable.init(from:)` and confirmed the `value = nil` fallback at line 431 is the only code path that can produce a silent null substitution.
- Read `RawJSON.init(from:)` at lines 286-291 and confirmed it decodes via `AnyCodable` and re-encodes, propagating the null.
- Read `Handlers.swift` lines 64-75 and confirmed `JSONDecoder().decode(ChatCompletionRequest.self, from: body)` is wrapped in do/catch that maps any decode error to 400 `invalid_request_error`.
- Confirmed `container.decodeNil()` at line 418 handles genuine JSON nulls before the fallback, so the change does not affect legitimate null values.
- Swift 6 concurrency: no data races introduced (pure synchronous decode path, no shared mutable state).
- Diff limited to `Sources/Core/OpenAIModels.swift`, `Tests/apfelTests/OpenAIModelsTests.swift`, `Tests/integration/server_validation_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code or `swift build` on this Linux runner. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug with a clear root cause and minimal fix. The issue was filed by `Arthur-Ficial` (owner account) and the analysis is accurate.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

https://claude.ai/code/session_01U6VhrGyeLFhcyTMySjg87i

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6VhrGyeLFhcyTMySjg87i)_