### PR TITLE
fix(security): create chat-history file 0600 before writing prompts (#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Chat history file (`APFEL_HISTFILE`) is now created at `0600` before libedit writes prompts into it, closing a TOCTOU window where the file was briefly world-readable at `0644` (#473). Parent directories are created at `0700`.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI/ChatHistory.swift
+++ b/Sources/CLI/ChatHistory.swift
@@ -38,4 +38,25 @@ public enum ChatHistory {
         guard !trimmed.isEmpty else { return nil }
         return (trimmed as NSString).expandingTildeInPath
     }
+
+    /// Create the history file and its parent directories with restrictive
+    /// permissions BEFORE any content is written.
+    ///
+    /// libedit's `write_history` uses `fopen(path, "w")`, which creates new
+    /// files at `0666 & ~umask` (typically `0644`) and does not change the
+    /// mode of an existing file. Calling this first ensures the file exists
+    /// at `0600` and directories at `0700` so prompts are never exposed.
+    public static func prepareHistoryFile(at path: String) {
+        let fm = FileManager.default
+        let dir = (path as NSString).deletingLastPathComponent
+        if !dir.isEmpty {
+            try? fm.createDirectory(
+                atPath: dir, withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+        }
+        if !fm.fileExists(atPath: path) {
+            fm.createFile(atPath: path, contents: nil,
+                          attributes: [.posixPermissions: 0o600])
+        }
+    }
 }

--- a/Sources/ChatLineEditor.swift
+++ b/Sources/ChatLineEditor.swift
@@ -90,11 +90,7 @@ final class ChatLineEditor: @unchecked Sendable {
     private func persistHistory() {
         guard let historyFile else { return }
 
-        let dir = (historyFile as NSString).deletingLastPathComponent
-        if !dir.isEmpty {
-            try? FileManager.default.createDirectory(
-                atPath: dir, withIntermediateDirectories: true)
-        }
+        ChatHistory.prepareHistoryFile(at: historyFile)
 
         let wrote = historyFile.withCString { write_history($0) }
         guard wrote == 0 else { return }

--- a/Tests/apfelTests/ChatHistoryTests.swift
+++ b/Tests/apfelTests/ChatHistoryTests.swift
@@ -41,4 +41,40 @@ func runChatHistoryTests() {
     test("history bound matches the in-memory stifle limit") {
         try assertEqual(ChatHistory.maxEntries, 500)
     }
+
+    test("prepareHistoryFile creates file at 0600 and directories at 0700") {
+        let base = NSTemporaryDirectory() + "apfel-test-hist-\(ProcessInfo.processInfo.processIdentifier)"
+        let path = base + "/sub/history"
+        defer { try? FileManager.default.removeItem(atPath: base) }
+
+        ChatHistory.prepareHistoryFile(at: path)
+
+        let fm = FileManager.default
+        func mode(_ p: String) -> Int? {
+            (try? fm.attributesOfItem(atPath: p))?[.posixPermissions] as? Int
+        }
+
+        try assertEqual(mode(base), 0o700)
+        try assertEqual(mode(base + "/sub"), 0o700)
+        try assertEqual(mode(path), 0o600)
+    }
+
+    test("prepareHistoryFile does not alter an existing file's mode") {
+        let base = NSTemporaryDirectory() + "apfel-test-hist2-\(ProcessInfo.processInfo.processIdentifier)"
+        let path = base + "/history"
+        defer { try? FileManager.default.removeItem(atPath: base) }
+
+        let fm = FileManager.default
+        try? fm.createDirectory(atPath: base, withIntermediateDirectories: true)
+        fm.createFile(atPath: path, contents: Data("existing".utf8),
+                      attributes: [.posixPermissions: 0o600])
+
+        ChatHistory.prepareHistoryFile(at: path)
+
+        let attrs = try? fm.attributesOfItem(atPath: path)
+        let mode = attrs?[.posixPermissions] as? Int
+        try assertEqual(mode, 0o600)
+        let content = try? String(contentsOfFile: path, encoding: .utf8)
+        try assertEqual(content, "existing")
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #473.

## Summary

`ChatLineEditor.persistHistory()` created directories at `0755` and let libedit's `write_history()` create the history file at `0644` (`0666 & ~umask`), only chmod'ing to `0600` afterwards. This left a TOCTOU window where prompts sat in a world-readable file. If `write_history` or `history_truncate_file` failed, the file was left at `0644` permanently.

The fix extracts a testable `ChatHistory.prepareHistoryFile(at:)` that creates the file at `0600` and parent directories at `0700` before libedit writes anything. The trailing `setAttributes` chmod stays as belt-and-braces (covers `history_truncate_file` potentially rewriting the file).

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

## Root cause

macOS libedit's `write_history()` uses `fopen(path, "w")`, which creates new files at `0666 & ~umask` (typically `0644`) and does not change the mode of an existing file. The previous code created directories without restrictive permissions and only chmod'd the file after libedit had already written the prompts into it.

## The fix

Added `ChatHistory.prepareHistoryFile(at:)` in the pure `ApfelCLI` library - it creates the file at `0600` and directories at `0700` before any content is written. `ChatLineEditor.persistHistory()` calls this method before invoking `write_history`. The directory-creation and file pre-creation logic moved out of `persistHistory()` and into the new testable method.

## Test coverage

- Added `ChatHistoryTests`: `testPrepareHistoryFileCreatesFileAt0600AndDirectoriesAt0700` - verifies fresh file and directory permissions.
- Added `ChatHistoryTests`: `testPrepareHistoryFileDoesNotAlterExistingFileMode` - verifies existing files are not clobbered.
- Existing `ChatHistoryTests` still cover the opt-in decision logic (env var parsing).

## What I verified (static only)

- Read the full `ChatLineEditor.swift` and `ChatHistory.swift` sources.
- Confirmed the `persistHistory()` call path: `deinit` -> `persistHistory()` -> now calls `prepareHistoryFile` before `write_history`.
- Confirmed `ChatHistory` is in `ApfelCLI` (pure, testable, no FoundationModels dependency).
- Swift 6 concurrency: no data races introduced. `prepareHistoryFile` is a static method using only local state and `FileManager.default`.
- Diff limited to `Sources/CLI/ChatHistory.swift`, `Sources/ChatLineEditor.swift`, `Tests/apfelTests/ChatHistoryTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - the issue was filed by Arthur-Ficial (the repo owner) and is a straightforward, well-documented security hardening fix.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTZRgaSxggGqE5RQqobEn

---
_Generated by [Claude Code](https://claude.ai/code/session_016bTZRgaSxggGqE5RQqobEn)_