### PR TITLE
fix(logging): gate MCP tool args and results behind --debug (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP tool arguments and results no longer leak to stderr without `--debug` (#464). Without `--debug`, the server logs only the tool name, ok/error status, and result length. With `--debug`, args and results appear but are truncated to 512 characters. Prevents sensitive tool output from being written to the world-readable brew-service log file.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/Handlers.swift
+++ b/Sources/Handlers.swift
@@ -311,7 +311,11 @@ private func mcpAutoExecuteResponse(
             options: genOpts
         ) {
             for log in executed.toolLog {
-                events.append("mcp tool: \(log.name)(\(log.args)) = \(log.isError ? "error: " : "")\(log.result)")
+                if serverState.config.debug {
+                    events.append("mcp tool: \(log.name)(\(truncateForLog(log.args, limit: 512))) = \(log.isError ? "error: " : "")\(truncateForLog(log.result, limit: 512))")
+                } else {
+                    events.append("mcp tool: \(log.name) \(log.isError ? "error" : "ok") result_chars=\(log.result.count)")
+                }
             }
             content = executed.content
             events.append("mcp: auto-executed, final response chars=\(content.count)")

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -1024,16 +1024,18 @@ def test_tool_result_not_logged_without_debug():
 
 
 def test_tool_result_logged_truncated_with_debug():
-    """With --debug, tool args and results appear in stderr (#464)."""
+    """With --debug, tool args and results appear but large results are truncated (#464)."""
     require_model()
-    mcp_script = ROOT / "mcp" / "calculator" / "server.py"
-    with _running_mcp_server_with_log(mcp_script, debug=True) as (api_url, read_log):
+    with _running_mcp_server_with_log(
+        FIXTURES / "huge_output_mcp_server.py", debug=True
+    ) as (api_url, read_log):
         post_chat_rotating_seeds(f"{api_url}/chat/completions", {
             "model": MODEL,
             "messages": [
                 {"role": "user",
-                 "content": "Use the add function to add 100 and 200. Reply with just the number."}
+                 "content": "Call the fetch_document tool, then summarize the document in one sentence."}
             ],
+            "max_tokens": 200,
         }, TIMEOUT)
         time.sleep(0.5)
         log = read_log()
@@ -1041,3 +1043,5 @@ def test_tool_result_logged_truncated_with_debug():
         assert mcp_lines, "Expected at least one 'mcp tool:' event in debug log"
         assert any("(" in l for l in mcp_lines), \
             f"Debug log should show tool args in parens: {mcp_lines}"
+        assert any("...[truncated]" in l for l in mcp_lines), \
+            f"Large tool result should be truncated in debug log: {mcp_lines}"

--- a/Tests/integration/mcp_server_test.py
+++ b/Tests/integration/mcp_server_test.py
@@ -960,3 +960,84 @@ def test_temperature_zero_with_mcp():
     assert data["choices"][0]["finish_reason"] == "stop"
     content = data["choices"][0]["message"]["content"]
     assert content is not None
+
+
+# ============================================================================
+# MCP tool log gating (#464)
+# ============================================================================
+
+@contextlib.contextmanager
+def _running_mcp_server_with_log(mcp_script, debug=False):
+    """Start apfel --serve --mcp <script>; yield (api_url, read_log).
+
+    When debug=True the server is started with --debug so tool arguments
+    and results appear in the event log.
+    """
+    port = find_free_port()
+    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as log_file:
+        args = [str(BINARY), "--serve", "--port", str(port),
+                "--mcp", str(mcp_script)]
+        if debug:
+            args.append("--debug")
+        proc = subprocess.Popen(args, stdout=log_file, stderr=log_file,
+                                text=True)
+        base_url = f"http://127.0.0.1:{port}"
+
+        def read_log():
+            log_file.flush()
+            with open(log_file.name, "r", encoding="utf-8") as fh:
+                return fh.read()
+
+        try:
+            wait_for_server(base_url)
+            yield f"{base_url}/v1", read_log
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
+def test_tool_result_not_logged_without_debug():
+    """Without --debug, stderr shows tool name and ok/error but not args or result (#464)."""
+    require_model()
+    mcp_script = ROOT / "mcp" / "calculator" / "server.py"
+    with _running_mcp_server_with_log(mcp_script, debug=False) as (api_url, read_log):
+        post_chat_rotating_seeds(f"{api_url}/chat/completions", {
+            "model": MODEL,
+            "messages": [
+                {"role": "user",
+                 "content": "Use the add function to add 100 and 200. Reply with just the number."}
+            ],
+        }, TIMEOUT)
+        time.sleep(0.5)
+        log = read_log()
+        mcp_lines = [l for l in log.splitlines() if "mcp tool:" in l]
+        assert mcp_lines, "Expected at least one 'mcp tool:' event in log"
+        for line in mcp_lines:
+            assert "result_chars=" in line, \
+                f"Non-debug log should use shape-only format: {line}"
+            assert "(" not in line.split("mcp tool:")[1], \
+                f"Tool args leaked into non-debug log: {line}"
+
+
+def test_tool_result_logged_truncated_with_debug():
+    """With --debug, tool args and results appear in stderr (#464)."""
+    require_model()
+    mcp_script = ROOT / "mcp" / "calculator" / "server.py"
+    with _running_mcp_server_with_log(mcp_script, debug=True) as (api_url, read_log):
+        post_chat_rotating_seeds(f"{api_url}/chat/completions", {
+            "model": MODEL,
+            "messages": [
+                {"role": "user",
+                 "content": "Use the add function to add 100 and 200. Reply with just the number."}
+            ],
+        }, TIMEOUT)
+        time.sleep(0.5)
+        log = read_log()
+        mcp_lines = [l for l in log.splitlines() if "mcp tool:" in l]
+        assert mcp_lines, "Expected at least one 'mcp tool:' event in debug log"
+        assert any("(" in l for l in mcp_lines), \
+            f"Debug log should show tool args in parens: {mcp_lines}"


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #464.

## Summary

MCP tool arguments and results were appended to the `events` array unconditionally in `Handlers.swift:314`, bypassing the `--debug` gate that already protects `request_body` and `response_body`. Under `brew services`, stderr is written to `/opt/homebrew/var/log/apfel.log` which is world-readable (`-rw-r--r--`), exposing whatever MCP tools return - file contents, database rows, API responses, credentials.

The fix gates MCP tool event logging behind `serverState.config.debug`:

- **Without `--debug`:** logs only `mcp tool: <name> ok|error result_chars=<N>` - the shape, never the data.
- **With `--debug`:** logs `mcp tool: <name>(<args>) = <result>` with both args and result truncated to 512 characters via the existing `truncateForLog`.

This aligns the events array with the same rule that `request_body`/`response_body` already follow (Logging.swift:21-22). The `/v1/logs` endpoint is already `--debug`-only (Server.swift:236-242), so the detailed events remain available exactly where they are already gated.

## Root cause

`Handlers.swift:314` appends full, untruncated MCP tool arguments and results into the `events` array with no `--debug` check. `LogStore.append` (Logging.swift:64-68) then writes every event to stderr unconditionally. The debug gate on lines 21-22 protects `request_body`/`response_body` while the events carrying the same class of data walk right past it.

## The fix

Single `if/else` branch in `Handlers.swift` around the existing `events.append` for MCP tool logs. When `serverState.config.debug` is false, logs a shape-only string (tool name, ok/error, result character count). When true, logs the full detail but truncates args and result to 512 characters each.

## Test coverage

- Added `mcp_server_test.py:test_tool_result_not_logged_without_debug()` - starts a server without `--debug`, triggers MCP tool execution, asserts stderr contains the tool name but uses the shape-only format (no args or result text).
- Added `mcp_server_test.py:test_tool_result_logged_truncated_with_debug()` - starts a server with `--debug`, triggers MCP tool execution, asserts stderr shows tool args in the detailed format.
- Both tests are `@pytest.mark.model` (via the file-level `pytestmark`) since they need the model to generate tool calls.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test
- [ ] `python3 -m pytest Tests/integration/mcp_server_test.py::test_tool_result_not_logged_without_debug -v`
- [ ] `python3 -m pytest Tests/integration/mcp_server_test.py::test_tool_result_logged_truncated_with_debug -v`

## What I verified (static only)

- `truncateForLog(_:limit:)` is already a global in the same target (`Sources/Logging.swift:131`), no new imports needed.
- `serverState.config.debug` is the established pattern used throughout `Handlers.swift` (12 existing call sites).
- Diff limited to `Sources/Handlers.swift`, `Tests/integration/mcp_server_test.py`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: no data races introduced (the fix reads `serverState.config.debug` which is already read on every request in this handler).

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward security hardening bug filed by the owner account. The proposed fix in the issue body aligned with what I found in the code, but I wrote the implementation and tests independently.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPA891NKVfKRS7MHVqnSeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPA891NKVfKRS7MHVqnSeX)_