### PR TITLE
fix(security): create chat-history file 0600 before libedit writes into it (#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Chat history file (`APFEL_HISTFILE`) is now created at `0600` before libedit writes prompts into it, closing a window where the file was world-readable at `0644` (#473). Parent directories are created at `0700`. An existing file with a wider mode is corrected on every persist call.
+
 ## [1.9.1] - 2026-08-05
 
 ### Changed

--- a/Sources/CLI/ChatHistory.swift
+++ b/Sources/CLI/ChatHistory.swift
@@ -38,4 +38,29 @@ public enum ChatHistory {
         guard !trimmed.isEmpty else { return nil }
         return (trimmed as NSString).expandingTildeInPath
     }
+
+    /// Create the history file at 0600 and its parent directories at 0700
+    /// before libedit writes prompts into it (#473).
+    ///
+    /// libedit's `write_history()` uses `fopen(path, "w")`, which creates a
+    /// new file at `0666 & ~umask` (0644 under the default umask 022) and
+    /// does not change the mode of an existing file. Calling this before
+    /// `write_history` ensures prompts never land in a world-readable file.
+    /// An existing file that has drifted to a wider mode is corrected.
+    public static func prepareHistoryFile(at path: String) {
+        let fm = FileManager.default
+        let dir = (path as NSString).deletingLastPathComponent
+        if !dir.isEmpty {
+            try? fm.createDirectory(
+                atPath: dir, withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+        }
+        if !fm.fileExists(atPath: path) {
+            fm.createFile(atPath: path, contents: nil,
+                          attributes: [.posixPermissions: 0o600])
+        } else {
+            try? fm.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: path)
+        }
+    }
 }

--- a/Sources/ChatLineEditor.swift
+++ b/Sources/ChatLineEditor.swift
@@ -90,11 +90,7 @@ final class ChatLineEditor: @unchecked Sendable {
     private func persistHistory() {
         guard let historyFile else { return }
 
-        let dir = (historyFile as NSString).deletingLastPathComponent
-        if !dir.isEmpty {
-            try? FileManager.default.createDirectory(
-                atPath: dir, withIntermediateDirectories: true)
-        }
+        ChatHistory.prepareHistoryFile(at: historyFile)
 
         let wrote = historyFile.withCString { write_history($0) }
         guard wrote == 0 else { return }

--- a/Tests/apfelTests/ChatHistoryTests.swift
+++ b/Tests/apfelTests/ChatHistoryTests.swift
@@ -41,4 +41,71 @@ func runChatHistoryTests() {
     test("history bound matches the in-memory stifle limit") {
         try assertEqual(ChatHistory.maxEntries, 500)
     }
+
+    // -- File-preparation security tests (#473) -------------------------
+
+    test("prepareHistoryFile creates file at 0600 before any content is written") {
+        let tmp = NSTemporaryDirectory() + "apfel-test-hist-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        let path = tmp + "/sub/history"
+
+        ChatHistory.prepareHistoryFile(at: path)
+
+        let fm = FileManager.default
+        try assertTrue(fm.fileExists(atPath: path), "file should exist")
+        let attrs = try fm.attributesOfItem(atPath: path)
+        let mode = (attrs[.posixPermissions] as? Int) ?? -1
+        try assertEqual(mode, 0o600, "file mode should be 0600")
+    }
+
+    test("prepareHistoryFile creates parent directories at 0700") {
+        let tmp = NSTemporaryDirectory() + "apfel-test-hist-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        let path = tmp + "/nested/dir/history"
+
+        ChatHistory.prepareHistoryFile(at: path)
+
+        let fm = FileManager.default
+        for dir in [tmp, tmp + "/nested", tmp + "/nested/dir"] {
+            let attrs = try fm.attributesOfItem(atPath: dir)
+            let mode = (attrs[.posixPermissions] as? Int) ?? -1
+            try assertEqual(mode, 0o700, "directory \(dir) mode should be 0700")
+        }
+    }
+
+    test("prepareHistoryFile does not change mode of an existing file") {
+        let tmp = NSTemporaryDirectory() + "apfel-test-hist-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        let path = tmp + "/history"
+
+        let fm = FileManager.default
+        try fm.createDirectory(atPath: tmp, withIntermediateDirectories: true)
+        fm.createFile(atPath: path, contents: Data("existing\n".utf8),
+                      attributes: [.posixPermissions: 0o600])
+
+        ChatHistory.prepareHistoryFile(at: path)
+
+        let content = try String(contentsOfFile: path, encoding: .utf8)
+        try assertEqual(content, "existing\n", "existing content must be preserved")
+        let attrs = try fm.attributesOfItem(atPath: path)
+        let mode = (attrs[.posixPermissions] as? Int) ?? -1
+        try assertEqual(mode, 0o600, "mode must stay 0600")
+    }
+
+    test("prepareHistoryFile corrects mode of an existing file to 0600") {
+        let tmp = NSTemporaryDirectory() + "apfel-test-hist-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        let path = tmp + "/history"
+
+        let fm = FileManager.default
+        try fm.createDirectory(atPath: tmp, withIntermediateDirectories: true)
+        fm.createFile(atPath: path, contents: Data("data\n".utf8),
+                      attributes: [.posixPermissions: 0o644])
+
+        ChatHistory.prepareHistoryFile(at: path)
+
+        let attrs = try fm.attributesOfItem(atPath: path)
+        let mode = (attrs[.posixPermissions] as? Int) ?? -1
+        try assertEqual(mode, 0o600, "mode must be corrected to 0600")
+    }
 }


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Fixes #473.

## Summary

`persistHistory()` chmod'd the chat-history file to `0600` only **after** libedit's `write_history()` had already created it at `0644` (`0666 & ~umask` under the default `umask 022`). This left a window where the user's prompts sat in a world-readable file. If `write_history` or `history_truncate_file` failed, the file was left at `0644` permanently. The containing directories were also created at `0755`.

The fix extracts a testable `ChatHistory.prepareHistoryFile(at:)` into the pure `ApfelCLI` target that:
- Creates parent directories at `0700` (not `0755`)
- Creates the file at `0600` before libedit touches it
- Corrects an existing file that has drifted to a wider mode

The trailing `setAttributes` in `persistHistory()` is kept as belt-and-braces since `history_truncate_file` may rewrite the file.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests` - 4 new tests in `ChatHistoryTests`:
  - `prepareHistoryFile creates file at 0600 before any content is written`
  - `prepareHistoryFile creates parent directories at 0700`
  - `prepareHistoryFile does not change mode of an existing file`
  - `prepareHistoryFile corrects mode of an existing file to 0600`
- [ ] `make install` and manual smoke test with `APFEL_HISTFILE=/tmp/apfelhist/sub/hist apfel --chat`

## What I verified (static only)

- Swift 6 concurrency: no data races introduced. `prepareHistoryFile` is a pure static method using only `FileManager.default`.
- Diff limited to `Sources/CLI/ChatHistory.swift`, `Sources/ChatLineEditor.swift`, `Tests/apfelTests/ChatHistoryTests.swift`, `CHANGELOG.md` - no touches to release infrastructure, guardrails, CI, or dependencies.
- Existing tests unaffected - the 7 prior `ChatHistoryTests` still cover the opt-in decision logic.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward security hardening bug filed by the owner account. The issue's reproduction script and suggested fix are consistent with the code I read.

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUYS3TEtff1n3iphibuZwn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUYS3TEtff1n3iphibuZwn)_