### PR TITLE
fix(server): set HTTP idle timeout to prevent stalled body permit leak (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Server now sets a 30-second HTTP idle timeout so stalled request bodies cannot hold concurrency permits forever (#463). Previously, a client that sent headers and stalled the body held its permit for as long as the socket stayed open; `--max-concurrent` such connections wedged the server permanently. Streaming completions and slow generations are unaffected (Hummingbird skips the timeout for fully-read requests still producing a response).
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -281,6 +281,7 @@ func startServer(config: ServerConfig, mcpManager: MCPManager? = nil) async thro
 
     let app = Application(
         router: router,
+        server: .http1(configuration: .init(idleTimeout: .seconds(30))),
         configuration: .init(
             address: .hostname(config.host, port: config.port)
         )

--- a/Tests/integration/security_test.py
+++ b/Tests/integration/security_test.py
@@ -560,3 +560,45 @@ def test_default_preflight_still_works_without_cors():
     )
     assert resp.status_code == 204
     assert "access-control-allow-headers" not in resp.headers
+
+
+# MARK: - Idle timeout (stalled request body permit leak, #463)
+
+def test_stalled_request_body_releases_permit():
+    """Stalled request bodies must not hold permits forever (#463).
+
+    Opens max_concurrent connections that send HTTP headers and a partial
+    body, then stop. With the idle timeout set, Hummingbird closes those
+    connections after ~30s. Once the permits are released, a normal health
+    check must succeed.
+    """
+    max_concurrent = 2
+    with running_server("--max-concurrent", str(max_concurrent)) as (base_url, _):
+        port = int(base_url.rsplit(":", 1)[1])
+        socks = []
+        for _ in range(max_concurrent):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect(("127.0.0.1", port))
+            s.sendall(
+                b"POST /v1/chat/completions HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: 5000\r\n"
+                b"\r\n"
+                b'{"model":"apple-foundationmodel","mess'
+            )
+            socks.append(s)
+
+        time.sleep(35)
+
+        resp = httpx.get(f"{base_url}/health", timeout=10)
+        assert resp.status_code == 200, (
+            f"Health check failed after idle timeout: HTTP {resp.status_code}"
+        )
+        data = resp.json()
+        assert data["active_requests"] == 0, (
+            f"Permits not released: active_requests={data['active_requests']}"
+        )
+
+        for s in socks:
+            s.close()

--- a/Tests/integration/security_test.py
+++ b/Tests/integration/security_test.py
@@ -564,13 +564,16 @@ def test_default_preflight_still_works_without_cors():
 
 # MARK: - Idle timeout (stalled request body permit leak, #463)
 
+IDLE_TIMEOUT_SECONDS = 30
+
+
 def test_stalled_request_body_releases_permit():
     """Stalled request bodies must not hold permits forever (#463).
 
     Opens max_concurrent connections that send HTTP headers and a partial
     body, then stop. With the idle timeout set, Hummingbird closes those
-    connections after ~30s. Once the permits are released, a normal health
-    check must succeed.
+    connections after ~IDLE_TIMEOUT_SECONDS. Once the permits are released,
+    a normal health check must succeed.
     """
     max_concurrent = 2
     with running_server("--max-concurrent", str(max_concurrent)) as (base_url, _):
@@ -589,7 +592,7 @@ def test_stalled_request_body_releases_permit():
             )
             socks.append(s)
 
-        time.sleep(35)
+        time.sleep(IDLE_TIMEOUT_SECONDS + 5)
 
         resp = httpx.get(f"{base_url}/health", timeout=10)
         assert resp.status_code == 200, (


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #463.

## Summary

- Set a 30-second HTTP idle timeout on the Hummingbird server so stalled request bodies cannot hold concurrency permits forever.
- Added integration test `test_stalled_request_body_releases_permit` to `security_test.py`.

## Root cause

The `Application` in `Server.swift:282` was created with no `server:` argument, so `HTTP1Channel.Configuration.idleTimeout` defaulted to `nil`. The concurrency permit is acquired at `Server.swift:125` before `Handlers.swift:48` reads the request body. A client that sent HTTP headers and then stalled the body held its permit for as long as the socket stayed open. `--max-concurrent` such connections (default 5) wedged the server permanently - every legitimate request then blocked for the full 30-second semaphore wait and returned 429.

The same failure mode occurs without an attacker: a client that dies or loses its network mid-upload leaks a permit until the OS reaps the half-open connection.

## The fix

One line added to the `Application` constructor:

```swift
server: .http1(configuration: .init(idleTimeout: .seconds(30))),
```

This is safe for streaming. Hummingbird's `HTTPConnectionStateHandler.StateMachine.timeoutTriggered()` explicitly skips connections that have finished reading the request and are still producing a response (`isRequestBeingRead == false` with `requestsInProgress > 0`). A stalled body has `isRequestBeingRead == true`, so it is reaped; an SSE stream or a slow completion has `isRequestBeingRead == false`, so it is not.

## Test coverage

- Added `Tests/integration/security_test.py::test_stalled_request_body_releases_permit` - opens `max_concurrent` stalled connections, waits past the idle timeout, and asserts a normal health check then succeeds with `active_requests: 0`.
- Existing security tests cover the happy paths for all server endpoints.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/security_test.py -v` (needs server running)
- [ ] Verify a streaming completion longer than 30s still finishes (acceptance criteria from #463)

## What I verified (static only)

- Read the Hummingbird `timeoutTriggered()` state machine logic confirming SSE/streaming safety.
- Diff limited to `Sources/Server.swift`, `Tests/integration/security_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced (configuration is a value type set at init).
- CHANGELOG `[Unreleased]` entry added (changelog-gate compliance, #369).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward bug. The issue was filed by Arthur-Ficial (us) from an automated security hardening pass with full code references and a local reproduction.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDHUsRpmxkY21ZdLBuLMrL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDHUsRpmxkY21ZdLBuLMrL)_