### PR TITLE
fix(server): decode parallel_tool_calls, validate named tool_choice (#480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [https://semver.org/](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ChatCompletionRequest` now decodes `parallel_tool_calls` (previously silently ignored). A named `tool_choice` referencing a function not present in the `tools` array is now rejected with a 400 instead of reaching the model with an impossible constraint (#480).
+
 ## [1.10.0] - 2026-09-07
 
 ### Fixed

--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -243,6 +243,12 @@ public enum ChatRequestValidator {
         if case .invalid(let raw) = request.tool_choice {
             return .invalidParameterValue("Invalid 'tool_choice' value: \(raw). Must be 'auto', 'none', 'required', or a {\"type\":\"function\",\"function\":{\"name\":\"...\"}} object.")
         }
+        if case .specific(let name) = request.tool_choice,
+           let tools = request.tools, !tools.isEmpty {
+            if !tools.contains(where: { $0.function.name == name }) {
+                return .invalidParameterValue("tool_choice function name '\(name)' does not match any tool in the 'tools' array. Available: \(tools.map(\.function.name).joined(separator: ", "))")
+            }
+        }
 
         return nil
     }

--- a/Sources/Core/ChatRequestValidator.swift
+++ b/Sources/Core/ChatRequestValidator.swift
@@ -243,6 +243,8 @@ public enum ChatRequestValidator {
         if case .invalid(let raw) = request.tool_choice {
             return .invalidParameterValue("Invalid 'tool_choice' value: \(raw). Must be 'auto', 'none', 'required', or a {\"type\":\"function\",\"function\":{\"name\":\"...\"}} object.")
         }
+        // Skipped when tools is nil/empty: MCP-injected tools resolve after
+        // validation, so a named choice without client tools is not yet invalid.
         if case .specific(let name) = request.tool_choice,
            let tools = request.tools, !tools.isEmpty {
             if !tools.contains(where: { $0.function.name == name }) {

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -96,6 +96,44 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         self.x_context_max_turns = x_context_max_turns
         self.x_context_output_reserve = x_context_output_reserve
     }
+
+    /// Backwards-compatible overload preserving the pre-#480 init signature.
+    public init(
+        model: String,
+        messages: [OpenAIMessage],
+        stream: Bool? = nil,
+        stream_options: StreamOptions? = nil,
+        temperature: Double? = nil,
+        top_p: Double? = nil,
+        max_tokens: Int? = nil,
+        seed: Int? = nil,
+        tools: [OpenAITool]? = nil,
+        tool_choice: ToolChoice? = nil,
+        response_format: ResponseFormat? = nil,
+        logprobs: Bool? = nil,
+        n: Int? = nil,
+        stop: RawJSON? = nil,
+        presence_penalty: Double? = nil,
+        frequency_penalty: Double? = nil,
+        user: String? = nil,
+        x_context_strategy: String? = nil,
+        x_context_max_turns: Int? = nil,
+        x_context_output_reserve: Int? = nil
+    ) {
+        self.init(
+            model: model, messages: messages, stream: stream,
+            stream_options: stream_options, temperature: temperature,
+            top_p: top_p, max_tokens: max_tokens, seed: seed,
+            tools: tools, tool_choice: tool_choice,
+            parallel_tool_calls: nil,
+            response_format: response_format, logprobs: logprobs,
+            n: n, stop: stop, presence_penalty: presence_penalty,
+            frequency_penalty: frequency_penalty, user: user,
+            x_context_strategy: x_context_strategy,
+            x_context_max_turns: x_context_max_turns,
+            x_context_output_reserve: x_context_output_reserve
+        )
+    }
 }
 
 /// OpenAI `stream_options` payload.

--- a/Sources/Core/OpenAIModels.swift
+++ b/Sources/Core/OpenAIModels.swift
@@ -27,6 +27,8 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
     public let tools: [OpenAITool]?
     /// How the client wants tool choice resolved.
     public let tool_choice: ToolChoice?
+    /// Whether the model may return multiple tool calls in one response.
+    public let parallel_tool_calls: Bool?
     /// Requested response-format contract.
     public let response_format: ResponseFormat?
     /// OpenAI logprobs request flag.
@@ -60,6 +62,7 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         seed: Int? = nil,
         tools: [OpenAITool]? = nil,
         tool_choice: ToolChoice? = nil,
+        parallel_tool_calls: Bool? = nil,
         response_format: ResponseFormat? = nil,
         logprobs: Bool? = nil,
         n: Int? = nil,
@@ -81,6 +84,7 @@ public struct ChatCompletionRequest: Decodable, Sendable, Equatable, Hashable {
         self.seed = seed
         self.tools = tools
         self.tool_choice = tool_choice
+        self.parallel_tool_calls = parallel_tool_calls
         self.response_format = response_format
         self.logprobs = logprobs
         self.n = n

--- a/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
+++ b/Tests/apfelTests/ApfelCorePublicAPIUsageTests.swift
@@ -214,6 +214,7 @@ func runApfelCorePublicAPIUsageTests() {
         let _: Int?                = req.seed
         let _: [OpenAITool]?       = req.tools
         let _: ToolChoice?         = req.tool_choice
+        let _: Bool?               = req.parallel_tool_calls
         let _: ResponseFormat?     = req.response_format
         let _: Bool?               = req.logprobs
         let _: Int?                = req.n

--- a/Tests/apfelTests/OpenAIModelsTests.swift
+++ b/Tests/apfelTests/OpenAIModelsTests.swift
@@ -682,6 +682,69 @@ func runChatRequestValidatorTests() {
         )
         try assertEqual(ChatRequestValidator.validate(request), .unknownRole("bogus"))
     }
+
+    // --- parallel_tool_calls decoding (#480) ---
+
+    test("ChatCompletionRequest decodes parallel_tool_calls=true (#480)") {
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],"parallel_tool_calls":true}"#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertEqual(req.parallel_tool_calls, true)
+    }
+
+    test("ChatCompletionRequest decodes parallel_tool_calls=false (#480)") {
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}],"parallel_tool_calls":false}"#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertEqual(req.parallel_tool_calls, false)
+    }
+
+    test("ChatCompletionRequest parallel_tool_calls is nil when absent (#480)") {
+        let json = #"{"model":"apple-foundationmodel","messages":[{"role":"user","content":"hi"}]}"#
+        let req = try decode(ChatCompletionRequest.self, from: json)
+        try assertNil(req.parallel_tool_calls)
+    }
+
+    // --- Named tool_choice validation against tools array (#480) ---
+
+    test("validator rejects named tool_choice when name not in tools (#480)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"bar","description":"d"}}],"tool_choice":{"type":"function","function":{"name":"foo"}}}"#
+        )
+        guard case .invalidParameterValue(let detail) = ChatRequestValidator.validate(request) else {
+            throw TestFailure("expected .invalidParameterValue for tool_choice naming unknown tool")
+        }
+        try assertTrue(detail.contains("foo"))
+        try assertTrue(detail.contains("bar"))
+    }
+
+    test("validator accepts named tool_choice when name matches a tool (#480)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"lookup","description":"d"}}],"tool_choice":{"type":"function","function":{"name":"lookup"}}}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator skips named tool_choice check when tools array is empty (#480)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"tool_choice":{"type":"function","function":{"name":"f"}}}"#
+        )
+        try assertNil(ChatRequestValidator.validate(request))
+    }
+
+    test("validator rejects named tool_choice among multiple tools when none match (#480)") {
+        let request = try decode(
+            ChatCompletionRequest.self,
+            from: #"{"model":"\#(M)","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"a","description":"d"}},{"type":"function","function":{"name":"b","description":"d"}}],"tool_choice":{"type":"function","function":{"name":"c"}}}"#
+        )
+        guard case .invalidParameterValue(let detail) = ChatRequestValidator.validate(request) else {
+            throw TestFailure("expected .invalidParameterValue for tool_choice naming unknown tool among multiple")
+        }
+        try assertTrue(detail.contains("c"))
+        try assertTrue(detail.contains("a"))
+        try assertTrue(detail.contains("b"))
+    }
 }
 
 private func unwrap<T>(_ value: T?, _ message: String) throws -> T {


### PR DESCRIPTION
**Draft PR - needs @franzenzenhofer review and local test run before merging.**

Refs #480 (step 1 of a scope-split - see issue comment for the full plan).

## Summary

Two request-level bugs in the OpenAI-compatible chat completions endpoint:

1. **`parallel_tool_calls` silently ignored.** The field was absent from `ChatCompletionRequest`, so `{"parallel_tool_calls": false}` decoded without error but the value was discarded. Now decoded as `Bool?`.

2. **Named `tool_choice` accepted impossible names.** A request with `tool_choice: {"type":"function","function":{"name":"nonexistent"}}` and a `tools` array that did not contain `nonexistent` passed validation and reached the model with a prompt instruction to call a function that was never defined. Now returns 400 with the offending name and the available names.

## Root cause

`ChatCompletionRequest` had no `parallel_tool_calls` property, so Swift's synthesized `Decodable` silently skipped the key. `ChatRequestValidator.validate` checked for `.invalid` format (malformed string/object, #238) but never compared a `.specific(name:)` against the `tools` array.

## The fix

- Added `parallel_tool_calls: Bool?` to `ChatCompletionRequest` (property, init parameter, init body).
- Added a backwards-compatible init overload preserving the pre-#480 signature so `swift package diagnose-api-breaking-changes` passes (the old `init(model:messages:...:tool_choice:response_format:...)` symbol must stay in the API dump).
- After the existing `.invalid` tool_choice check in `ChatRequestValidator`, added a guard: when `tool_choice` is `.specific(name:)` AND `tools` is non-empty, the name must appear in the tools array. When `tools` is nil or empty, the check is skipped because MCP-injected tools resolve after validation (documented in a code comment at the guard).
- Updated the public API surface test.

## Test coverage

- Added `OpenAIModelsTests`: 3 tests for `parallel_tool_calls` decoding (true, false, nil-when-absent).
- Added `OpenAIModelsTests`: 4 tests for named tool_choice validation (name not in tools, name matches, empty tools array skipped, multiple tools none match).
- Existing `tool_choice` format tests (#238) unchanged - they send `tool_choice` without tools, which remains valid.

## What I verified (static only)

- Diff limited to `OpenAIModels.swift`, `ChatRequestValidator.swift`, `OpenAIModelsTests.swift`, `ApfelCorePublicAPIUsageTests.swift`, `CHANGELOG.md`.
- No touches to release infrastructure, guardrails, CI, or dependencies.
- Swift 6 concurrency: all new types are `Sendable`-compatible (existing `Bool?` property on an existing `Sendable` struct).
- Existing integration tests all provide matching tool names when using specific `tool_choice`, so no breakage expected.

## What I did NOT verify

- **Functional correctness. This needs `make test` on a Mac with Apple Intelligence.** I cannot run FoundationModels code. If the fix does not actually resolve the reported behaviour, that is on me to refine - ping me in a review comment.

## Anything that seemed suspicious

Nothing - straightforward validation gap. The issue was filed by the project owner with detailed source references.

## Remaining work (#480 scope-split)

This PR is step 1. The full issue requires:

- **Step 2: Response-boundary enforcement** - Gate `ToolCallHandler.detectToolCall()` on `tool_choice` in `Handlers.swift` (non-streaming and streaming paths). When `tool_choice: none`, tool-call-shaped output becomes ordinary content. This step should also close the MCP gap where a named choice can still reference a tool no MCP server provides.
- **Step 3: `parallel_tool_calls: false` enforcement** - Limit detected tool calls to one when the flag is false.
- **Step 4: Typed errors** - `tool_choice_not_satisfied` error type for when the model ignores a forced choice. SSE error termination for mid-stream contract violations.
- **Step 5: `supported_parameters` + close** - Add `parallel_tool_calls` to the `/v1/models` response's `supported_parameters` list in `Server.swift`. Close #480.

## Merge-order note

#488 adds a backwards-compatible init overload with the same 20-parameter legacy signature. Whichever merges second must fold its new field into the other's designated init and resolve the conflict. See review thread for details.

## Test plan

- [ ] `swift build -c release`
- [ ] `swift run apfel-tests`
- [ ] `make install` and manual smoke test

---

cc @franzenzenhofer - draft stays draft until you review, test locally, and mark ready.

_Generated by the apfel bug-solver routine._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199eW8kcWiThZVk5xjjKaxW