### PR TITLE
fix(security): cap JSON nesting depth in AnyCodable (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AnyCodable` now rejects JSON nesting deeper than 64 levels with a 400 instead of crashing the server with a stack overflow (#462). Applies to `tools[].function.parameters`, `response_format.json_schema.schema`, and `text.format.schema`.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -285,7 +285,17 @@ public struct RawJSON: Decodable, Sendable, Equatable, Hashable {
     /// Decodes arbitrary JSON and stores its canonical serialized form.
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        let raw = try container.decode(AnyCodable.self)
+        let raw: AnyCodable
+        do {
+            raw = try container.decode(AnyCodable.self)
+        } catch is AnyCodable.NestingDepthExceeded {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "JSON nesting exceeds the maximum supported depth of \(AnyCodable.maxNestingDepth)"
+                )
+            )
+        }
         let data = try JSONEncoder().encode(raw)
         value = String(data: data, encoding: .utf8) ?? "{}"
     }
@@ -413,16 +423,13 @@ public struct JSONSchemaSpec: Decodable, Sendable, Equatable, Hashable {
 struct AnyCodable: Codable, Sendable {
     static let maxNestingDepth = 64
 
+    struct NestingDepthExceeded: Error {}
+
     let value: (any Sendable)?
 
     init(from decoder: Decoder) throws {
         if decoder.codingPath.count > Self.maxNestingDepth {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: decoder.codingPath,
-                    debugDescription: "JSON nesting exceeds the maximum supported depth of \(Self.maxNestingDepth)"
-                )
-            )
+            throw NestingDepthExceeded()
         }
         let container = try decoder.singleValueContainer()
         if container.decodeNil()                                    { value = nil; return }
@@ -430,14 +437,16 @@ struct AnyCodable: Codable, Sendable {
         if let int = try? container.decode(Int.self)                { value = int; return }
         if let double = try? container.decode(Double.self)          { value = double; return }
         if let string = try? container.decode(String.self)          { value = string; return }
-        if let object = try? container.decode([String: AnyCodable].self) {
+        do {
+            let object = try container.decode([String: AnyCodable].self)
             value = object
             return
-        }
-        if let array = try? container.decode([AnyCodable].self) {
+        } catch is NestingDepthExceeded { throw NestingDepthExceeded() } catch {}
+        do {
+            let array = try container.decode([AnyCodable].self)
             value = array
             return
-        }
+        } catch is NestingDepthExceeded { throw NestingDepthExceeded() } catch {}
         value = nil
     }
 

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -411,9 +411,19 @@ public struct JSONSchemaSpec: Decodable, Sendable, Equatable, Hashable {
 // MARK: - Type-erased Codable for raw JSON schemas
 
 struct AnyCodable: Codable, Sendable {
+    static let maxNestingDepth = 64
+
     let value: (any Sendable)?
 
     init(from decoder: Decoder) throws {
+        if decoder.codingPath.count > Self.maxNestingDepth {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "JSON nesting exceeds the maximum supported depth of \(Self.maxNestingDepth)"
+                )
+            )
+        }
         let container = try decoder.singleValueContainer()
         if container.decodeNil()                                    { value = nil; return }
         if let bool = try? container.decode(Bool.self)              { value = bool; return }

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -124,6 +124,28 @@ func runOpenAIModelsTests() {
         try assertEqual(parsed?[1] as? String, "two")
         try assertEqual(parsed?[2] as? Bool, false)
     }
+
+    // MARK: - AnyCodable nesting depth cap (#462)
+
+    test("AnyCodable rejects excessive nesting depth (#462)") {
+        let depth = 200
+        let nested = String(repeating: #"{"a":"#, count: depth) + "1" + String(repeating: "}", count: depth)
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t","parameters":"# + nested + #"}}]}"#
+        do {
+            _ = try decode(ChatCompletionRequest.self, from: json)
+            throw TestFailure("expected DecodingError for 200-level nesting, but decoding succeeded")
+        } catch is DecodingError {
+            // expected
+        }
+    }
+
+    test("AnyCodable accepts realistic nesting depth (#462)") {
+        let schema = #"{"type":"object","properties":{"a":{"type":"object","properties":{"b":{"type":"object","properties":{"c":{"type":"object","properties":{"d":{"type":"string"}}}}}}}}}"#
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t","parameters":"# + schema + #"}}]}"#
+        let request = try decode(ChatCompletionRequest.self, from: json)
+        let params = try unwrap(request.tools?.first?.function.parameters, "missing parameters")
+        try assertTrue(params.value.contains("\"d\""))
+    }
 }
 
 func runChatRequestValidatorTests() {

--- a/Tests/integration/security_test.py
+++ b/Tests/integration/security_test.py
@@ -547,6 +547,73 @@ def test_cors_preflight_echoes_requested_headers():
     assert "x-stainless-lang" in allowed.lower()
 
 
+def test_deeply_nested_schema_is_rejected_not_fatal():
+    """A 200-level nested JSON schema must return 400, not crash the server (#462)."""
+    import json as _json
+
+    depth = 200
+    nest = '{"a":' * depth + '1' + '}' * depth
+
+    # tools[].function.parameters
+    tools_payload = _json.dumps({
+        "model": "apple-foundationmodel",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "t"}}],
+    })
+    # Inject the raw nested JSON into the parameters field.
+    tools_payload = tools_payload.replace(
+        '"name": "t"',
+        f'"name": "t", "parameters": {nest}',
+    )
+    resp = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        content=tools_payload.encode(),
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    assert resp.status_code == 400, f"expected 400, got {resp.status_code}"
+
+    # response_format.json_schema.schema
+    fmt_payload = _json.dumps({
+        "model": "apple-foundationmodel",
+        "messages": [{"role": "user", "content": "hi"}],
+        "response_format": {"type": "json_schema", "json_schema": {"name": "s"}},
+    })
+    fmt_payload = fmt_payload.replace(
+        '"name": "s"',
+        f'"name": "s", "schema": {nest}',
+    )
+    resp = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        content=fmt_payload.encode(),
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    assert resp.status_code == 400, f"expected 400 for response_format schema, got {resp.status_code}"
+
+    # text.format.schema on /v1/responses
+    responses_payload = _json.dumps({
+        "model": "apple-foundationmodel",
+        "input": "hi",
+        "text": {"format": {"type": "json_schema", "name": "s"}},
+    })
+    responses_payload = responses_payload.replace(
+        '"name": "s"',
+        f'"name": "s", "schema": {nest}',
+    )
+    resp = httpx.post(
+        f"{BASE_URL}/v1/responses",
+        content=responses_payload.encode(),
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    assert resp.status_code == 400, f"expected 400 for /v1/responses schema, got {resp.status_code}"
+
+    # Server must still be alive
+    health = httpx.get(f"{BASE_URL}/health", timeout=5)
+    assert health.status_code == 200, "server crashed after deeply nested payload"
+
+
 def test_default_preflight_still_works_without_cors():
     """Without --cors flag, OPTIONS should return 204 but no CORS headers."""
     resp = httpx.options(


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #462.

## Root cause

`AnyCodable.init(from:)` in `Sources/Core/OpenAIModels.swift` recurses once per level of JSON nesting with no depth limit. `RawJSON.init(from:)` decodes through it, and `RawJSON` is the declared type of three request fields an unauthenticated caller fully controls: `tools[].function.parameters`, `response_format.json_schema.schema`, and `text.format.schema`. Foundation's JSON scanner only rejects nesting at ~512 levels, but the cooperative-pool thread stack is exhausted at ~160 levels - depths between 160 and 511 crash the server with SIGBUS before any handler or auth check runs.

## The fix

Added a `maxNestingDepth` constant (64) on `AnyCodable` and a depth check at the top of `init(from:)` using `decoder.codingPath.count`. When exceeded, it throws `DecodingError.dataCorrupted`, which the existing `catch` blocks in `Handlers.swift:67` and `ResponsesHandlers.swift:116` surface as the normal `400 Invalid JSON` response. No new error plumbing needed. 64 levels is well beyond any real JSON Schema but safely below the ~160-level stack overflow threshold.

## Test coverage

- Added `OpenAIModelsTests.swift`: `testAnyCodableRejectsExcessiveNesting` - verifies a 200-level nested object throws `DecodingError`.
- Added `OpenAIModelsTests.swift`: `testAnyCodableAcceptsRealisticNesting` - verifies a 4-level schema still decodes and round-trips.
- Added `security_test.py`: `test_deeply_nested_schema_is_rejected_not_fatal` - posts a 200-level nested payload to all three vulnerable fields (`tools[].function.parameters`, `response_format.json_schema.schema`, `text.format.schema`), asserts 400 each time, and confirms `/health` still responds afterwards.
- Existing `RawJSON` round-trip tests cover the happy path for normal schemas.

## What I verified (static only)

- Read `AnyCodable.init(from:)` and traced the recursion path through `[String: AnyCodable]` and `[AnyCodable]` decode branches.
- Confirmed `DecodingError` from `AnyCodable` is caught by the existing `catch` in `Handlers.swift:66-71` and `ResponsesHandlers.swift:114-122`.
- Confirmed `AnyCodable` is internal to `OpenAIModels.swift` - no downstream consumers affected.
- Swift 6 concurrency: no data races introduced - `maxNestingDepth` is a `static let` on a `Sendable` struct.
- Diff limited to `Sources/Core/OpenAIModels.swift`, `Tests/apfelTests/OpenAIModelsTests.swift`, `Tests/integration/security_test.py`, and `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward security bug filed by the owner account. The issue body contains a reproduction script with `curl` and `python3` that constructs nested JSON locally - no external URLs, no network exfiltration, no malicious intent.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsBfoWQJ5Wxh4KGgAvqwaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsBfoWQJ5Wxh4KGgAvqwaP)_